### PR TITLE
ci: disable parallel version task execution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Execute version target on all affected packages and release them
-        run: npx nx affected --base=latest --target=version --dryRun
+        run: npx nx affected --base=latest --target=version --parallel=1 --dryRun
   release:
     if: |
       github.repository == 'code-pushup/cli' && (
@@ -72,7 +72,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         # un-exclude packages when they're ready for public release
-        run: npx nx affected --base=latest --target=version --exclude=plugin-lighthouse,nx-plugin
+        run: npx nx affected --base=latest --target=version --exclude=plugin-lighthouse,nx-plugin --parallel=1
       - name: Tag latest
         shell: bash
         run: |


### PR DESCRIPTION
After merging PR in the main, the release job starts. In the release job, version tasks start with Nx. Nx, by default, starts tasks with `parallel=3`. This is a reason for the release job failing. 

[Here is a failing pipeline](https://github.com/code-pushup/cli/actions/runs/6978138664/job/18989026545)
```
[plugin-eslint] 🟠 No previous version tag found, fallback to version 0.0.0.
        New version will be calculated based on all changes since first commit.
        If your project is already versioned, please tag the latest release commit with plugin-eslint@x.y.z and run this command again.
[plugin-eslint] 🆕 Calculated new version "0.1.0".
[plugin-eslint] 📜 Generated CHANGELOG.md.
[plugin-eslint] 📝 Updated package.json version.
[plugin-eslint] ❌ Error: packages/core/CHANGELOG.md 121ms
packages/core/package.json 20ms
packages/plugin-eslint/CHANGELOG.md 63ms
packages/plugin-eslint/package.json 2ms
fatal: cannot lock ref 'HEAD': is at dbc9889ed37b7c0f8080cb91d613eeff2ba1d021 but expected 3037fd7890bcb6ae7f15754d2a56c1c0ca88ecd2

    at /home/runner/work/cli/cli/node_modules/@jscutlery/semver/src/executors/common/exec.js:10:34
    at ChildProcess.exithandler (node:child_process:430:5)
    at ChildProcess.emit (node:events:[51](https://github.com/code-pushup/cli/actions/runs/6978138664/job/18989026545#step:6:52)7:28)
    at maybeClose (node:internal/child_process:1098:16)
    at ChildProcess._handle.onexit (node:internal/child_process:303:5)
```
Every version task makes a commit, and it has to be consistent.