### PR TITLE
ci(workflows): set up code coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Unit test affected projects
         uses: Wandalen/wretry.action@master
         with:
-          command: npx nx affected:test --parallel=3
+          command: npx nx affected:test --parallel=3 --coverage
           attempt_limit: 2
 
   e2e:

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -1,0 +1,61 @@
+name: Code Coverage
+
+on:
+  push:
+    branches: [main]
+
+env:
+  NX_NON_NATIVE_HASHER: true
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    name: Update code coverage
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v3
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Execute all tests
+        run: npx nx run-many -t test
+      - name: Upload cli coverage reports to Codecov
+        uses: codecov/codecov-action@v3
+        env:
+          files: ./coverage/packages/cli/coverage-final.json
+          flags: cli
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      - name: Upload core coverage reports to Codecov
+        uses: codecov/codecov-action@v3
+        env:
+          files: ./coverage/packages/core/coverage-final.json
+          flags: core
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      - name: Upload plugin-eslint coverage reports to Codecov
+        uses: codecov/codecov-action@v3
+        env:
+          files: ./coverage/packages/plugin-eslint/coverage-final.json
+          flags: plugin-eslint
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      - name: Upload models coverage reports to Codecov
+        uses: codecov/codecov-action@v3
+        env:
+          files: ./coverage/packages/models/coverage-final.json
+          flags: models
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      - name: Upload utils coverage reports to Codecov
+        uses: codecov/codecov-action@v3
+        env:
+          files: ./coverage/packages/utils/coverage-final.json
+          flags: utils
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      - name: Upload testing-utils coverage reports to Codecov
+        uses: codecov/codecov-action@v3
+        env:
+          files: ./coverage/testing-utils/coverage-final.json
+          flags: testing-utils
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -9,8 +9,12 @@ env:
 
 jobs:
   coverage:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        lib: [cli, core, models, plugin-eslint, utils, testing-utils]
     name: Update code coverage
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v3
@@ -21,41 +25,11 @@ jobs:
           cache: npm
       - name: Install dependencies
         run: npm ci
-      - name: Execute all tests
-        run: npx nx run-many -t test
-      - name: Upload cli coverage reports to Codecov
+      - name: Execute all tests and generate coverage reports
+        run: npx nx run ${{ matrix.lib }}:test --coverage
+      - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
         env:
-          files: ./coverage/packages/cli/coverage-final.json
-          flags: cli
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      - name: Upload core coverage reports to Codecov
-        uses: codecov/codecov-action@v3
-        env:
-          files: ./coverage/packages/core/coverage-final.json
-          flags: core
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      - name: Upload plugin-eslint coverage reports to Codecov
-        uses: codecov/codecov-action@v3
-        env:
-          files: ./coverage/packages/plugin-eslint/coverage-final.json
-          flags: plugin-eslint
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      - name: Upload models coverage reports to Codecov
-        uses: codecov/codecov-action@v3
-        env:
-          files: ./coverage/packages/models/coverage-final.json
-          flags: models
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      - name: Upload utils coverage reports to Codecov
-        uses: codecov/codecov-action@v3
-        env:
-          files: ./coverage/packages/utils/coverage-final.json
-          flags: utils
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      - name: Upload testing-utils coverage reports to Codecov
-        uses: codecov/codecov-action@v3
-        env:
-          files: ./coverage/testing-utils/coverage-final.json
-          flags: testing-utils
+          files: ./coverage/${{ matrix.lib }}/coverage-final.json
+          flags: ${{ matrix.lib }}
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "@typescript-eslint/eslint-plugin": "^5.62.0",
         "@typescript-eslint/parser": "^5.62.0",
         "@vitejs/plugin-react": "~4.0.0",
-        "@vitest/coverage-c8": "~0.32.0",
+        "@vitest/coverage-v8": "^0.34.6",
         "@vitest/ui": "~0.32.0",
         "benchmark": "^2.1.4",
         "commitizen": "^4.3.0",
@@ -6734,22 +6734,29 @@
         "vite": "^4.2.0"
       }
     },
-    "node_modules/@vitest/coverage-c8": {
-      "version": "0.32.4",
+    "node_modules/@vitest/coverage-v8": {
+      "version": "0.34.6",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-0.34.6.tgz",
+      "integrity": "sha512-fivy/OK2d/EsJFoEoxHFEnNGTg+MmdZBAVK9Ka4qhXR2K3J0DS08vcGVwzDtXSuUMabLv4KtPcpSKkcMXFDViw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "^2.2.1",
-        "c8": "^7.14.0",
-        "magic-string": "^0.30.0",
+        "@bcoe/v8-coverage": "^0.2.3",
+        "istanbul-lib-coverage": "^3.2.0",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^4.0.1",
+        "istanbul-reports": "^3.1.5",
+        "magic-string": "^0.30.1",
         "picocolors": "^1.0.0",
-        "std-env": "^3.3.3"
+        "std-env": "^3.3.3",
+        "test-exclude": "^6.0.0",
+        "v8-to-istanbul": "^9.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "vitest": ">=0.30.0 <1"
+        "vitest": ">=0.32.0 <1"
       }
     },
     "node_modules/@vitest/expect": {
@@ -8275,66 +8282,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/c8": {
-      "version": "7.14.0",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "@bcoe/v8-coverage": "^0.2.3",
-        "@istanbuljs/schema": "^0.1.3",
-        "find-up": "^5.0.0",
-        "foreground-child": "^2.0.0",
-        "istanbul-lib-coverage": "^3.2.0",
-        "istanbul-lib-report": "^3.0.0",
-        "istanbul-reports": "^3.1.4",
-        "rimraf": "^3.0.2",
-        "test-exclude": "^6.0.0",
-        "v8-to-istanbul": "^9.0.0",
-        "yargs": "^16.2.0",
-        "yargs-parser": "^20.2.9"
-      },
-      "bin": {
-        "c8": "bin/c8.js"
-      },
-      "engines": {
-        "node": ">=10.12.0"
-      }
-    },
-    "node_modules/c8/node_modules/cliui": {
-      "version": "7.0.4",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^7.0.0"
-      }
-    },
-    "node_modules/c8/node_modules/yargs": {
-      "version": "16.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^7.0.2",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/c8/node_modules/yargs-parser": {
-      "version": "20.2.9",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/cac": {
@@ -12532,18 +12479,6 @@
       "dev": true,
       "dependencies": {
         "is-callable": "^1.1.3"
-      }
-    },
-    "node_modules/foreground-child": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "cross-spawn": "^7.0.0",
-        "signal-exit": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=8.0.0"
       }
     },
     "node_modules/forever-agent": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@typescript-eslint/eslint-plugin": "^5.62.0",
     "@typescript-eslint/parser": "^5.62.0",
     "@vitejs/plugin-react": "~4.0.0",
-    "@vitest/coverage-c8": "~0.32.0",
+    "@vitest/coverage-v8": "^0.34.6",
     "@vitest/ui": "~0.32.0",
     "benchmark": "^2.1.4",
     "commitizen": "^4.3.0",

--- a/packages/cli/project.json
+++ b/packages/cli/project.json
@@ -31,10 +31,10 @@
     },
     "test": {
       "executor": "@nx/vite:test",
-      "outputs": ["{workspaceRoot}/coverage/packages/cli"],
+      "outputs": ["{options.reportsDirectory}"],
       "options": {
         "passWithNoTests": true,
-        "reportsDirectory": "../../coverage/packages/cli"
+        "reportsDirectory": "../../coverage/cli"
       }
     },
     "run-help": {

--- a/packages/core/project.json
+++ b/packages/core/project.json
@@ -30,7 +30,7 @@
       "outputs": ["{options.reportsDirectory}"],
       "options": {
         "passWithNoTests": true,
-        "reportsDirectory": "../../coverage/packages/core"
+        "reportsDirectory": "../../coverage/core"
       }
     }
   },

--- a/packages/models/project.json
+++ b/packages/models/project.json
@@ -31,10 +31,10 @@
     },
     "test": {
       "executor": "@nx/vite:test",
-      "outputs": ["{workspaceRoot}/coverage/packages/models"],
+      "outputs": ["{options.reportsDirectory}"],
       "options": {
         "passWithNoTests": true,
-        "reportsDirectory": "../../coverage/packages/models"
+        "reportsDirectory": "../../coverage/models"
       }
     }
   },

--- a/packages/plugin-eslint/project.json
+++ b/packages/plugin-eslint/project.json
@@ -32,10 +32,10 @@
     },
     "test": {
       "executor": "@nx/vite:test",
-      "outputs": ["{workspaceRoot}/coverage/packages/plugin-eslint"],
+      "outputs": ["{options.reportsDirectory}"],
       "options": {
         "passWithNoTests": true,
-        "reportsDirectory": "../../coverage/packages/plugin-eslint"
+        "reportsDirectory": "../../coverage/plugin-eslint"
       }
     }
   },

--- a/packages/utils/project.json
+++ b/packages/utils/project.json
@@ -36,13 +36,8 @@
       "executor": "@nx/vite:test",
       "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
       "options": {
-        "passWithNoTests": true
-      },
-      "configurations": {
-        "ci": {
-          "ci": true,
-          "codeCoverage": true
-        }
+        "passWithNoTests": true,
+        "reportsDirectory": "../../coverage/packages/utils"
       }
     }
   },

--- a/packages/utils/project.json
+++ b/packages/utils/project.json
@@ -34,10 +34,10 @@
     },
     "test": {
       "executor": "@nx/vite:test",
-      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "outputs": ["{options.reportsDirectory}"],
       "options": {
         "passWithNoTests": true,
-        "reportsDirectory": "../../coverage/packages/utils"
+        "reportsDirectory": "../../coverage/utils"
       }
     }
   },


### PR DESCRIPTION
Closes #169 

In this PR, I set up the code coverage to run in our pipelines.

- Coverage results can be displayed by adding `--coverage` to any test `nx` command (was already working).
- I included coverage output in logs of every CI run (e.g. [here](https://github.com/code-pushup/cli/actions/runs/6893655166/job/18753721481?pr=278)).
- I set up [Codecov](https://about.codecov.io/) for our organisation (currently waiting for integration approval by an organisation owner).
- I created a separate pipeline taking results from all `nx` libraries to upload them and hopefully create a badge.
- The deprecated vitest coverage package [c8](https://www.npmjs.com/package/@vitest/coverage-c8) package was replaced by v8.

![image](https://github.com/code-pushup/cli/assets/6306671/cc0feca8-e807-498f-b7fe-3209c49a8b38)
