### PR TITLE
fix(plugin-eslint): fix default Nx lint patterns - directory not valid for "files" in eslintrc

### DIFF
--- a/packages/plugin-eslint/src/lib/nx/utils.ts
+++ b/packages/plugin-eslint/src/lib/nx/utils.ts
@@ -25,7 +25,7 @@ export function getLintFilePatterns(project: ProjectConfiguration): string[] {
     | { lintFilePatterns?: string | string[] }
     | undefined;
   return options?.lintFilePatterns == null
-    ? [project.root] // lintFilePatterns defaults to ["{projectRoot}"] - https://github.com/nrwl/nx/pull/20313
+    ? [`${project.root}/**/*`] // lintFilePatterns defaults to ["{projectRoot}"] - https://github.com/nrwl/nx/pull/20313
     : toArray(options.lintFilePatterns);
 }
 


### PR DESCRIPTION
Follow-up to:
- #384 

Should solve `Error: 'filePath' should not be a directory path.` :crossed_fingers: 