### PR TITLE
ci: add custom `release` type to commitlint configuration

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,4 +1,5 @@
 const { RuleConfigSeverity } = require('@commitlint/types');
+const { rules } = require('@commitlint/config-conventional');
 const {
   utils: { getProjects },
 } = require('@commitlint/config-nx-scopes');
@@ -16,6 +17,14 @@ const configuration = {
       );
       const scopes = [...projects, 'tools', 'workflows', 'testing'].sort();
       return [RuleConfigSeverity.Error, 'always', scopes];
+    },
+    'type-enum': () => {
+      const defaultTypes = rules['type-enum'][2];
+      const types = [
+        ...defaultTypes,
+        'release', // custom type for release commits
+      ];
+      return [RuleConfigSeverity.Error, 'always', types];
     },
     'tense/subject-tense': [
       RuleConfigSeverity.Error,


### PR DESCRIPTION
Now, `commitlint` will accept `release` as a type for commit messages along with the previously existing types, allowing more specific categorization of release commits. This change doesn't affect any existing functionality but extends the types that can be used for commit messages.

`release` was added for release actions after merging in the main.