### PR TITLE
chore: remove ESLint issues from test files in core, plugin-eslint and utils

### DIFF
--- a/packages/core/.eslintrc.json
+++ b/packages/core/.eslintrc.json
@@ -3,7 +3,6 @@
   // temporarily disable failing rules so `nx lint` passes
   // number of errors/warnings per rule recorded at Tue Nov 28 2023 15:38:21 GMT+0100 (Central European Standard Time)
   "rules": {
-    "arrow-body-style": "off", // 3 warnings
     "max-lines-per-function": "off", // 1 warning
     "prefer-template": "off", // 3 warnings
     "@typescript-eslint/no-confusing-void-expression": "off", // 2 warnings
@@ -12,15 +11,12 @@
     "@typescript-eslint/no-unnecessary-condition": "off", // 4 warnings
     "@typescript-eslint/no-unsafe-return": "off", // 1 error
     "@typescript-eslint/prefer-nullish-coalescing": "off", // 2 warnings
-    "@typescript-eslint/require-await": "off", // 13 warnings
     "functional/immutable-data": "off", // 1 error, 2 warnings
     "functional/no-let": "off", // 2 warnings
-    "n/no-sync": "off", // 21 warnings
+    "n/no-sync": "off", // 6 warnings
     "unicorn/catch-error-name": "off", // 3 warnings
     "unicorn/explicit-length-check": "off", // 2 warnings
     "unicorn/import-style": "off", // 6 warnings
-    "unicorn/numeric-separators-style": "off", // 2 warnings
-    "unicorn/prefer-node-protocol": "off", // 12 warnings
     "unicorn/prefer-spread": "off", // 2 warnings
     "unicorn/prefer-ternary": "off" // 1 warning
   },

--- a/packages/core/src/lib/implementation/execute-plugin.unit.test.ts
+++ b/packages/core/src/lib/implementation/execute-plugin.unit.test.ts
@@ -173,16 +173,15 @@ describe('executePlugins', () => {
             command: 'node',
             args: ['-v'],
             outputFile: 'output.json',
-            outputTransform: (outputs: unknown): Promise<AuditOutputs> => {
-              return Promise.resolve([
+            outputTransform: (outputs: unknown): Promise<AuditOutputs> =>
+              Promise.resolve([
                 {
                   slug: (outputs as AuditOutputs)[0]!.slug,
                   score: 0.3,
                   value: 16,
                   displayValue: '16.0.0',
                 },
-              ]);
-            },
+              ]),
           },
         },
       ],

--- a/packages/core/src/lib/implementation/persist.ts
+++ b/packages/core/src/lib/implementation/persist.ts
@@ -1,6 +1,6 @@
-import { existsSync, mkdirSync } from 'fs';
-import { stat, writeFile } from 'fs/promises';
-import { join } from 'path';
+import { existsSync, mkdirSync } from 'node:fs';
+import { stat, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
 import { PersistConfig, Report } from '@code-pushup/models';
 import {
   MultipleFileResults,

--- a/packages/core/src/lib/implementation/persist.unit.test.ts
+++ b/packages/core/src/lib/implementation/persist.unit.test.ts
@@ -1,6 +1,6 @@
-import { readFileSync } from 'fs';
 import { vol } from 'memfs';
-import { join } from 'path';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { Report } from '@code-pushup/models';
 import { MEMFS_VOLUME, MINIMAL_REPORT_MOCK } from '@code-pushup/testing-utils';
@@ -41,7 +41,7 @@ describe('persistReport', () => {
     });
 
     const jsonReport: Report = JSON.parse(
-      readFileSync(join(MEMFS_VOLUME, 'report.json')).toString(),
+      await readFile(join(MEMFS_VOLUME, 'report.json'), 'utf8'),
     );
     expect(jsonReport).toEqual(
       expect.objectContaining({
@@ -50,9 +50,9 @@ describe('persistReport', () => {
       }),
     );
 
-    expect(() => readFileSync(join(MEMFS_VOLUME, 'report.md'))).toThrow(
-      'no such file or directory',
-    );
+    await expect(() =>
+      readFile(join(MEMFS_VOLUME, 'report.md')),
+    ).rejects.toThrow('no such file or directory');
   });
 
   it('should create a report in md format', async () => {
@@ -62,12 +62,12 @@ describe('persistReport', () => {
       format: ['md'],
     });
 
-    const mdReport = readFileSync(join(MEMFS_VOLUME, 'report.md')).toString();
+    const mdReport = await readFile(join(MEMFS_VOLUME, 'report.md'), 'utf8');
     expect(mdReport).toContain('Code PushUp Report');
 
-    expect(() => readFileSync(join(MEMFS_VOLUME, 'report.json'))).toThrow(
-      'no such file or directory',
-    );
+    await expect(() =>
+      readFile(join(MEMFS_VOLUME, 'report.json'), 'utf8'),
+    ).rejects.toThrow('no such file or directory');
   });
 
   it('should create a report in all formats', async () => {
@@ -77,12 +77,12 @@ describe('persistReport', () => {
       filename: 'report',
     });
 
-    const mdReport = readFileSync(join(MEMFS_VOLUME, 'report.md')).toString();
+    const mdReport = await readFile(join(MEMFS_VOLUME, 'report.md'), 'utf8');
     expect(mdReport).toContain('Code PushUp Report');
     expect(mdReport).toContain('|🏷 Category|⭐ Score|🛡 Audits|');
 
     const jsonReport: Report = JSON.parse(
-      readFileSync(join(MEMFS_VOLUME, 'report.json')).toString(),
+      await readFile(join(MEMFS_VOLUME, 'report.json'), 'utf8'),
     );
     expect(jsonReport).toEqual(
       expect.objectContaining({
@@ -94,8 +94,8 @@ describe('persistReport', () => {
 });
 
 describe('logPersistedResults', () => {
-  it('should log report sizes correctly`', async () => {
-    logPersistedResults([{ status: 'fulfilled', value: ['out.json', 10000] }]);
+  it('should log report sizes correctly`', () => {
+    logPersistedResults([{ status: 'fulfilled', value: ['out.json', 10_000] }]);
     expect(console.info).toHaveBeenNthCalledWith(
       1,
       'Generated reports successfully: ',
@@ -110,7 +110,7 @@ describe('logPersistedResults', () => {
     );
   });
 
-  it('should log fails correctly`', async () => {
+  it('should log fails correctly`', () => {
     logPersistedResults([{ status: 'rejected', reason: 'fail' }]);
 
     expect(console.warn).toHaveBeenNthCalledWith(
@@ -123,9 +123,9 @@ describe('logPersistedResults', () => {
     );
   });
 
-  it('should log report sizes and fails correctly`', async () => {
+  it('should log report sizes and fails correctly`', () => {
     logPersistedResults([
-      { status: 'fulfilled', value: ['out.json', 10000] },
+      { status: 'fulfilled', value: ['out.json', 10_000] },
       { status: 'rejected', reason: 'fail' },
     ]);
 

--- a/packages/core/src/lib/implementation/read-code-pushup-config.integration.test.ts
+++ b/packages/core/src/lib/implementation/read-code-pushup-config.integration.test.ts
@@ -1,5 +1,5 @@
-import { dirname, join } from 'path';
-import { fileURLToPath } from 'url';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, expect } from 'vitest';
 import { readCodePushupConfig } from './read-code-pushup-config';
 

--- a/packages/core/src/lib/implementation/runner.ts
+++ b/packages/core/src/lib/implementation/runner.ts
@@ -1,4 +1,4 @@
-import { join } from 'path';
+import { join } from 'node:path';
 import {
   AuditOutputs,
   OnProgress,

--- a/packages/core/src/lib/implementation/runner.unit.test.ts
+++ b/packages/core/src/lib/implementation/runner.unit.test.ts
@@ -49,16 +49,15 @@ describe('executeRunnerConfig', () => {
       command: 'node',
       args: ['-v'],
       outputFile: 'output.json',
-      outputTransform: (outputs: unknown): Promise<AuditOutputs> => {
-        return Promise.resolve([
+      outputTransform: (outputs: unknown): Promise<AuditOutputs> =>
+        Promise.resolve([
           {
             slug: (outputs as AuditOutputs)[0]!.slug,
             score: 0.3,
             value: 16,
             displayValue: '16.0.0',
           },
-        ]);
-      },
+        ]),
     });
 
     expect(runnerResult.audits[0]?.slug).toBe('node-version');
@@ -71,11 +70,8 @@ describe('executeRunnerConfig', () => {
         command: 'node',
         args: ['-v'],
         outputFile: 'output.json',
-        outputTransform: () => {
-          return Promise.reject(
-            new Error('Error: outputTransform has failed.'),
-          );
-        },
+        outputTransform: () =>
+          Promise.reject(new Error('Error: outputTransform has failed.')),
       }),
     ).rejects.toThrow('Error: outputTransform has failed.');
   });

--- a/packages/plugin-eslint/.eslintrc.json
+++ b/packages/plugin-eslint/.eslintrc.json
@@ -10,10 +10,8 @@
     "@typescript-eslint/no-unsafe-return": "off", // 2 errors
     "functional/immutable-data": "off", // 2 errors
     "sonarjs/no-nested-template-literals": "off", // 1 error
-    "unicorn/better-regex": "off", // 1 warning
     "unicorn/explicit-length-check": "off", // 1 warning
     "unicorn/import-style": "off", // 5 warnings
-    "unicorn/prefer-node-protocol": "off", // 14 warnings
     "unicorn/prefer-top-level-await": "off" // 1 warning
   }
 }

--- a/packages/plugin-eslint/src/lib/eslint-plugin.integration.test.ts
+++ b/packages/plugin-eslint/src/lib/eslint-plugin.integration.test.ts
@@ -1,6 +1,6 @@
-import os from 'os';
-import { dirname, join } from 'path';
-import { fileURLToPath } from 'url';
+import os from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import type { SpyInstance } from 'vitest';
 import type { Audit, PluginConfig, RunnerConfig } from '@code-pushup/models';
 import { toUnixPath } from '@code-pushup/utils';

--- a/packages/plugin-eslint/src/lib/eslint-plugin.ts
+++ b/packages/plugin-eslint/src/lib/eslint-plugin.ts
@@ -1,6 +1,6 @@
-import { mkdir, writeFile } from 'fs/promises';
-import { dirname, join } from 'path';
-import { fileURLToPath } from 'url';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { PluginConfig } from '@code-pushup/models';
 import { name, version } from '../../package.json';
 import { ESLintPluginConfig, eslintPluginConfigSchema } from './config';

--- a/packages/plugin-eslint/src/lib/meta/hash.ts
+++ b/packages/plugin-eslint/src/lib/meta/hash.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'crypto';
+import { createHash } from 'node:crypto';
 import { slugify } from '@code-pushup/utils';
 
 export function ruleIdToSlug(

--- a/packages/plugin-eslint/src/lib/meta/hash.unit.test.ts
+++ b/packages/plugin-eslint/src/lib/meta/hash.unit.test.ts
@@ -56,6 +56,6 @@ describe('jsonHash', () => {
   ])('should produce short hexadecimal hash for rule options: %j', options => {
     const hash = jsonHash(options);
     expect(hash).toHaveLength(16);
-    expect(hash).toMatch(/^[0-9a-f]+$/);
+    expect(hash).toMatch(/^[\da-f]+$/);
   });
 });

--- a/packages/plugin-eslint/src/lib/meta/rules.unit.test.ts
+++ b/packages/plugin-eslint/src/lib/meta/rules.unit.test.ts
@@ -1,6 +1,6 @@
 import { ESLint } from 'eslint';
-import { dirname, join } from 'path';
-import { fileURLToPath } from 'url';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import type { SpyInstance } from 'vitest';
 import { RuleData, listRules, parseRuleId } from './rules';
 

--- a/packages/plugin-eslint/src/lib/nx.integration.test.ts
+++ b/packages/plugin-eslint/src/lib/nx.integration.test.ts
@@ -1,6 +1,6 @@
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { setWorkspaceRoot } from 'nx/src/utils/workspace-root';
-import { dirname, join } from 'path';
-import { fileURLToPath } from 'url';
 import type { SpyInstance } from 'vitest';
 import { ESLintPluginConfig } from './config';
 import { eslintConfigFromNxProject, eslintConfigFromNxProjects } from './nx';

--- a/packages/plugin-eslint/src/lib/runner.integration.test.ts
+++ b/packages/plugin-eslint/src/lib/runner.integration.test.ts
@@ -1,9 +1,9 @@
 import { ESLint } from 'eslint';
-import { mkdir, rm, writeFile } from 'fs/promises';
-import os from 'os';
-import { dirname, join } from 'path';
-import { fileURLToPath } from 'url';
-import type { SpyInstance } from 'vitest';
+import { mkdir, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { SpyInstance, describe, expect, it } from 'vitest';
 import type { AuditOutput, Issue } from '@code-pushup/models';
 import { readJsonFile } from '@code-pushup/utils';
 import { listAuditsAndGroups } from './meta';

--- a/packages/plugin-eslint/src/lib/runner/index.ts
+++ b/packages/plugin-eslint/src/lib/runner/index.ts
@@ -1,6 +1,6 @@
-import { mkdir, writeFile } from 'fs/promises';
-import { platform } from 'os';
-import { dirname, join } from 'path';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { platform } from 'node:os';
+import { dirname, join } from 'node:path';
 import type { Audit, AuditOutput, RunnerConfig } from '@code-pushup/models';
 import { pluginWorkDir, readJsonFile, toArray } from '@code-pushup/utils';
 import { lint } from './lint';

--- a/packages/utils/.eslintrc.json
+++ b/packages/utils/.eslintrc.json
@@ -14,32 +14,29 @@
     "@typescript-eslint/naming-convention": "off", // 8 warnings
     "@typescript-eslint/no-floating-promises": "off", // 2 errors
     "@typescript-eslint/no-shadow": "off", // 8 warnings
-    "@typescript-eslint/no-unnecessary-condition": "off", // 25 warnings
+    "@typescript-eslint/no-unnecessary-condition": "off", // 18 warnings
     "@typescript-eslint/no-unnecessary-type-assertion": "off", // 1 error
     "@typescript-eslint/no-unsafe-argument": "off", // 1 error
     "@typescript-eslint/no-unsafe-assignment": "off", // 15 errors
-    "@typescript-eslint/no-unsafe-call": "off", // 8 errors
+    "@typescript-eslint/no-unsafe-call": "off", // 2 errors
     "@typescript-eslint/no-unsafe-member-access": "off", // 12 errors
     "@typescript-eslint/no-unsafe-return": "off", // 13 errors
     "@typescript-eslint/prefer-nullish-coalescing": "off", // 11 warnings
-    "@typescript-eslint/require-await": "off", // 23 warnings
     "@typescript-eslint/restrict-plus-operands": "off", // 1 error
     "@typescript-eslint/restrict-template-expressions": "off", // 2 errors
-    "functional/immutable-data": "off", // 22 errors, 4 warnings
+    "functional/immutable-data": "off", // 25 errors
     "functional/no-let": "off", // 12 warnings
     "import/no-cycle": "off", // 2 errors
     "import/no-named-as-default": "off", // 2 warnings
     "import/no-useless-path-segments": "off", // 1 warning
     "sonarjs/cognitive-complexity": "off", // 1 error
     "sonarjs/no-duplicate-string": "off", // 1 warning
-    "unicorn/better-regex": "off", // 2 warnings
     "unicorn/consistent-destructuring": "off", // 31 warnings
     "unicorn/explicit-length-check": "off", // 2 warnings
     "unicorn/import-style": "off", // 3 warnings
     "unicorn/no-negated-condition": "off", // 1 warning
     "unicorn/no-new-array": "off", // 6 warnings
     "unicorn/numeric-separators-style": "off", // 12 warnings
-    "unicorn/prefer-node-protocol": "off", // 7 warnings
     "unicorn/prefer-number-properties": "off", // 4 warnings
     "unicorn/prefer-spread": "off", // 7 warnings
     "unicorn/prefer-ternary": "off" // 1 warning

--- a/packages/utils/perf/crawl-file-system/index.ts
+++ b/packages/utils/perf/crawl-file-system/index.ts
@@ -1,5 +1,5 @@
 import * as Benchmark from 'benchmark';
-import { join } from 'path';
+import { join } from 'node:path';
 import {
   CrawlFileSystemOptions,
   crawlFileSystem,

--- a/packages/utils/src/lib/execute-process.ts
+++ b/packages/utils/src/lib/execute-process.ts
@@ -1,4 +1,4 @@
-import { spawn } from 'child_process';
+import { spawn } from 'node:child_process';
 import { calcDuration } from './report';
 
 /**

--- a/packages/utils/src/lib/execute-process.unit.test.ts
+++ b/packages/utils/src/lib/execute-process.unit.test.ts
@@ -20,10 +20,10 @@ describe('executeProcess', () => {
       args: ['-v'],
       observer: spyObserver,
     });
-    expect(spyObserver?.onStdout).toHaveBeenCalledTimes(1);
-    expect(spyObserver?.onComplete).toHaveBeenCalledTimes(1);
-    expect(spyObserver?.onError).toHaveBeenCalledTimes(0);
-    expect(processResult.stdout).toMatch(/v[0-9]{1,2}(\.[0-9]{1,2}){0,2}/);
+    expect(spyObserver.onStdout).toHaveBeenCalledTimes(1);
+    expect(spyObserver.onComplete).toHaveBeenCalledTimes(1);
+    expect(spyObserver.onError).toHaveBeenCalledTimes(0);
+    expect(processResult.stdout).toMatch(/v\d{1,2}(\.\d{1,2}){0,2}/);
   });
 
   it('should work with npx command `npx --help`', async () => {
@@ -32,9 +32,9 @@ describe('executeProcess', () => {
       args: ['--help'],
       observer: spyObserver,
     });
-    expect(spyObserver?.onStdout).toHaveBeenCalledTimes(1);
-    expect(spyObserver?.onComplete).toHaveBeenCalledTimes(1);
-    expect(spyObserver?.onError).toHaveBeenCalledTimes(0);
+    expect(spyObserver.onStdout).toHaveBeenCalledTimes(1);
+    expect(spyObserver.onComplete).toHaveBeenCalledTimes(1);
+    expect(spyObserver.onError).toHaveBeenCalledTimes(0);
     expect(processResult.stdout).toContain('npm exec');
   });
 
@@ -46,9 +46,9 @@ describe('executeProcess', () => {
 
     expect(errorSpy).toHaveBeenCalledTimes(0);
     expect(processResult.stdout).toContain('process:complete');
-    expect(spyObserver?.onStdout).toHaveBeenCalledTimes(6); // intro + 4 runs + complete
-    expect(spyObserver?.onError).toHaveBeenCalledTimes(0);
-    expect(spyObserver?.onComplete).toHaveBeenCalledTimes(1);
+    expect(spyObserver.onStdout).toHaveBeenCalledTimes(6); // intro + 4 runs + complete
+    expect(spyObserver.onError).toHaveBeenCalledTimes(0);
+    expect(spyObserver.onComplete).toHaveBeenCalledTimes(1);
   });
 
   it('should work with async script `node custom-script.js` that throws an error', async () => {
@@ -63,8 +63,8 @@ describe('executeProcess', () => {
 
     expect(errorSpy).toHaveBeenCalledTimes(1);
     expect(processResult).toBeUndefined();
-    expect(spyObserver?.onStdout).toHaveBeenCalledTimes(2); // intro + 1 run before error
-    expect(spyObserver?.onError).toHaveBeenCalledTimes(1);
-    expect(spyObserver?.onComplete).toHaveBeenCalledTimes(0);
+    expect(spyObserver.onStdout).toHaveBeenCalledTimes(2); // intro + 1 run before error
+    expect(spyObserver.onError).toHaveBeenCalledTimes(1);
+    expect(spyObserver.onComplete).toHaveBeenCalledTimes(0);
   });
 });

--- a/packages/utils/src/lib/file-system.ts
+++ b/packages/utils/src/lib/file-system.ts
@@ -1,7 +1,7 @@
 import { type Options, bundleRequire } from 'bundle-require';
 import chalk from 'chalk';
-import { mkdir, readFile, readdir, stat } from 'fs/promises';
-import { join } from 'path';
+import { mkdir, readFile, readdir, stat } from 'node:fs/promises';
+import { join } from 'node:path';
 import { formatBytes } from './formatting';
 import { logMultipleResults } from './log-results';
 

--- a/packages/utils/src/lib/file-system.unit.test.ts
+++ b/packages/utils/src/lib/file-system.unit.test.ts
@@ -1,6 +1,6 @@
-import { stat } from 'fs/promises';
 import { vol } from 'memfs';
-import { join } from 'path';
+import { stat } from 'node:fs/promises';
+import { join } from 'node:path';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { MEMFS_VOLUME } from '@code-pushup/testing-utils';
 import {
@@ -34,7 +34,7 @@ describe('logMultipleFileResults', () => {
     const persistResult = [
       {
         status: 'fulfilled',
-        value: ['out.json', 10000],
+        value: ['out.json', 10_000],
       } as PromiseFulfilledResult<FileResult>,
     ];
     const messagePrefix = 'Generated reports';

--- a/packages/utils/src/lib/formatting.ts
+++ b/packages/utils/src/lib/formatting.ts
@@ -5,7 +5,7 @@ export function slugify(text: string): string {
     .trim()
     .toLowerCase()
     .replace(/\s+|\//g, '-')
-    .replace(/[^a-z0-9-]/g, '');
+    .replace(/[^a-z\d-]/g, '');
 }
 
 export function pluralize(text: string): string {

--- a/packages/utils/src/lib/formatting.unit.test.ts
+++ b/packages/utils/src/lib/formatting.unit.test.ts
@@ -46,7 +46,7 @@ describe('formatBytes', () => {
   });
 
   it('should log file sizes correctly with correct decimal', () => {
-    expect(formatBytes(10000, 1)).toBe('9.8 kB');
+    expect(formatBytes(10_000, 1)).toBe('9.8 kB');
   });
 });
 

--- a/packages/utils/src/lib/git.integration.test.ts
+++ b/packages/utils/src/lib/git.integration.test.ts
@@ -8,7 +8,7 @@ describe('getLatestCommit', () => {
   it('should log latest commit', async () => {
     await expect(getLatestCommit()).resolves.toEqual(
       expect.objectContaining({
-        hash: expect.stringMatching(/^[0-9a-f]{40}$/),
+        hash: expect.stringMatching(/^[\da-f]{40}$/),
         message: expect.stringMatching(/.+/),
         author: expect.stringMatching(/.+/),
         date: expect.stringMatching(gitCommitDateRegex),

--- a/packages/utils/src/lib/log-results.unit.test.ts
+++ b/packages/utils/src/lib/log-results.unit.test.ts
@@ -6,7 +6,7 @@ describe('logMultipleResults', () => {
   const succeededCallbackMock = vi.fn();
   const failedCallbackMock = vi.fn();
 
-  it('should call logPromiseResults with successfull plugin result', async () => {
+  it('should call logPromiseResults with successfull plugin result', () => {
     logMultipleResults(
       [
         {
@@ -23,7 +23,7 @@ describe('logMultipleResults', () => {
     expect(failedCallbackMock).not.toHaveBeenCalled();
   });
 
-  it('should call logPromiseResults with failed plugin result', async () => {
+  it('should call logPromiseResults with failed plugin result', () => {
     logMultipleResults(
       [{ status: 'rejected', reason: 'fail' } as PromiseRejectedResult],
       'Generated reports',
@@ -35,7 +35,7 @@ describe('logMultipleResults', () => {
     expect(succeededCallbackMock).not.toHaveBeenCalled();
   });
 
-  it('should call logPromiseResults twice', async () => {
+  it('should call logPromiseResults twice', () => {
     logMultipleResults(
       [
         {
@@ -55,7 +55,7 @@ describe('logMultipleResults', () => {
 });
 
 describe('logPromiseResults', () => {
-  it('should log on success', async () => {
+  it('should log on success', () => {
     logPromiseResults(
       [
         {
@@ -76,7 +76,7 @@ describe('logPromiseResults', () => {
     expect(console.info).toHaveBeenNthCalledWith(2, ['out.json']);
   });
 
-  it('should log on fail', async () => {
+  it('should log on fail', () => {
     logPromiseResults(
       [{ status: 'rejected', reason: 'fail' } as PromiseRejectedResult],
       'Generated reports failed:',

--- a/packages/utils/src/lib/progress.integration.test.ts
+++ b/packages/utils/src/lib/progress.integration.test.ts
@@ -27,15 +27,15 @@ describe('getSingletonMultiProgressBars', () => {
 
 const taskAName = 'a';
 const bars = getSingletonProgressBars({ progressWidth: 1 });
-const tasks = bars?.['tasks'];
-const progressBuffer = bars?.['logger'].progressBuffer;
+const tasks = bars['tasks'];
+const progressBuffer = bars['logger'].progressBuffer;
 
 describe('getProgressBar', () => {
-  it('should init task', async () => {
+  it('should init task', () => {
     expect(bars.getIndex(taskAName)).toBeUndefined();
     getProgressBar(taskAName);
     expect(bars.getIndex(taskAName)).toBe(0);
-    expect(progressBuffer[0].trim()).toBe(
+    expect(progressBuffer[0]!.trim()).toBe(
       `${taskAName}: ${barStyles.idle(' ')}   0% |`,
     );
 
@@ -44,45 +44,45 @@ describe('getProgressBar', () => {
     expect(bars.getIndex(taskAName)).toBeUndefined();
   });
 
-  it('should update task message', async () => {
+  it('should update task message', () => {
     const taskA = getProgressBar(taskAName);
     expect(tasks[taskAName].message).toBe('');
 
     taskA.updateTitle('0');
     expect(tasks[taskAName].message).toBe('0');
-    expect(progressBuffer[0].trim()).toBe(
+    expect(progressBuffer[0]!.trim()).toBe(
       `${taskAName}: ${barStyles.active(' ')}   0% | 0`,
     );
     taskA.updateTitle('1');
     expect(tasks[taskAName].message).toBe('1');
-    expect(progressBuffer[0].trim()).toBe(
+    expect(progressBuffer[0]!.trim()).toBe(
       `${taskAName}: ${barStyles.active(' ')}   0% | 1`,
     );
 
     bars.removeTask(taskAName);
   });
 
-  it('should update task progress', async () => {
+  it('should update task progress', () => {
     const taskA = getProgressBar(taskAName);
     taskA.incrementInSteps(2);
     expect(tasks[taskAName].message).toBe('');
-    expect(progressBuffer[0].trim()).toBe(
+    expect(progressBuffer[0]!.trim()).toBe(
       `${taskAName}: ${barStyles.active('▌')}  50% |`,
     );
     taskA.incrementInSteps(2);
     expect(tasks[taskAName].message).toBe('');
-    expect(progressBuffer[0].trim()).toBe(
+    expect(progressBuffer[0]!.trim()).toBe(
       `${taskAName}: ${barStyles.active('█')} 100% |`,
     );
     bars.removeTask(taskAName);
   });
 
-  it('should end task when endProgress is called', async () => {
+  it('should end task when endProgress is called', () => {
     const taskA = getProgressBar(taskAName);
     expect(bars.isDone(taskAName)).toBe(false);
     taskA.endProgress();
     expect(bars.isDone(taskAName)).toBe(true);
-    expect(progressBuffer[0].trim()).toBe(
+    expect(progressBuffer[0]!.trim()).toBe(
       `${taskAName}: ${barStyles.done('█')} 100% |`,
     );
   });

--- a/packages/utils/src/lib/report.ts
+++ b/packages/utils/src/lib/report.ts
@@ -1,4 +1,4 @@
-import { join } from 'path';
+import { join } from 'node:path';
 import {
   CategoryRef,
   IssueSeverity as CliIssueSeverity,

--- a/packages/utils/src/lib/report.unit.test.ts
+++ b/packages/utils/src/lib/report.unit.test.ts
@@ -1,8 +1,8 @@
 import { vol } from 'memfs';
 import { describe, expect, it } from 'vitest';
-import { Issue, IssueSeverity, PluginReport } from '@code-pushup/models';
+import { Issue, IssueSeverity, Report } from '@code-pushup/models';
 import { reportMock } from '@code-pushup/models/testing';
-import { MEMFS_VOLUME } from '@code-pushup/testing-utils';
+import { MEMFS_VOLUME, REPORT_MOCK } from '@code-pushup/testing-utils';
 import {
   calcDuration,
   compareIssueSeverity,
@@ -102,17 +102,12 @@ describe('loadReport', () => {
   });
 
   it('should throw for an invalid JSON report', async () => {
-    const invalidReportMock = reportMock();
-    invalidReportMock.plugins = [
-      {
-        ...invalidReportMock.plugins[0],
-        slug: '-Invalud_slug',
-      } as unknown as PluginReport,
-    ];
-
     vol.fromJSON(
       {
-        [`report.json`]: JSON.stringify(invalidReportMock),
+        [`report.json`]: JSON.stringify({
+          ...REPORT_MOCK,
+          plugins: [{ ...REPORT_MOCK.plugins[0]!, slug: '-Invalid_slug' }],
+        } satisfies Report),
       },
       MEMFS_VOLUME,
     );

--- a/testing-utils/src/lib/fixtures/report.mock.ts
+++ b/testing-utils/src/lib/fixtures/report.mock.ts
@@ -1,4 +1,4 @@
-import { type Report } from '../../../../packages/models/src';
+import type { Report } from '../../../../packages/models/src';
 
 export const MINIMAL_REPORT_MOCK = {
   packageName: '@code-pushup/core',


### PR DESCRIPTION
I went through the report and removed most ESLint related issues in test files and enabled rules where possible.

There are still ESLint issues in models (I will deal with those during my test refactor), nx-plugin (not relevant atm) and a few waiting for the rule to be enabled (so that I can disable the ESLint for that line)

## Stats
Before: 189 errors, 364 warnings, 10 info
After: 183 errors, 271 warnings, 10 info
Link to report displayed in portal [here](https://quality-metrics-staging.web.app/portal/code-pushup/cli/branch/fix-eslint-in-test-files/dashboard).