### PR TITLE
build: lint .spec.ts files to report filename errors

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -235,6 +235,7 @@
     },
     {
       "files": [
+        "*.spec.ts", // <- so that vitest/consistent-test-filename reports .spec.ts files
         "*.test.ts",
         "*.mock.ts",
         "test/**/*.ts",


### PR DESCRIPTION
So that we can catch mistakes like this:

![image](https://github.com/code-pushup/cli/assets/34691111/c7172e0f-08a9-4659-a5df-0b10d1124a42)

Context: https://github.com/code-pushup/cli/pull/275#discussion_r1401776075