### PR TITLE
ci: fix labeler workflow for prs from fork

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,7 +1,7 @@
 name: PR Labeler
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize]
 
 jobs:


### PR DESCRIPTION
As PR's from forks fail (see #381) we need to adopt the trigger for `pull_request` to `pull_request_target`.
Docs can be found here: https://github.com/actions/labeler#permissions