### PR TITLE
ci: fix and simplify `version` and `github` configurations

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -19,29 +19,20 @@
       "cache": true
     },
     "version": {
-      "dependsOn": ["^build"],
-      "inputs": ["production", "^production"],
       "executor": "@jscutlery/semver:version",
       "options": {
         "commitMessageFormat": "release({projectName}): {version} [skip ci]",
         "tagPrefix": "{projectName}@",
-        "preset": {
-          "name": "conventionalcommits",
-          "types": [
-            { "type": "feat", "section": "Features" },
-            { "type": "fix", "section": "Bug Fixes" },
-            { "type": "build", "section": "Dependency updates" },
-            { "type": "docs", "section": "Documentation" },
-            { "type": "refactor", "section": "Code Refactoring" },
-            { "type": "perf", "section": "Performance Improvements" }
-          ]
-        }
+        "preset": "angular",
+        "postTargets": ["github"],
+        "push": true
       }
     },
     "github": {
       "executor": "@jscutlery/semver:github",
       "options": {
-        "tag": "{tag}"
+        "tag": "{tag}",
+        "notes": "{notes}"
       }
     },
     "e2e": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
         "benchmark": "^2.1.4",
         "commitizen": "^4.3.0",
         "commitlint-plugin-tense": "^1.0.2",
+        "conventional-changelog-angular": "^7.0.0",
         "dotenv": "^16.3.1",
         "esbuild": "^0.19.2",
         "eslint": "~8.46.0",
@@ -2403,6 +2404,18 @@
         "node": ">=v14"
       }
     },
+    "node_modules/@commitlint/parse/node_modules/conventional-changelog-angular": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-6.0.0.tgz",
+      "integrity": "sha512-6qLgrBF4gueoC7AFVHu51nHL9pF9FRjXrH+ceVf7WmAfH3gs+gEYOkvxhjMPjZu57I4AGUGoNTY8V7Hrgf1uqg==",
+      "dev": true,
+      "dependencies": {
+        "compare-func": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@commitlint/read": {
       "version": "17.5.1",
       "dev": true,
@@ -3792,18 +3805,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
-    },
-    "node_modules/@jscutlery/semver/node_modules/conventional-changelog-angular": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-7.0.0.tgz",
-      "integrity": "sha512-ROjNchA9LgfNMTTFSIWPzebCwOGFdgkEq45EnvvrmSLvCtAw0HSmrCs7/ty+wAeYUZyNay0YMUNYFTRL72PkBQ==",
-      "dev": true,
-      "dependencies": {
-        "compare-func": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
     },
     "node_modules/@jscutlery/semver/node_modules/conventional-changelog-conventionalcommits": {
       "version": "7.0.2",
@@ -8983,14 +8984,15 @@
       }
     },
     "node_modules/conventional-changelog-angular": {
-      "version": "6.0.0",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-7.0.0.tgz",
+      "integrity": "sha512-ROjNchA9LgfNMTTFSIWPzebCwOGFdgkEq45EnvvrmSLvCtAw0HSmrCs7/ty+wAeYUZyNay0YMUNYFTRL72PkBQ==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "compare-func": "^2.0.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "node_modules/conventional-changelog-atom": {
@@ -9424,18 +9426,6 @@
       "dev": true,
       "engines": {
         "node": ">= 10.x"
-      }
-    },
-    "node_modules/conventional-changelog/node_modules/conventional-changelog-angular": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-7.0.0.tgz",
-      "integrity": "sha512-ROjNchA9LgfNMTTFSIWPzebCwOGFdgkEq45EnvvrmSLvCtAw0HSmrCs7/ty+wAeYUZyNay0YMUNYFTRL72PkBQ==",
-      "dev": true,
-      "dependencies": {
-        "compare-func": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=16"
       }
     },
     "node_modules/conventional-changelog/node_modules/conventional-changelog-conventionalcommits": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "benchmark": "^2.1.4",
     "commitizen": "^4.3.0",
     "commitlint-plugin-tense": "^1.0.2",
+    "conventional-changelog-angular": "^7.0.0",
     "dotenv": "^16.3.1",
     "esbuild": "^0.19.2",
     "eslint": "~8.46.0",

--- a/packages/cli/project.json
+++ b/packages/cli/project.json
@@ -19,14 +19,8 @@
       "command": "node tools/scripts/publish.mjs cli {args.ver} {args.tag}",
       "dependsOn": ["build"]
     },
-    "version": {
-      "postTargets": ["cli:github"]
-    },
-    "github": {
-      "options": {
-        "notesFile": "./packages/cli/CHANGELOG.md"
-      }
-    },
+    "version": {},
+    "github": {},
     "lint": {
       "executor": "@nx/linter:eslint",
       "outputs": ["{options.outputFile}"],

--- a/packages/core/project.json
+++ b/packages/core/project.json
@@ -15,12 +15,8 @@
         "esbuildConfig": "esbuild.config.js"
       }
     },
-    "version": { "postTargets": ["core:github"] },
-    "github": {
-      "options": {
-        "notesFile": "./packages/core/CHANGELOG.md"
-      }
-    },
+    "version": {},
+    "github": {},
     "publish": {
       "command": "node tools/scripts/publish.mjs core {args.ver} {args.tag}",
       "dependsOn": ["build"]

--- a/packages/models/project.json
+++ b/packages/models/project.json
@@ -15,12 +15,8 @@
         "esbuildConfig": "esbuild.config.js"
       }
     },
-    "version": { "postTargets": ["models:github"] },
-    "github": {
-      "options": {
-        "notesFile": "./packages/models/CHANGELOG.md"
-      }
-    },
+    "version": {},
+    "github": {},
     "publish": {
       "command": "node tools/scripts/publish.mjs models {args.ver} {args.tag}",
       "dependsOn": ["build"]

--- a/packages/nx-plugin/project.json
+++ b/packages/nx-plugin/project.json
@@ -36,12 +36,8 @@
         ]
       }
     },
-    "version": { "postTargets": ["nx-plugin:github"] },
-    "github": {
-      "options": {
-        "notesFile": "./packages/nx-plugin/CHANGELOG.md"
-      }
-    },
+    "version": {},
+    "github": {},
     "exec:init": {
       "command": "nx g ./dist/packages/nx-plugin:init",
       "dependsOn": ["build"]

--- a/packages/plugin-eslint/project.json
+++ b/packages/plugin-eslint/project.json
@@ -16,12 +16,8 @@
         "esbuildConfig": "esbuild.config.js"
       }
     },
-    "version": { "postTargets": ["plugin-eslint:github"] },
-    "github": {
-      "options": {
-        "notesFile": "./packages/plugin-eslint/CHANGELOG.md"
-      }
-    },
+    "version": {},
+    "github": {},
     "publish": {
       "command": "node tools/scripts/publish.mjs plugin-eslint {args.ver} {args.tag}",
       "dependsOn": ["build"]

--- a/packages/plugin-lighthouse/project.json
+++ b/packages/plugin-lighthouse/project.json
@@ -15,12 +15,8 @@
         "esbuildConfig": "esbuild.config.js"
       }
     },
-    "version": { "postTargets": ["plugin-lighthouse:github"] },
-    "github": {
-      "options": {
-        "notesFile": "./packages/plugin-lighthouse/CHANGELOG.md"
-      }
-    },
+    "version": {},
+    "github": {},
     "lint": {
       "executor": "@nx/linter:eslint",
       "outputs": ["{options.outputFile}"],

--- a/packages/utils/project.json
+++ b/packages/utils/project.json
@@ -15,12 +15,8 @@
         "esbuildConfig": "esbuild.config.js"
       }
     },
-    "version": { "postTargets": ["utils:github"] },
-    "github": {
-      "options": {
-        "notesFile": "./packages/utils/CHANGELOG.md"
-      }
-    },
+    "version": {},
+    "github": {},
     "publish": {
       "command": "node tools/scripts/publish.mjs utils {args.ver} {args.tag}",
       "dependsOn": ["build"]


### PR DESCRIPTION
- remove the `dependsOn` and `inputs` options for the `version` target. It's unnecessary here.
- change the `preset` option to `angular`. If `preset` is like an object, it must be a whole `preset` config with functions. It is not possible to set it in JSON format. We may need to create a preset package in a separate repo.
- move the `postTargets` options to `targetDefaults`.
- replace the `notesFile` option with `notes`. `notesFile` sent the whole `changelog` file to the single release.

All tests I did in [my test repo](https://github.com/IKatsuba/test-nx-semver) 