### PR TITLE
ci: fix Code PushUp step in release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,8 +90,8 @@ jobs:
         run: |
           echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> .npmrc
           npx nx run-many -t=deploy --exclude=plugin-lighthouse,nx-plugin
-      - name: Collect and Upload Code PushUp report
-        run: npx dist/packages/cli --config code-pushup.config.ts autorun
+      - name: Collect and upload Code PushUp report
+        run: npx nx run-autorun
         env:
           CP_SERVER: ${{ secrets.CP_SERVER }}
           CP_API_KEY: ${{ secrets.CP_API_KEY }}


### PR DESCRIPTION
Forgot to update `release.yml` in #397 :facepalm: 

[Example of failing step](https://github.com/code-pushup/cli/actions/runs/7472201046/job/20333895343)

![image](https://github.com/code-pushup/cli/assets/34691111/a82250b1-fdf4-4058-ac69-7395f53adb09)
