### PR TITLE
test(cli): set up mocks, disable exit process for tests

### DIFF
--- a/packages/cli/mocks/constants.ts
+++ b/packages/cli/mocks/constants.ts
@@ -8,4 +8,5 @@ export const DEFAULT_CLI_CONFIGURATION = {
   options,
   middlewares,
   commands,
+  noExitProcess: true, // exiting process suppresses error message
 };

--- a/packages/cli/src/lib/autorun/autorun-command.unit.test.ts
+++ b/packages/cli/src/lib/autorun/autorun-command.unit.test.ts
@@ -1,39 +1,12 @@
 import { bundleRequire } from 'bundle-require';
 import { vol } from 'memfs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import {
-  PortalUploadArgs,
-  ReportFragment,
-  uploadToPortal,
-} from '@code-pushup/portal-client';
+import { PortalUploadArgs, uploadToPortal } from '@code-pushup/portal-client';
 import { collectAndPersistReports } from '@code-pushup/core';
 import { MINIMAL_REPORT_MOCK } from '@code-pushup/testing-utils';
 import { DEFAULT_CLI_CONFIGURATION } from '../../../mocks/constants';
 import { yargsCli } from '../yargs-cli';
 import { yargsAutorunCommandObject } from './autorun-command';
-
-// This in needed to mock the API client used inside the upload function
-vi.mock('@code-pushup/portal-client', async () => {
-  const module: typeof import('@code-pushup/portal-client') =
-    await vi.importActual('@code-pushup/portal-client');
-
-  return {
-    ...module,
-    uploadToPortal: vi.fn(
-      async () => ({ packageName: '@code-pushup/cli' } as ReportFragment),
-    ),
-  };
-});
-
-// Mock file system API's
-vi.mock('fs', async () => {
-  const memfs: typeof import('memfs') = await vi.importActual('memfs');
-  return memfs.fs;
-});
-vi.mock('fs/promises', async () => {
-  const memfs: typeof import('memfs') = await vi.importActual('memfs');
-  return memfs.fs.promises;
-});
 
 vi.mock('@code-pushup/core', async () => {
   const core = await vi.importActual('@code-pushup/core');
@@ -43,21 +16,8 @@ vi.mock('@code-pushup/core', async () => {
   };
 });
 
-// Mock bundleRequire inside importEsmModule used for fetching config
-vi.mock('bundle-require', async () => {
-  const { CORE_CONFIG_MOCK }: typeof import('@code-pushup/testing-utils') =
-    await vi.importActual('@code-pushup/testing-utils');
-  return {
-    bundleRequire: vi
-      .fn()
-      .mockResolvedValue({ mod: { default: CORE_CONFIG_MOCK } }),
-  };
-});
-
 describe('autorun-command', () => {
   beforeEach(() => {
-    vi.clearAllMocks();
-    vol.reset();
     vol.fromJSON(
       {
         'my-report.json': JSON.stringify(MINIMAL_REPORT_MOCK),

--- a/packages/cli/src/lib/collect/collect-command.unit.test.ts
+++ b/packages/cli/src/lib/collect/collect-command.unit.test.ts
@@ -6,16 +6,6 @@ import { DEFAULT_CLI_CONFIGURATION } from '../../../mocks/constants';
 import { yargsCli } from '../yargs-cli';
 import { yargsCollectCommandObject } from './collect-command';
 
-// Mock file system API's
-vi.mock('fs', async () => {
-  const memfs: typeof import('memfs') = await vi.importActual('memfs');
-  return memfs.fs;
-});
-vi.mock('fs/promises', async () => {
-  const memfs: typeof import('memfs') = await vi.importActual('memfs');
-  return memfs.fs.promises;
-});
-
 vi.mock('@code-pushup/core', async () => {
   const core = await vi.importActual('@code-pushup/core');
   return {
@@ -24,21 +14,8 @@ vi.mock('@code-pushup/core', async () => {
   };
 });
 
-// Mock bundleRequire inside importEsmModule used for fetching config
-vi.mock('bundle-require', async () => {
-  const { CORE_CONFIG_MOCK }: typeof import('@code-pushup/testing-utils') =
-    await vi.importActual('@code-pushup/testing-utils');
-  return {
-    bundleRequire: vi
-      .fn()
-      .mockResolvedValue({ mod: { default: CORE_CONFIG_MOCK } }),
-  };
-});
-
 describe('collect-command', () => {
   beforeEach(() => {
-    vi.clearAllMocks();
-    vol.reset();
     vol.fromJSON(
       {
         'code-pushup.config.ts': '', // only needs to exist for stat inside readCodePushupConfig

--- a/packages/cli/src/lib/implementation/only-plugins-utils.unit.test.ts
+++ b/packages/cli/src/lib/implementation/only-plugins-utils.unit.test.ts
@@ -1,4 +1,4 @@
-import { SpyInstance, describe, expect } from 'vitest';
+import { describe, expect } from 'vitest';
 import { CoreConfig } from '@code-pushup/models';
 import {
   filterCategoryByOnlyPluginsOption,
@@ -37,16 +37,6 @@ describe('filterPluginsByOnlyPluginsOption', () => {
 // without the `no-secrets` rule, this would be flagged as a security issue
 // eslint-disable-next-line no-secrets/no-secrets
 describe('filterCategoryByOnlyPluginsOption', () => {
-  let logSpy: SpyInstance;
-
-  beforeEach(() => {
-    logSpy = vi.spyOn(console, 'log');
-  });
-
-  afterEach(() => {
-    logSpy.mockRestore();
-  });
-
   it('should return all categories if no onlyPlugins option', () => {
     expect(
       filterCategoryByOnlyPluginsOption(
@@ -87,26 +77,16 @@ describe('filterCategoryByOnlyPluginsOption', () => {
         onlyPlugins: ['plugin1', 'plugin3'],
       },
     );
-    expect(logSpy).toHaveBeenCalledWith(
+    expect(console.log).toHaveBeenCalledWith(
       expect.stringContaining('"category1" is ignored'),
     );
-    expect(logSpy).toHaveBeenCalledWith(
+    expect(console.log).toHaveBeenCalledWith(
       expect.stringContaining('skipped plugin "plugin2"'),
     );
   });
 });
 
 describe('validateOnlyPluginsOption', () => {
-  let logSpy: SpyInstance;
-
-  beforeEach(() => {
-    logSpy = vi.spyOn(console, 'log');
-  });
-
-  afterEach(() => {
-    logSpy.mockRestore();
-  });
-
   it('should log if onlyPlugins option contains non-existing plugin', () => {
     validateOnlyPluginsOption(
       [{ slug: 'plugin1' }, { slug: 'plugin2' }] as CoreConfig['plugins'],
@@ -114,7 +94,7 @@ describe('validateOnlyPluginsOption', () => {
         onlyPlugins: ['plugin1', 'plugin3', 'plugin4'],
       },
     );
-    expect(logSpy).toHaveBeenCalledWith(
+    expect(console.log).toHaveBeenCalledWith(
       expect.stringContaining(
         'plugins with "plugin3", "plugin4" slugs, but no such plugins are present',
       ),
@@ -128,6 +108,6 @@ describe('validateOnlyPluginsOption', () => {
         onlyPlugins: ['plugin1'],
       },
     );
-    expect(logSpy).not.toHaveBeenCalled();
+    expect(console.log).not.toHaveBeenCalled();
   });
 });

--- a/packages/cli/src/lib/print-config/print-config-command.unit.test.ts
+++ b/packages/cli/src/lib/print-config/print-config-command.unit.test.ts
@@ -1,47 +1,17 @@
 import { vol } from 'memfs';
-import { SpyInstance, describe, expect } from 'vitest';
+import { beforeEach, describe, expect } from 'vitest';
 import { DEFAULT_CLI_CONFIGURATION } from '../../../mocks/constants';
 import { yargsCli } from '../yargs-cli';
 import { yargsConfigCommandObject } from './print-config-command';
 
-// Mock file system API's
-vi.mock('fs', async () => {
-  const memfs: typeof import('memfs') = await vi.importActual('memfs');
-  return memfs.fs;
-});
-vi.mock('fs/promises', async () => {
-  const memfs: typeof import('memfs') = await vi.importActual('memfs');
-  return memfs.fs.promises;
-});
-
-// Mock bundleRequire inside importEsmModule used for fetching config
-vi.mock('bundle-require', async () => {
-  const { CORE_CONFIG_MOCK }: typeof import('@code-pushup/testing-utils') =
-    await vi.importActual('@code-pushup/testing-utils');
-  return {
-    bundleRequire: vi
-      .fn()
-      .mockResolvedValue({ mod: { default: CORE_CONFIG_MOCK } }),
-  };
-});
-
 describe('print-config-command', () => {
-  let logSpy: SpyInstance;
-
   beforeEach(() => {
-    vi.clearAllMocks();
-    logSpy = vi.spyOn(console, 'log');
-    vol.reset();
     vol.fromJSON(
       {
         'code-pushup.config.ts': '', // only needs to exist for stat inside readCodePushupConfig
       },
       '/test',
     );
-  });
-
-  afterEach(() => {
-    logSpy.mockRestore();
   });
 
   it('should filter out meta arguments and kebab duplicates', async () => {
@@ -55,12 +25,16 @@ describe('print-config-command', () => {
       { ...DEFAULT_CLI_CONFIGURATION, commands: [yargsConfigCommandObject()] },
     ).parseAsync();
 
-    expect(logSpy).not.toHaveBeenCalledWith(expect.stringContaining('"$0":'));
-    expect(logSpy).not.toHaveBeenCalledWith(expect.stringContaining('"_":'));
-    expect(logSpy).toHaveBeenCalledWith(
+    expect(console.log).not.toHaveBeenCalledWith(
+      expect.stringContaining('"$0":'),
+    );
+    expect(console.log).not.toHaveBeenCalledWith(
+      expect.stringContaining('"_":'),
+    );
+    expect(console.log).toHaveBeenCalledWith(
       expect.stringContaining('"outputDir": "destinationDir"'),
     );
-    expect(logSpy).not.toHaveBeenCalledWith(
+    expect(console.log).not.toHaveBeenCalledWith(
       expect.stringContaining('"output-dir":'),
     );
   });

--- a/packages/cli/src/lib/upload/upload-command.unit.test.ts
+++ b/packages/cli/src/lib/upload/upload-command.unit.test.ts
@@ -1,54 +1,14 @@
 import { bundleRequire } from 'bundle-require';
 import { vol } from 'memfs';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import {
-  PortalUploadArgs,
-  ReportFragment,
-  uploadToPortal,
-} from '@code-pushup/portal-client';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { PortalUploadArgs, uploadToPortal } from '@code-pushup/portal-client';
 import { MINIMAL_REPORT_MOCK } from '@code-pushup/testing-utils';
 import { DEFAULT_CLI_CONFIGURATION } from '../../../mocks/constants';
 import { yargsCli } from '../yargs-cli';
 import { yargsUploadCommandObject } from './upload-command';
 
-// This in needed to mock the API client used inside the upload function
-vi.mock('@code-pushup/portal-client', async () => {
-  const module: typeof import('@code-pushup/portal-client') =
-    await vi.importActual('@code-pushup/portal-client');
-
-  return {
-    ...module,
-    uploadToPortal: vi.fn(
-      async () => ({ packageName: '@code-pushup/cli' } as ReportFragment),
-    ),
-  };
-});
-
-// Mock file system API's
-vi.mock('fs', async () => {
-  const memfs: typeof import('memfs') = await vi.importActual('memfs');
-  return memfs.fs;
-});
-vi.mock('fs/promises', async () => {
-  const memfs: typeof import('memfs') = await vi.importActual('memfs');
-  return memfs.fs.promises;
-});
-
-// Mock bundleRequire inside importEsmModule used for fetching config
-vi.mock('bundle-require', async () => {
-  const { CORE_CONFIG_MOCK }: typeof import('@code-pushup/testing-utils') =
-    await vi.importActual('@code-pushup/testing-utils');
-  return {
-    bundleRequire: vi
-      .fn()
-      .mockResolvedValue({ mod: { default: CORE_CONFIG_MOCK } }),
-  };
-});
-
 describe('upload-command-object', () => {
   beforeEach(() => {
-    vi.clearAllMocks();
-    vol.reset();
     vol.fromJSON(
       {
         'my-report.json': JSON.stringify(MINIMAL_REPORT_MOCK),

--- a/packages/cli/src/lib/yargs-cli.ts
+++ b/packages/cli/src/lib/yargs-cli.ts
@@ -27,9 +27,10 @@ export function yargsCli<T = unknown>(
       middlewareFunction: unknown;
       applyBeforeValidation?: boolean;
     }[];
+    noExitProcess?: boolean;
   },
 ): Argv<T> {
-  const { usageMessage, scriptName } = cfg;
+  const { usageMessage, scriptName, noExitProcess } = cfg;
   let { commands, options, middlewares } = cfg;
   commands = Array.isArray(commands) ? commands : [];
   middlewares = Array.isArray(middlewares) ? middlewares : [];
@@ -83,6 +84,13 @@ export function yargsCli<T = unknown>(
       }),
     });
   });
+
+  // this flag should be set for tests and debugging purposes
+  // when there is an error and exitProcess is called, it suppresses the error message
+  // more info here: https://yargs.js.org/docs/#api-reference-exitprocessenable
+  if (noExitProcess) {
+    cli.exitProcess(false);
+  }
 
   // return CLI object
   return cli as unknown as Argv<T>;

--- a/packages/cli/vite.config.integration.ts
+++ b/packages/cli/vite.config.integration.ts
@@ -12,6 +12,5 @@ export default defineConfig({
     },
     environment: 'node',
     include: ['src/**/*.integration.test.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
-    globalSetup: ['global-setup.ts'],
   },
 });

--- a/packages/cli/vite.config.unit.ts
+++ b/packages/cli/vite.config.unit.ts
@@ -12,6 +12,12 @@ export default defineConfig({
     },
     environment: 'node',
     include: ['src/**/*.unit.test.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
-    globalSetup: ['global-setup.ts'],
+    setupFiles: [
+      '../../testing-utils/src/lib/setup/fs.mock.ts',
+      '../../testing-utils/src/lib/setup/console-log.mock.ts',
+      '../../testing-utils/src/lib/setup/portal-client.mock.ts',
+      '../../testing-utils/src/lib/setup/bundle-require.mock.ts',
+      '../../testing-utils/src/lib/setup/reset.mocks.ts',
+    ],
   },
 });

--- a/testing-utils/src/lib/setup/bundle-require.mock.ts
+++ b/testing-utils/src/lib/setup/bundle-require.mock.ts
@@ -1,0 +1,12 @@
+import { vi } from 'vitest';
+
+// Mock bundleRequire inside importEsmModule used for fetching config
+vi.mock('bundle-require', async () => {
+  const { CORE_CONFIG_MOCK }: typeof import('@code-pushup/testing-utils') =
+    await vi.importActual('@code-pushup/testing-utils');
+  return {
+    bundleRequire: vi
+      .fn()
+      .mockResolvedValue({ mod: { default: CORE_CONFIG_MOCK } }),
+  };
+});

--- a/testing-utils/src/lib/setup/console-log.mock.ts
+++ b/testing-utils/src/lib/setup/console-log.mock.ts
@@ -1,0 +1,11 @@
+import { SpyInstance, afterEach, beforeEach, vi } from 'vitest';
+
+let consoleLogSpy: SpyInstance;
+
+beforeEach(() => {
+  consoleLogSpy = vi.spyOn(console, 'log');
+});
+
+afterEach(() => {
+  consoleLogSpy.mockRestore();
+});

--- a/testing-utils/src/lib/setup/fs.mock.ts
+++ b/testing-utils/src/lib/setup/fs.mock.ts
@@ -1,0 +1,10 @@
+import { vi } from 'vitest';
+
+vi.mock('fs', async () => {
+  const memfs: typeof import('memfs') = await vi.importActual('memfs');
+  return memfs.fs;
+});
+vi.mock('fs/promises', async () => {
+  const memfs: typeof import('memfs') = await vi.importActual('memfs');
+  return memfs.fs.promises;
+});

--- a/testing-utils/src/lib/setup/portal-client.mock.ts
+++ b/testing-utils/src/lib/setup/portal-client.mock.ts
@@ -1,0 +1,14 @@
+import { vi } from 'vitest';
+import { ReportFragment } from '@code-pushup/portal-client';
+
+vi.mock('@code-pushup/portal-client', async () => {
+  const module: typeof import('@code-pushup/portal-client') =
+    await vi.importActual('@code-pushup/portal-client');
+
+  return {
+    ...module,
+    uploadToPortal: vi.fn(
+      async () => ({ packageName: '@code-pushup/cli' } as ReportFragment),
+    ),
+  };
+});

--- a/testing-utils/src/lib/setup/reset.mocks.ts
+++ b/testing-utils/src/lib/setup/reset.mocks.ts
@@ -1,0 +1,7 @@
+import { vol } from 'memfs';
+import { beforeEach, vi } from 'vitest';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vol.reset();
+});


### PR DESCRIPTION
Closes #211 

In this PR, I extract and configure mock setup for the CLI package:
- unnecessary global setup is removed from both CLI integration and unit tests
- `fs` and `fs/promises` used in almost all unit tests.
- `console.log` is now mocked for all unit tests.
- `bundleRequire` used by command objects is also extracted.
- `portal-client`, while used by two command objects, is also extracted as it could be reused.
- I also reset mocks and `memfs` volume before each test.

Additionally, for better debugging, I disabled `exitProcess` in `yargsCli` which closes #243 