### PR TITLE
fix(plugin-eslint): truncate rule texts to pass models validations

### DIFF
--- a/packages/models/src/index.ts
+++ b/packages/models/src/index.ts
@@ -1,16 +1,21 @@
 export {
   CategoryConfig,
   CategoryRef,
-  categoryRefSchema,
   categoryConfigSchema,
+  categoryRefSchema,
 } from './lib/category-config';
-
 export {
   CoreConfig,
   coreConfigSchema,
   refineCoreConfig,
   unrefinedCoreConfigSchema,
 } from './lib/core-config';
+export {
+  MAX_DESCRIPTION_LENGTH,
+  MAX_SLUG_LENGTH,
+  MAX_TITLE_LENGTH,
+} from './lib/implementation/limits';
+export { materialIconSchema } from './lib/implementation/schemas';
 export {
   Format,
   PersistConfig,
@@ -19,15 +24,22 @@ export {
 } from './lib/persist-config';
 export { PluginConfig, pluginConfigSchema } from './lib/plugin-config';
 export {
-  auditSchema,
   Audit,
+  auditSchema,
   pluginAuditsSchema,
 } from './lib/plugin-config-audits';
 export {
-  AuditGroupRef,
   AuditGroup,
+  AuditGroupRef,
   auditGroupSchema,
 } from './lib/plugin-config-groups';
+export {
+  OnProgress,
+  RunnerConfig,
+  RunnerFunction,
+  onProgressSchema,
+  runnerConfigSchema,
+} from './lib/plugin-config-runner';
 export {
   AuditOutput,
   AuditOutputs,
@@ -36,18 +48,10 @@ export {
 export { Issue, IssueSeverity } from './lib/plugin-process-output-audit-issue';
 export {
   AuditReport,
-  auditReportSchema,
   PluginReport,
   Report,
+  auditReportSchema,
   pluginReportSchema,
   reportSchema,
 } from './lib/report';
 export { UploadConfig, uploadConfigSchema } from './lib/upload-config';
-export { materialIconSchema } from './lib/implementation/schemas';
-export {
-  onProgressSchema,
-  OnProgress,
-  RunnerFunction,
-  runnerConfigSchema,
-  RunnerConfig,
-} from './lib/plugin-config-runner';

--- a/packages/models/src/lib/implementation/limits.ts
+++ b/packages/models/src/lib/implementation/limits.ts
@@ -1,0 +1,3 @@
+export const MAX_SLUG_LENGTH = 128;
+export const MAX_TITLE_LENGTH = 256;
+export const MAX_DESCRIPTION_LENGTH = 65_536;

--- a/packages/models/src/lib/implementation/schemas.ts
+++ b/packages/models/src/lib/implementation/schemas.ts
@@ -1,5 +1,10 @@
 import { z } from 'zod';
 import { MATERIAL_ICONS, MaterialIcon } from '@code-pushup/portal-client';
+import {
+  MAX_DESCRIPTION_LENGTH,
+  MAX_SLUG_LENGTH,
+  MAX_TITLE_LENGTH,
+} from './limits';
 import { filenameRegex, slugRegex } from './utils';
 
 /**
@@ -33,8 +38,8 @@ export function slugSchema(
       message:
         'The slug has to follow the pattern [0-9a-z] followed by multiple optional groups of -[0-9a-z]. e.g. my-slug',
     })
-    .max(128, {
-      message: 'slug can be max 128 characters long',
+    .max(MAX_SLUG_LENGTH, {
+      message: `slug can be max ${MAX_SLUG_LENGTH} characters long`,
     });
 }
 
@@ -43,7 +48,7 @@ export function slugSchema(
  * @param description
  */
 export function descriptionSchema(description = 'Description (markdown)') {
-  return z.string({ description }).max(65536).optional();
+  return z.string({ description }).max(MAX_DESCRIPTION_LENGTH).optional();
 }
 
 /**
@@ -67,7 +72,7 @@ export function urlSchema(description: string) {
  * @param description
  */
 export function titleSchema(description = 'Descriptive name') {
-  return z.string({ description }).max(256);
+  return z.string({ description }).max(MAX_TITLE_LENGTH);
 }
 
 /**

--- a/packages/plugin-eslint/src/lib/meta/transform.ts
+++ b/packages/plugin-eslint/src/lib/meta/transform.ts
@@ -1,4 +1,5 @@
 import type { Audit } from '@code-pushup/models';
+import { truncateDescription, truncateTitle } from '@code-pushup/utils';
 import { ruleIdToSlug } from './hash';
 import { RuleData } from './rules';
 
@@ -17,8 +18,8 @@ export function ruleToAudit({ ruleId, meta, options }: RuleData): Audit {
 
   return {
     slug: ruleIdToSlug(ruleId, options),
-    title: meta.docs?.description ?? name,
-    description: lines.join('\n\n'),
+    title: truncateTitle(meta.docs?.description ?? name),
+    description: truncateDescription(lines.join('\n\n')),
     ...(meta.docs?.url && {
       docsUrl: meta.docs.url,
     }),

--- a/packages/plugin-eslint/src/lib/meta/transform.unit.test.ts
+++ b/packages/plugin-eslint/src/lib/meta/transform.unit.test.ts
@@ -144,4 +144,28 @@ Custom options:
         'https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/extensions.md',
     });
   });
+
+  it('rule with overlong description -> title is truncated', () => {
+    expect(
+      ruleToAudit({
+        ruleId: '@angular-eslint/template/mouse-events-have-key-events',
+        meta: {
+          docs: {
+            description:
+              '[Accessibility] Ensures that the mouse events `mouseout` and `mouseover` are accompanied by `focus` and `blur` events respectively. Coding for the keyboard is important for users with physical disabilities who cannot use a mouse, AT compatibility, and screenreader users. See more at https://www.w3.org/WAI/WCAG21/Understanding/keyboard',
+            url: 'https://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin-template/docs/rules/mouse-events-have-key-events.md',
+          },
+        },
+        options: [],
+      }),
+    ).toEqual<Audit>({
+      slug: 'angular-eslint-template-mouse-events-have-key-events',
+      title:
+        '[Accessibility] Ensures that the mouse events `mouseout` and `mouseover` are accompanied by `focus` and `blur` events respectively. Coding for the keyboard is important for users with physical disabilities who cannot use a mouse, AT compatibility, and s...',
+      description:
+        'ESLint rule **mouse-events-have-key-events**, from _@angular-eslint/template_ plugin.',
+      docsUrl:
+        'https://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin-template/docs/rules/mouse-events-have-key-events.md',
+    });
+  });
 });

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -27,6 +27,9 @@ export {
   pluralize,
   pluralizeToken,
   slugify,
+  truncateDescription,
+  truncateText,
+  truncateTitle,
 } from './lib/formatting';
 export { getLatestCommit, git } from './lib/git';
 export {

--- a/packages/utils/src/lib/formatting.ts
+++ b/packages/utils/src/lib/formatting.ts
@@ -1,3 +1,5 @@
+import { MAX_DESCRIPTION_LENGTH, MAX_TITLE_LENGTH } from '@code-pushup/models';
+
 export function slugify(text: string): string {
   return text
     .trim()
@@ -39,4 +41,20 @@ export function formatDuration(duration: number): string {
     return `${duration} ms`;
   }
   return `${(duration / 1000).toFixed(2)} s`;
+}
+
+export function truncateText(text: string, maxChars: number): string {
+  if (text.length <= maxChars) {
+    return text;
+  }
+  const ellipsis = '...';
+  return text.slice(0, maxChars - ellipsis.length) + ellipsis;
+}
+
+export function truncateTitle(text: string): string {
+  return truncateText(text, MAX_TITLE_LENGTH);
+}
+
+export function truncateDescription(text: string): string {
+  return truncateText(text, MAX_DESCRIPTION_LENGTH);
 }

--- a/packages/utils/src/lib/formatting.unit.test.ts
+++ b/packages/utils/src/lib/formatting.unit.test.ts
@@ -5,6 +5,7 @@ import {
   pluralize,
   pluralizeToken,
   slugify,
+  truncateText,
 } from './formatting';
 
 describe('slugify', () => {
@@ -76,5 +77,23 @@ describe('formatDuration', () => {
     [1200, '1.20 s'],
   ])('should log correct plural for %s`', (ms, displayValue) => {
     expect(formatDuration(ms)).toBe(displayValue);
+  });
+});
+
+describe('truncateText', () => {
+  it('should replace overflowing text with ellipsis', () => {
+    expect(truncateText('All work and no play makes Jack a dull boy', 32)).toBe(
+      'All work and no play makes Ja...',
+    );
+  });
+
+  it('should produce truncated text which fits within limit', () => {
+    expect(
+      truncateText('All work and no play makes Jack a dull boy', 32).length,
+    ).toBeLessThanOrEqual(32);
+  });
+
+  it('should leave text unchanged when within character limit', () => {
+    expect(truncateText("Here's Johnny!", 32)).toBe("Here's Johnny!");
   });
 });


### PR DESCRIPTION
Ran into validation problems when trying to integrate rules from Angular ESLint. This unblocks https://github.com/code-pushup/portal/issues/151