### PR TITLE
ci: meaningful categories configuration

### DIFF
--- a/code-pushup.config.ts
+++ b/code-pushup.config.ts
@@ -6,7 +6,6 @@ import {
   packageJsonDocumentationGroupRef,
   packageJsonPerformanceGroupRef,
   packageJsonPlugin,
-  packageJsonVersionControlGroupRef,
 } from './dist/examples/plugins';
 import eslintPlugin, {
   eslintConfigFromNxProjects,
@@ -45,18 +44,17 @@ const config: CoreConfig = {
 
   plugins: [
     await eslintPlugin(await eslintConfigFromNxProjects()),
+
     fileSizePlugin({
-      directory: './dist/packages',
+      directory: './dist/examples/react-todos-app',
       pattern: /\.js$/,
-      budget: 42_000,
+      budget: 174_080, // 170 kB
     }),
+
     packageJsonPlugin({
-      directory: './packages',
+      directory: './dist/packages',
       license: 'MIT',
       type: 'module',
-      dependencies: {
-        zod: '^3.22.4',
-      },
     }),
   ],
 
@@ -64,10 +62,7 @@ const config: CoreConfig = {
     {
       slug: 'bug-prevention',
       title: 'Bug prevention',
-      refs: [
-        { type: 'group', plugin: 'eslint', slug: 'problems', weight: 1 },
-        packageJsonVersionControlGroupRef,
-      ],
+      refs: [{ type: 'group', plugin: 'eslint', slug: 'problems', weight: 1 }],
     },
     {
       slug: 'code-style',
@@ -77,14 +72,13 @@ const config: CoreConfig = {
       ],
     },
     {
-      slug: 'performance',
-      title: 'Performance',
-      refs: [...fileSizeRecommendedRefs, packageJsonPerformanceGroupRef],
-    },
-    {
-      slug: 'documentation',
-      title: 'Documentation',
-      refs: [packageJsonDocumentationGroupRef],
+      slug: 'custom-checks',
+      title: 'Custom checks',
+      refs: [
+        ...fileSizeRecommendedRefs,
+        packageJsonPerformanceGroupRef,
+        packageJsonDocumentationGroupRef,
+      ],
     },
   ],
 };

--- a/examples/plugins/src/package-json/README.md
+++ b/examples/plugins/src/package-json/README.md
@@ -9,8 +9,8 @@ The plugin crawls the file base depending on your configuration and checks the c
 You can configure the plugin with the following options:
 
 - `directory` - directory to crawl as string
-- `license` - file name pattern as string
-- `type` - size budget as number in bytes
+- `license` - expected value of [`license` property in `package.json`](https://docs.npmjs.com/cli/configuring-npm/package-json#license)
+- `type` - expected value of [`type` property in `package.json`](https://nodejs.org/api/packages.html#type)
 - `dependencies` - package dependencies as object
 - `devDependencies` - package dependencies as object
 - `optionalDependencies` - package dependencies as object

--- a/examples/plugins/src/package-json/src/integration/license.audit.ts
+++ b/examples/plugins/src/package-json/src/integration/license.audit.ts
@@ -11,7 +11,7 @@ const licenseAuditSlug = 'package-license';
 export const licenseAuditMeta: Audit = {
   slug: licenseAuditSlug,
   title: 'License',
-  description: 'An audit to check NPM package license`.',
+  description: 'An audit to check NPM package license.',
 };
 
 export function licenseAudit(

--- a/examples/plugins/src/package-json/src/integration/type.audit.ts
+++ b/examples/plugins/src/package-json/src/integration/type.audit.ts
@@ -12,7 +12,7 @@ const typeAuditSlug = 'package-type';
 export const typeAuditInfoMeta = {
   slug: typeAuditSlug,
   title: 'Type',
-  description: 'An audit to check NPM package type`.',
+  description: 'An audit to check NPM package type.',
 };
 
 export function typeAudit(

--- a/project.json
+++ b/project.json
@@ -32,7 +32,12 @@
       "command": "npx dist/packages/cli collect --config=code-pushup.config.ts",
       "dependsOn": [
         {
-          "projects": ["cli", "plugin-eslint", "examples-plugins"],
+          "projects": [
+            "cli",
+            "plugin-eslint",
+            "examples-plugins",
+            "react-todos-app"
+          ],
           "target": "build"
         }
       ]
@@ -41,7 +46,12 @@
       "command": "npx dist/packages/cli upload --config=code-pushup.config.ts",
       "dependsOn": [
         {
-          "projects": ["cli", "plugin-eslint", "examples-plugins"],
+          "projects": [
+            "cli",
+            "plugin-eslint",
+            "examples-plugins",
+            "react-todos-app"
+          ],
           "target": "build"
         }
       ]
@@ -50,7 +60,12 @@
       "command": "npx dist/packages/cli autorun --config=code-pushup.config.ts",
       "dependsOn": [
         {
-          "projects": ["cli", "plugin-eslint", "examples-plugins"],
+          "projects": [
+            "cli",
+            "plugin-eslint",
+            "examples-plugins",
+            "react-todos-app"
+          ],
           "target": "build"
         }
       ]


### PR DESCRIPTION
#397 should be merged before this PR.

Closes #390 

## Problem

Since the custom plugins have been added to our Code PushUp config, meaningful audits (ESLint) are now intermingled with random audits (from custom plugins) which measure things that aren't meaningful for our repository.

- 50% of the Bug prevention score is made up of an audit which requires every package directly depends on Zod version `^3.22.4` (all but one fail). The 106 ESLint problems in total only impact the other 50% of the score. Hence why the score dropped massively from 84 to 50.
  ![image](https://github.com/code-pushup/cli/assets/34691111/110707ef-c170-4592-ae37-9bf68d30d1c6)
  ![image](https://github.com/code-pushup/cli/assets/34691111/0a31a48a-9263-4946-a7a0-4a2f86c95a78)
  - The weight is ridiculous. The dependency audit shouldn't be 106x more impactful than each ESLint rule.
  - The assertion is nonsense. Why should every package directly depend on Zod? It shouldn't. And why `^3.22.4` (`models` package fails with `^3.22.1`)? No reason. The [`@nx/dependency-checks`](https://nx.dev/nx-api/eslint-plugin/documents/dependency-checks) rule is way more accurate
- 50% of the Performance score is based on whether each package's `index.js` bundle is less than 41.02 kB (half fail).
  ![image](https://github.com/code-pushup/cli/assets/34691111/1dc31430-38d9-4426-a171-c4aa12611875)
  ![image](https://github.com/code-pushup/cli/assets/34691111/56d8ffe7-2c8e-4201-a7d3-437cd908b438)
  - Bundle size is a big concern for web apps, but these are Node packages, where bundle size is almost completely irrelevant. And the budget of `41.02 kB` (`42_000` bytes) is completely arbitrary.
- The other 50% of Performance score and 100% of Documentation score is based on checking if `"type": "module"` and `"license": "MIT"` are present in source `package.json` files (every packages fails). 
![image](https://github.com/code-pushup/cli/assets/34691111/bed30641-5951-466f-9387-7f72fb2b26e4)
  - We do actually want those properties present, but we're creating them dynamically by ESBuild, so the `package.json`s in `dist/packages` should be checked instead (that's what gets deployed to NPM), otherwise it's a false alarm.
  - The categories seem to be arbitrary. What has `"type": "module"` to do with Performance? If anything, it's more like Bug prevention (package cannot be imported without it). And a Documentation category made up entirely of "does the package have `"license": "MIT"`?" feels very surface-level.

## Solution

To keep things simple, I decided to move all the custom audits under a Custom checks category, so that they don't pollute the Bug prevention and Code Style categories, and don't overstate what they measure as Performance and Documentation categories did (removed them until we have something meaningful to measure there).

I also changed configuration of the plugins so that they actually measure things we care about:
- File size checks the bundle size of the example React app we're already using for tests, so that the budget is less arbitrary.
- The `license` and `type` properties are checked against the `package.json`s in `dist/packages`.
- I removed the dependencies audit, couldn't think of a good use case for it.
(The old configuration is still used in `examples/plugins/code-pushup.config.ts`, in case it's still useful for testing the plugins.)

![image](https://github.com/code-pushup/cli/assets/34691111/3bda0d02-9164-4ec3-a299-60ce40171f62)

![image](https://github.com/code-pushup/cli/assets/34691111/16788837-646b-450f-8a58-50c76110ced0)
