### PR TITLE
ci: update GitHub workflow permissions to create tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,8 @@ jobs:
       )
     name: Release packages
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Add write permission for the release workflow to fix tag pushing ([failed job](https://github.com/code-pushup/cli/actions/runs/6995824898/job/19031044372))