### PR TITLE
refactor(examples-plugins): optimize Nx project configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# for uploading to portal
+CP_SERVER=
+CP_API_KEY=
+CP_ORGANIZATION=
+CP_PROJECT=

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -46,7 +46,11 @@
               },
               {
                 "sourceTag": "type:feature",
-                "onlyDependOnLibsWithTags": ["type:util", "type:testing-util"]
+                "onlyDependOnLibsWithTags": [
+                  "type:feature",
+                  "type:util",
+                  "type:testing-util"
+                ]
               },
               {
                 "sourceTag": "type:util",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,7 +180,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Build CLI and ESLint plugin
-        run: npx nx run-many -t build -p cli,plugin-eslint --parallel=2
+        run: npx nx run-many -t build -p cli,plugin-eslint,examples-plugins --parallel=3
       - name: Collect Code PushUp report
         run: npx dist/packages/cli --config code-pushup.config.ts collect
       - name: Upload Code PushUp report to portal

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,12 +179,10 @@ jobs:
           cache: npm
       - name: Install dependencies
         run: npm ci
-      - name: Build CLI and ESLint plugin
-        run: npx nx run-many -t build -p cli,plugin-eslint,examples-plugins --parallel=3
       - name: Collect Code PushUp report
-        run: npx dist/packages/cli --config code-pushup.config.ts collect
+        run: npx nx run-collect
       - name: Upload Code PushUp report to portal
-        run: npx dist/packages/cli --config code-pushup.config.ts upload
+        run: npx nx run-upload
       - name: Save report files as workflow artifact
         uses: actions/upload-artifact@v3
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,6 +67,7 @@ Projects are tagged in two different dimensions - scope and type:
 | `scope:plugin`      | a specific plugin implementation (contract with core defined by data models) | `scope:shared`                                     |
 | `scope:shared`      | data models, utility functions, etc. (not specific to core or plugins)       | `scope:shared`                                     |
 | `scope:tooling`     | supplementary tooling, e.g. code generation                                  | `scope:shared`                                     |
+| `scope:internal`    | internal project, e.g. example plugin                                        | any                                                |
 | `type:app`          | application, e.g. CLI or example web app                                     | `type:feature`, `type:util` or `type:testing-util` |
 | `type:feature`      | library with business logic for a specific feature                           | `type:util` or `type:testing-util`                 |
 | `type:util`         | general purpose utilities and types intended for reuse                       | `type:util` or `type:testing-util`                 |

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -36,6 +36,9 @@ npx nx build cli
 
 # lint projects affected by changes (compared to main branch)
 npx nx affected:lint
+
+# run Code PushUp command on this repository
+npx nx run-collect
 ```
 
 ## Git

--- a/README.md
+++ b/README.md
@@ -26,3 +26,5 @@ This monorepo contains code for open-source Code PushUp NPM packages:
 - [🧩 @code-pushup/utils](./packages/utils/) - various **utilities** (useful for custom plugins or other integrations)
 - plugins:
   - [📦 @code-pushup/eslint-plugin](./packages/plugin-eslint/) - static analysis using **ESLint** rules
+
+If you want to contribute, please refer to [CONTRIBUTING.md](./CONTRIBUTING.md).

--- a/code-pushup.config.ts
+++ b/code-pushup.config.ts
@@ -14,12 +14,14 @@ import eslintPlugin, {
 import type { CoreConfig } from './packages/models/src';
 
 // load upload configuration from environment
-const envSchema = z.object({
-  CP_SERVER: z.string().url(),
-  CP_API_KEY: z.string().min(1),
-  CP_ORGANIZATION: z.string().min(1),
-  CP_PROJECT: z.string().min(1),
-});
+const envSchema = z
+  .object({
+    CP_SERVER: z.string().url(),
+    CP_API_KEY: z.string().min(1),
+    CP_ORGANIZATION: z.string().min(1),
+    CP_PROJECT: z.string().min(1),
+  })
+  .partial();
 const env = await envSchema.parseAsync(process.env);
 
 const config: CoreConfig = {
@@ -29,12 +31,17 @@ const config: CoreConfig = {
     format: ['json', 'md'],
   },
 
-  upload: {
-    server: env.CP_SERVER,
-    apiKey: env.CP_API_KEY,
-    organization: env.CP_ORGANIZATION,
-    project: env.CP_PROJECT,
-  },
+  ...(env.CP_SERVER &&
+    env.CP_API_KEY &&
+    env.CP_ORGANIZATION &&
+    env.CP_PROJECT && {
+      upload: {
+        server: env.CP_SERVER,
+        apiKey: env.CP_API_KEY,
+        organization: env.CP_ORGANIZATION,
+        project: env.CP_PROJECT,
+      },
+    }),
 
   plugins: [
     await eslintPlugin(await eslintConfigFromNxProjects()),

--- a/code-pushup.config.ts
+++ b/code-pushup.config.ts
@@ -1,8 +1,5 @@
 import 'dotenv/config';
 import { z } from 'zod';
-import eslintPlugin, {
-  eslintConfigFromNxProjects,
-} from './dist/packages/plugin-eslint';
 import {
   fileSizePlugin,
   fileSizeRecommendedRefs,
@@ -10,7 +7,10 @@ import {
   packageJsonPerformanceGroupRef,
   packageJsonPlugin,
   packageJsonVersionControlGroupRef,
-} from './examples/plugins/src';
+} from './dist/examples/plugins';
+import eslintPlugin, {
+  eslintConfigFromNxProjects,
+} from './dist/packages/plugin-eslint';
 import type { CoreConfig } from './packages/models/src';
 
 // load upload configuration from environment

--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -1,10 +1,14 @@
 const esbuild = require('esbuild');
 const { execSync } = require('child_process');
-const { readFileSync, writeFileSync } = require('fs');
+const { readFileSync, writeFileSync, existsSync } = require('fs');
 
 const project = process.env.NX_TASK_TARGET_PROJECT;
-const isPublishable = project !== 'testing-utils';
-const projectPath = isPublishable ? `packages/${project}` : project;
+const projectPath =
+  project === 'testing-utils'
+    ? 'testing-utils'
+    : project === 'examples-plugins'
+    ? 'examples/plugins'
+    : `packages/${project}`;
 
 esbuild.build({
   plugins: [
@@ -24,44 +28,56 @@ esbuild.build({
         });
       },
     },
-    ...(isPublishable
-      ? [
-          {
-            name: 'PackageJSON',
-            setup(build) {
-              build.onEnd(result => {
-                if (result.errors.length > 0) return;
+    {
+      name: 'PackageJSON',
+      setup(build) {
+        build.onEnd(result => {
+          if (result.errors.length > 0) return;
 
-                /** @type {import('type-fest').PackageJson} */
-                const rootPackageJson = JSON.parse(
-                  readFileSync(`${__dirname}/package.json`).toString(),
-                );
+          if (!existsSync(`${projectPath}/package.json`)) {
+            /** @type {import('type-fest').PackageJson} */
+            const newPackageJson = {
+              name: `@code-pushup/${project}`,
+              private: true,
+              type: 'module',
+              main: 'index.js',
+              types: 'src/index.d.ts',
+            };
+            writeFileSync(
+              `dist/${projectPath}/package.json`,
+              JSON.stringify(newPackageJson, null, 2),
+            );
+            return;
+          }
 
-                /** @type {import('type-fest').PackageJson} */
-                const packageJson = JSON.parse(
-                  readFileSync(`${projectPath}/package.json`).toString(),
-                );
+          /** @type {import('type-fest').PackageJson} */
+          const packageJson = JSON.parse(
+            readFileSync(`${projectPath}/package.json`).toString(),
+          );
 
-                packageJson.license = rootPackageJson.license;
-                packageJson.homepage = rootPackageJson.homepage;
-                packageJson.bugs = rootPackageJson.bugs;
-                packageJson.repository = {
-                  ...rootPackageJson.repository,
-                  directory: projectPath,
-                };
-                packageJson.contributors = rootPackageJson.contributors;
-                packageJson.type = 'module';
-                packageJson.main = './index.js';
-                packageJson.types = './src/index.d.ts';
+          /** @type {import('type-fest').PackageJson} */
+          const rootPackageJson = JSON.parse(
+            readFileSync('package.json').toString(),
+          );
 
-                writeFileSync(
-                  `dist/${projectPath}/package.json`,
-                  JSON.stringify(packageJson, null, 2),
-                );
-              });
-            },
-          },
-        ]
-      : []),
+          packageJson.license = rootPackageJson.license;
+          packageJson.homepage = rootPackageJson.homepage;
+          packageJson.bugs = rootPackageJson.bugs;
+          packageJson.repository = {
+            ...rootPackageJson.repository,
+            directory: projectPath,
+          };
+          packageJson.contributors = rootPackageJson.contributors;
+          packageJson.type = 'module';
+          packageJson.main = './index.js';
+          packageJson.types = './src/index.d.ts';
+
+          writeFileSync(
+            `dist/${projectPath}/package.json`,
+            JSON.stringify(packageJson, null, 2),
+          );
+        });
+      },
+    },
   ],
 });

--- a/examples/plugins/.eslintrc.json
+++ b/examples/plugins/.eslintrc.json
@@ -1,6 +1,6 @@
 {
   "extends": ["../../.eslintrc.json"],
-  "ignorePatterns": ["!**/*"],
+  "ignorePatterns": ["!**/*", "code-pushup.config.ts"],
   "overrides": [
     {
       "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],

--- a/examples/plugins/.eslintrc.json
+++ b/examples/plugins/.eslintrc.json
@@ -4,9 +4,7 @@
   "overrides": [
     {
       "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
-      "rules": {
-        "@nx/enforce-module-boundaries": ["off"]
-      }
+      "rules": {}
     },
     {
       "files": ["*.ts", "*.tsx"],

--- a/examples/plugins/code-pushup.config.ts
+++ b/examples/plugins/code-pushup.config.ts
@@ -1,12 +1,11 @@
 import {
+  fileSizePlugin,
+  fileSizeRecommendedRefs,
   packageJsonDocumentationGroupRef,
   packageJsonPerformanceGroupRef,
   packageJsonPlugin,
   packageJsonVersionControlGroupRef,
-} from './src';
-import fileSizePlugin, {
-  recommendedRefs as fileSizeRecommendedRefs,
-} from './src/file-size/src/file-size.plugin';
+} from '../../dist/examples/plugins';
 
 /**
  * Run it with:
@@ -17,8 +16,7 @@ import fileSizePlugin, {
  *
  */
 
-// eslint-disable-next-line unicorn/no-unreadable-iife
-const config = (() => ({
+const config = {
   plugins: [
     fileSizePlugin({
       directory: './dist/packages',
@@ -52,6 +50,6 @@ const config = (() => ({
       refs: [packageJsonDocumentationGroupRef],
     },
   ],
-}))();
+};
 
 export default config;

--- a/examples/plugins/project.json
+++ b/examples/plugins/project.json
@@ -3,15 +3,24 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "examples/plugins/src",
   "projectType": "library",
-  "implicitDependencies": ["cli"],
   "targets": {
+    "build": {
+      "executor": "@nx/esbuild:esbuild",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "outputPath": "dist/examples/plugins",
+        "main": "examples/plugins/src/index.ts",
+        "tsConfig": "examples/plugins/tsconfig.lib.json",
+        "assets": ["examples/plugins/*.md"],
+        "esbuildConfig": "esbuild.config.js"
+      }
+    },
     "lint": {
       "executor": "@nx/linter:eslint",
       "outputs": ["{options.outputFile}"],
       "options": {
         "lintFilePatterns": ["examples/plugins/**/*.ts"]
-      },
-      "dependsOn": ["^build"]
+      }
     },
     "unit-test": {
       "executor": "@nx/vite:test",
@@ -19,8 +28,7 @@
       "options": {
         "config": "examples/plugins/vite.config.unit.ts",
         "reportsDirectory": "../../coverage/examples-plugins/unit-tests"
-      },
-      "dependsOn": ["^build"]
+      }
     },
     "integration-test": {
       "executor": "@nx/vite:test",
@@ -28,16 +36,23 @@
       "options": {
         "config": "examples/plugins/vite.config.integration.ts",
         "reportsDirectory": "../../coverage/examples-plugins/integration-tests"
-      },
-      "dependsOn": ["^build"]
+      }
     },
     "run-collect": {
       "command": "npx dist/packages/cli collect --config=examples/plugins/code-pushup.config.ts --persist.format=md",
-      "dependsOn": ["^build"]
+      "dependsOn": [
+        "build",
+        "^build",
+        { "projects": ["cli"], "target": "build" }
+      ]
     },
     "run-print-config": {
       "command": "npx dist/packages/cli print-config --config=examples/plugins/code-pushup.config.ts",
-      "dependsOn": ["^build"]
+      "dependsOn": [
+        "build",
+        "^build",
+        { "projects": ["cli"], "target": "build" }
+      ]
     }
   },
   "tags": []

--- a/examples/plugins/project.json
+++ b/examples/plugins/project.json
@@ -55,5 +55,5 @@
       ]
     }
   },
-  "tags": []
+  "tags": ["scope:internal", "type:feature"]
 }

--- a/examples/plugins/src/file-size/src/file-size.plugin.ts
+++ b/examples/plugins/src/file-size/src/file-size.plugin.ts
@@ -13,7 +13,7 @@ import {
   formatBytes,
   pluralizeToken,
   toUnixPath,
-} from '../../../../../dist/packages/utils';
+} from '@code-pushup/utils';
 
 export type PluginOptions = {
   directory: string;

--- a/examples/plugins/src/file-size/src/file-size.plugin.unit.test.ts
+++ b/examples/plugins/src/file-size/src/file-size.plugin.unit.test.ts
@@ -2,7 +2,7 @@ import { vol } from 'memfs';
 import { unlink } from 'node:fs/promises';
 import { basename, join } from 'node:path';
 import { beforeEach, describe, expect, it } from 'vitest';
-import { formatBytes } from '../../../../../dist/packages/utils';
+import { formatBytes } from '@code-pushup/utils';
 import {
   PluginOptions,
   assertFileSize,

--- a/examples/plugins/src/package-json/src/integration/dependencies.audit.ts
+++ b/examples/plugins/src/package-json/src/integration/dependencies.audit.ts
@@ -1,8 +1,5 @@
 import { Audit, AuditOutput, Issue } from '@code-pushup/models';
-import {
-  factorOf,
-  findLineNumberInText,
-} from '../../../../../../dist/packages/utils';
+import { factorOf, findLineNumberInText } from '@code-pushup/utils';
 import {
   DependencyMap,
   DependencyType,

--- a/examples/plugins/src/package-json/src/integration/type.audit.ts
+++ b/examples/plugins/src/package-json/src/integration/type.audit.ts
@@ -1,5 +1,5 @@
 import { AuditOutput, Issue } from '@code-pushup/models';
-import { findLineNumberInText } from '../../../../../../dist/packages/utils';
+import { findLineNumberInText } from '@code-pushup/utils';
 import { PackageJson, SourceResult, SourceResults } from './types';
 import {
   assertPropertyEmpty,

--- a/examples/plugins/src/package-json/src/integration/utils.ts
+++ b/examples/plugins/src/package-json/src/integration/utils.ts
@@ -3,7 +3,7 @@ import {
   factorOf,
   findLineNumberInText,
   pluralizeToken,
-} from '../../../../../../dist/packages/utils';
+} from '@code-pushup/utils';
 import { PackageJson, SourceResult } from './types';
 
 export function baseAuditOutput(slug: string): AuditOutput {

--- a/examples/plugins/src/package-json/src/package-json.plugin.ts
+++ b/examples/plugins/src/package-json/src/package-json.plugin.ts
@@ -7,7 +7,7 @@ import {
   crawlFileSystem,
   readJsonFile,
   readTextFile,
-} from '../../../../../dist/packages/utils';
+} from '@code-pushup/utils';
 import { pluginSlug } from './constants';
 import {
   RequiredDependencies,

--- a/examples/plugins/tsconfig.lib.json
+++ b/examples/plugins/tsconfig.lib.json
@@ -5,7 +5,7 @@
     "declaration": true,
     "types": ["node"]
   },
-  "include": ["src/**/*.ts", "src/index.ts", "code-pushup.config.ts"],
+  "include": ["src/**/*.ts"],
   "exclude": [
     "vite.config.unit.ts",
     "vite.config.integration.ts",

--- a/examples/react-todos-app/project.json
+++ b/examples/react-todos-app/project.json
@@ -53,5 +53,5 @@
       }
     }
   },
-  "tags": []
+  "tags": ["scope:internal", "type:app"]
 }

--- a/project.json
+++ b/project.json
@@ -27,6 +27,33 @@
         "tag": "{tag}",
         "notes": "{notes}"
       }
+    },
+    "run-collect": {
+      "command": "npx dist/packages/cli collect --config=code-pushup.config.ts",
+      "dependsOn": [
+        {
+          "projects": ["cli", "plugin-eslint", "examples-plugins"],
+          "target": "build"
+        }
+      ]
+    },
+    "run-upload": {
+      "command": "npx dist/packages/cli upload --config=code-pushup.config.ts",
+      "dependsOn": [
+        {
+          "projects": ["cli", "plugin-eslint", "examples-plugins"],
+          "target": "build"
+        }
+      ]
+    },
+    "run-autorun": {
+      "command": "npx dist/packages/cli autorun --config=code-pushup.config.ts",
+      "dependsOn": [
+        {
+          "projects": ["cli", "plugin-eslint", "examples-plugins"],
+          "target": "build"
+        }
+      ]
     }
   }
 }

--- a/testing-utils/package.json
+++ b/testing-utils/package.json
@@ -1,5 +1,0 @@
-{
-  "name": "@code-pushup/testing-utils",
-  "version": "0.8.1",
-  "dependencies": {}
-}


### PR DESCRIPTION
Cleaned up the `examples-plugins` Nx project, in order to improve DX and bring it more in line with Nx conventions.
- No longer imports from `.../dist/packages/utils` in `src` folder, tests and lint targets no longer depend on `build`.
- No longer ignores the `@nx/enforce-module-boundaries` rule.

Made some other related improvements:
- Added custom targets to root project for running Code PushUp command on the whole repo (e.g. `npx nx run-collect`), automatically builds dependencies using `dependsOn`. 
- ESBuild config supports non-publishable libraries - creates minimal `package.json` automatically, includes necessary metadata so imports from `dist` work correctly (e.g. references correct type declarations).
  - Removed `package.json` from `testing-utils` - it only needs to be buildable (because of Nx lint), not publishable. 
- Added a `scope:internal` Nx tag and added missing tags to Nx projects.
- Contributing docs are linked from README.