### PR TITLE
chore: add package metadata

### DIFF
--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -49,6 +49,7 @@ esbuild.build({
                   ...rootPackageJson.repository,
                   directory: projectPath,
                 };
+                packageJson.contributors = rootPackageJson.contributors;
                 packageJson.type = 'module';
                 packageJson.main = './index.js';
                 packageJson.types = './src/index.d.ts';

--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -33,10 +33,16 @@ esbuild.build({
                 if (result.errors.length > 0) return;
 
                 /** @type {import('type-fest').PackageJson} */
+                const rootPackageJson = JSON.parse(
+                  readFileSync(`${__dirname}/package.json`).toString(),
+                );
+
+                /** @type {import('type-fest').PackageJson} */
                 const packageJson = JSON.parse(
                   readFileSync(`${projectPath}/package.json`).toString(),
                 );
 
+                packageJson.license = rootPackageJson.license;
                 packageJson.type = 'module';
                 packageJson.main = './index.js';
                 packageJson.types = './src/index.d.ts';

--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -43,6 +43,12 @@ esbuild.build({
                 );
 
                 packageJson.license = rootPackageJson.license;
+                packageJson.homepage = rootPackageJson.homepage;
+                packageJson.bugs = rootPackageJson.bugs;
+                packageJson.repository = {
+                  ...rootPackageJson.repository,
+                  directory: projectPath,
+                };
                 packageJson.type = 'module';
                 packageJson.main = './index.js';
                 packageJson.types = './src/index.d.ts';

--- a/package.json
+++ b/package.json
@@ -2,6 +2,14 @@
   "name": "@code-pushup/cli-source",
   "version": "0.5.4",
   "license": "MIT",
+  "homepage": "https://github.com/code-pushup/cli#readme",
+  "bugs": {
+    "url": "https://github.com/code-pushup/cli/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/code-pushup/cli.git"
+  },
   "scripts": {
     "prepare": "husky install",
     "commit": "git-cz"

--- a/package.json
+++ b/package.json
@@ -10,6 +10,33 @@
     "type": "git",
     "url": "https://github.com/code-pushup/cli.git"
   },
+  "contributors": [
+    {
+      "name": "Igor Katsuba",
+      "email": "igor@katsuba.dev",
+      "url": "https://katsuba.dev"
+    },
+    {
+      "name": "Kateřina Pilátová",
+      "email": "katerina.pilatova@flowup.cz",
+      "url": "https://github.com/Tlacenka"
+    },
+    {
+      "name": "Matěj Chalk",
+      "email": "matej.chalk@flowup.cz",
+      "url": "https://github.com/matejchalk"
+    },
+    {
+      "name": "Michael Hladky",
+      "email": "michael.hladky@push-based.io",
+      "url": "https://push-based.io"
+    },
+    {
+      "name": "Michael Seredenko",
+      "email": "misha.seredenko@push-based.io",
+      "url": "https://github.com/MishaSeredenkoPushBased"
+    }
+  ],
   "scripts": {
     "prepare": "husky install",
     "commit": "git-cz"


### PR DESCRIPTION
## Docs

For every `packages/*/package.json` file except `packages/test-utils/package.json`, add the following metadata as part of the build process

- License (MIT)
- Homepage (currently the readme in the GitHub repo)
- Bug tracker (GitHub Issues)
- Git repo and sub-directory for the individual package
- Contributors (@matejchalk, @BioPhoton, @Tlacenka, @MishaSeredenkoPushBased, @IKatsuba)

This metadata is copied from the root `package.json` file via our `PackageJSON` ESBuild plugin and shows up on npm pages like https://www.npmjs.com/package/@code-pushup/cli