### PR TITLE
feat(utils): add sorting of audit issues for report md

### DIFF
--- a/packages/utils/src/lib/report-to-md.ts
+++ b/packages/utils/src/lib/report-to-md.ts
@@ -34,6 +34,7 @@ import {
   reportHeadlineText,
   reportMetaTableHeaders,
   reportOverviewTableHeaders,
+  sortAuditIssues,
   sortAudits,
   sortCategoryAudits,
 } from './report';
@@ -216,7 +217,7 @@ function reportToAuditsSection(report: ScoredReport): string {
 
       const detailsTableData = [
         detailsTableHeaders,
-        ...audit.details.issues.map((issue: Issue) => {
+        ...audit.details.issues.sort(sortAuditIssues).map((issue: Issue) => {
           const severity = `${getSeverityIcon(issue.severity)} <i>${
             issue.severity
           }</i>`;

--- a/packages/utils/src/lib/report-to-md.ts
+++ b/packages/utils/src/lib/report-to-md.ts
@@ -21,6 +21,7 @@ import {
 import {
   FOOTER_PREFIX,
   README_LINK,
+  compareIssues,
   countCategoryAudits,
   detailsTableHeaders,
   formatReportScore,
@@ -34,7 +35,6 @@ import {
   reportHeadlineText,
   reportMetaTableHeaders,
   reportOverviewTableHeaders,
-  sortAuditIssues,
   sortAudits,
   sortCategoryAudits,
 } from './report';
@@ -217,7 +217,7 @@ function reportToAuditsSection(report: ScoredReport): string {
 
       const detailsTableData = [
         detailsTableHeaders,
-        ...audit.details.issues.sort(sortAuditIssues).map((issue: Issue) => {
+        ...audit.details.issues.sort(compareIssues).map((issue: Issue) => {
           const severity = `${getSeverityIcon(issue.severity)} <i>${
             issue.severity
           }</i>`;

--- a/packages/utils/src/lib/report.ts
+++ b/packages/utils/src/lib/report.ts
@@ -297,6 +297,14 @@ export function compareIssues(a: Issue, b: Issue): number {
     return a.source?.file.localeCompare(b.source?.file || '') || 0;
   }
 
+  if (!a.source?.position && b.source?.position) {
+    return -1;
+  }
+
+  if (a.source?.position && !b.source?.position) {
+    return 1;
+  }
+
   if (a.source?.position?.startLine !== b.source?.position?.startLine) {
     return (
       (a.source?.position?.startLine || 0) -

--- a/packages/utils/src/lib/report.ts
+++ b/packages/utils/src/lib/report.ts
@@ -4,6 +4,7 @@ import {
   CategoryRef,
   IssueSeverity as CliIssueSeverity,
   Format,
+  Issue,
   PersistConfig,
   Report,
   reportSchema,
@@ -277,4 +278,23 @@ export function getPluginNameFromSlug(
   return (
     plugins.find(({ slug: pluginSlug }) => pluginSlug === slug)?.title || slug
   );
+}
+
+export function sortAuditIssues(a: Issue, b: Issue): number {
+  if (a.severity !== b.severity) {
+    return -compareIssueSeverity(a.severity, b.severity);
+  }
+
+  if (a.source?.file !== b.source?.file) {
+    return a.source?.file.localeCompare(b.source?.file || '') || 0;
+  }
+
+  if (a.source?.position?.startLine !== b.source?.position?.startLine) {
+    return (
+      (a.source?.position?.startLine || 0) -
+      (b.source?.position?.startLine || 0)
+    );
+  }
+
+  return 0;
 }

--- a/packages/utils/src/lib/report.ts
+++ b/packages/utils/src/lib/report.ts
@@ -280,9 +280,17 @@ export function getPluginNameFromSlug(
   );
 }
 
-export function sortAuditIssues(a: Issue, b: Issue): number {
+export function compareIssues(a: Issue, b: Issue): number {
   if (a.severity !== b.severity) {
     return -compareIssueSeverity(a.severity, b.severity);
+  }
+
+  if (!a.source && b.source) {
+    return -1;
+  }
+
+  if (a.source && !b.source) {
+    return 1;
   }
 
   if (a.source?.file !== b.source?.file) {

--- a/packages/utils/src/lib/report.unit.test.ts
+++ b/packages/utils/src/lib/report.unit.test.ts
@@ -1,6 +1,11 @@
 import { vol } from 'memfs';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { CategoryRef, IssueSeverity, PluginReport } from '@code-pushup/models';
+import {
+  CategoryRef,
+  Issue,
+  IssueSeverity,
+  PluginReport,
+} from '@code-pushup/models';
 import { MEMFS_VOLUME, report } from '@code-pushup/models/testing';
 import {
   calcDuration,
@@ -8,6 +13,7 @@ import {
   countWeightedRefs,
   getPluginNameFromSlug,
   loadReport,
+  sortAuditIssues,
   sortAudits,
   sortCategoryAudits,
 } from './report';
@@ -221,5 +227,39 @@ describe('getPluginNameFromSlug', () => {
     ] as ScoredReport['plugins'];
     expect(getPluginNameFromSlug('plugin-a', plugins)).toBe('Plugin A');
     expect(getPluginNameFromSlug('plugin-b', plugins)).toBe('Plugin B');
+  });
+});
+
+describe('sortAuditIssues', () => {
+  it('should sort issues by severity and source file', () => {
+    const mockIssues = [
+      { severity: 'warning', source: { file: 'b' } },
+      { severity: 'error', source: { file: 'c' } },
+      { severity: 'error', source: { file: 'a' } },
+      { severity: 'info', source: { file: 'b' } },
+    ] as Issue[];
+    const sortedIssues = [...mockIssues].sort(sortAuditIssues);
+    expect(sortedIssues).toEqual([
+      { severity: 'error', source: { file: 'a' } },
+      { severity: 'error', source: { file: 'c' } },
+      { severity: 'warning', source: { file: 'b' } },
+      { severity: 'info', source: { file: 'b' } },
+    ]);
+  });
+
+  it('should sort issues by source file and source start line', () => {
+    const mockIssues = [
+      { severity: 'info', source: { file: 'b', position: { startLine: 2 } } },
+      { severity: 'info', source: { file: 'c', position: { startLine: 1 } } },
+      { severity: 'info', source: { file: 'a', position: { startLine: 2 } } },
+      { severity: 'info', source: { file: 'b', position: { startLine: 1 } } },
+    ] as Issue[];
+    const sortedIssues = [...mockIssues].sort(sortAuditIssues);
+    expect(sortedIssues).toEqual([
+      { severity: 'info', source: { file: 'a', position: { startLine: 2 } } },
+      { severity: 'info', source: { file: 'b', position: { startLine: 1 } } },
+      { severity: 'info', source: { file: 'b', position: { startLine: 2 } } },
+      { severity: 'info', source: { file: 'c', position: { startLine: 1 } } },
+    ]);
   });
 });

--- a/packages/utils/src/lib/report.unit.test.ts
+++ b/packages/utils/src/lib/report.unit.test.ts
@@ -10,10 +10,10 @@ import { MEMFS_VOLUME, report } from '@code-pushup/models/testing';
 import {
   calcDuration,
   compareIssueSeverity,
+  compareIssues,
   countWeightedRefs,
   getPluginNameFromSlug,
   loadReport,
-  sortAuditIssues,
   sortAudits,
   sortCategoryAudits,
 } from './report';
@@ -238,7 +238,7 @@ describe('sortAuditIssues', () => {
       { severity: 'error', source: { file: 'a' } },
       { severity: 'info', source: { file: 'b' } },
     ] as Issue[];
-    const sortedIssues = [...mockIssues].sort(sortAuditIssues);
+    const sortedIssues = [...mockIssues].sort(compareIssues);
     expect(sortedIssues).toEqual([
       { severity: 'error', source: { file: 'a' } },
       { severity: 'error', source: { file: 'c' } },
@@ -254,9 +254,35 @@ describe('sortAuditIssues', () => {
       { severity: 'info', source: { file: 'a', position: { startLine: 2 } } },
       { severity: 'info', source: { file: 'b', position: { startLine: 1 } } },
     ] as Issue[];
-    const sortedIssues = [...mockIssues].sort(sortAuditIssues);
+    const sortedIssues = [...mockIssues].sort(compareIssues);
     expect(sortedIssues).toEqual([
       { severity: 'info', source: { file: 'a', position: { startLine: 2 } } },
+      { severity: 'info', source: { file: 'b', position: { startLine: 1 } } },
+      { severity: 'info', source: { file: 'b', position: { startLine: 2 } } },
+      { severity: 'info', source: { file: 'c', position: { startLine: 1 } } },
+    ]);
+  });
+
+  it('should sort issues without source on top of same severity', () => {
+    const mockIssues = [
+      { severity: 'info', source: { file: 'b', position: { startLine: 2 } } },
+      { severity: 'info', source: { file: 'c', position: { startLine: 1 } } },
+      {
+        severity: 'warning',
+        source: { file: 'a', position: { startLine: 2 } },
+      },
+      { severity: 'info', source: { file: 'b', position: { startLine: 1 } } },
+      { severity: 'info' },
+      { severity: 'error' },
+    ] as Issue[];
+    const sortedIssues = [...mockIssues].sort(compareIssues);
+    expect(sortedIssues).toEqual([
+      { severity: 'error' },
+      {
+        severity: 'warning',
+        source: { file: 'a', position: { startLine: 2 } },
+      },
+      { severity: 'info' },
       { severity: 'info', source: { file: 'b', position: { startLine: 1 } } },
       { severity: 'info', source: { file: 'b', position: { startLine: 2 } } },
       { severity: 'info', source: { file: 'c', position: { startLine: 1 } } },

--- a/packages/utils/src/lib/report.unit.test.ts
+++ b/packages/utils/src/lib/report.unit.test.ts
@@ -272,7 +272,7 @@ describe('sortAuditIssues', () => {
         source: { file: 'a', position: { startLine: 2 } },
       },
       { severity: 'info', source: { file: 'b', position: { startLine: 1 } } },
-      { severity: 'info' },
+      { severity: 'info', source: { file: 'b' } },
       { severity: 'error' },
     ] as Issue[];
     const sortedIssues = [...mockIssues].sort(compareIssues);
@@ -282,7 +282,7 @@ describe('sortAuditIssues', () => {
         severity: 'warning',
         source: { file: 'a', position: { startLine: 2 } },
       },
-      { severity: 'info' },
+      { severity: 'info', source: { file: 'b' } },
       { severity: 'info', source: { file: 'b', position: { startLine: 1 } } },
       { severity: 'info', source: { file: 'b', position: { startLine: 2 } } },
       { severity: 'info', source: { file: 'c', position: { startLine: 1 } } },


### PR DESCRIPTION
Added sorting of audit issues for `report.md`:
- by severity (errors first), 
- by source file (alphabetical),
- by start line (ascending).

Closes #313