### PR TITLE
chore(cli): fix most ESLint issues

### DIFF
--- a/packages/cli/.eslintrc.json
+++ b/packages/cli/.eslintrc.json
@@ -3,20 +3,6 @@
   // temporarily disable failing rules so `nx lint` passes
   // number of errors/warnings per rule recorded at Tue Nov 28 2023 15:38:17 GMT+0100 (Central European Standard Time)
   "rules": {
-    "max-lines-per-function": "off", // 1 warning
-    "@typescript-eslint/naming-convention": "off", // 7 warnings
-    "@typescript-eslint/no-floating-promises": "off", // 1 error
-    "@typescript-eslint/no-unnecessary-condition": "off", // 3 warnings
-    "@typescript-eslint/no-unsafe-argument": "off", // 1 error
-    "@typescript-eslint/no-unsafe-return": "off", // 1 error
-    "@typescript-eslint/no-unused-expressions": "off", // 1 warning
-    "@typescript-eslint/prefer-nullish-coalescing": "off", // 1 warning
-    "@typescript-eslint/require-await": "off", // 2 warnings
-    "functional/immutable-data": "off", // 2 errors
-    "functional/no-let": "off", // 1 warning
-    "import/no-cycle": "off", // 5 errors
-    "unicorn/catch-error-name": "off", // 1 warning
-    "unicorn/no-negated-condition": "off", // 1 warning
-    "unicorn/prefer-at": "off" // 1 warning
+    "@typescript-eslint/no-unnecessary-condition": "off" // 6 warnings
   }
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -3,4 +3,4 @@ import { hideBin } from 'yargs/helpers';
 import { cli } from './lib/cli';
 
 // bootstrap yargs; format arguments
-cli(hideBin(process.argv)).argv;
+await cli(hideBin(process.argv)).argv;

--- a/packages/cli/src/lib/autorun/autorun-command.ts
+++ b/packages/cli/src/lib/autorun/autorun-command.ts
@@ -6,7 +6,7 @@ import {
   collectAndPersistReports,
   upload,
 } from '@code-pushup/core';
-import { CLI_NAME } from '../cli';
+import { CLI_NAME } from '../constants';
 import { yargsOnlyPluginsOptionsDefinition } from '../implementation/only-plugins-options';
 
 type AutorunOptions = CollectOptions & UploadOptions;
@@ -34,10 +34,11 @@ export function yargsAutorunCommandObject() {
       };
 
       await collectAndPersistReports(optionsWithFormat);
-      if (!options.upload) {
-        console.warn('Upload skipped because configuration is not set.'); // @TODO log verbose
-      } else {
+
+      if (options.upload) {
         await upload(options);
+      } else {
+        console.warn('Upload skipped because configuration is not set.'); // @TODO log verbose
       }
     },
   } satisfies CommandModule;

--- a/packages/cli/src/lib/cli.ts
+++ b/packages/cli/src/lib/cli.ts
@@ -1,10 +1,8 @@
 import { commands } from './commands';
+import { CLI_NAME, CLI_SCRIPT_NAME } from './constants';
 import { middlewares } from './middlewares';
 import { options } from './options';
 import { yargsCli } from './yargs-cli';
-
-export const CLI_NAME = 'Code PushUp CLI';
-export const CLI_SCRIPT_NAME = 'code-pushup';
 
 export const cli = (args: string[]) =>
   yargsCli(args, {

--- a/packages/cli/src/lib/collect/collect-command.ts
+++ b/packages/cli/src/lib/collect/collect-command.ts
@@ -4,7 +4,7 @@ import {
   CollectAndPersistReportsOptions,
   collectAndPersistReports,
 } from '@code-pushup/core';
-import { CLI_NAME } from '../cli';
+import { CLI_NAME } from '../constants';
 import { yargsOnlyPluginsOptionsDefinition } from '../implementation/only-plugins-options';
 
 export function yargsCollectCommandObject(): CommandModule {

--- a/packages/cli/src/lib/constants.ts
+++ b/packages/cli/src/lib/constants.ts
@@ -1,0 +1,2 @@
+export const CLI_NAME = 'Code PushUp CLI';
+export const CLI_SCRIPT_NAME = 'code-pushup';

--- a/packages/cli/src/lib/implementation/config-middleware.ts
+++ b/packages/cli/src/lib/implementation/config-middleware.ts
@@ -39,16 +39,16 @@ export async function configMiddleware<
       // so we have to manually implement the order
       persist: {
         outputDir:
-          cliOptions?.persist?.outputDir ||
-          importedRc?.persist?.outputDir ||
+          cliOptions.persist?.outputDir ||
+          importedRc.persist?.outputDir ||
           PERSIST_OUTPUT_DIR,
         filename:
-          cliOptions?.persist?.filename ||
-          importedRc?.persist?.filename ||
+          cliOptions.persist?.filename ||
+          importedRc.persist?.filename ||
           PERSIST_FILENAME,
         format: coerceArray<Format>(
-          cliOptions?.persist?.format ||
-            importedRc?.persist?.format ||
+          cliOptions.persist?.format ??
+            importedRc.persist?.format ??
             PERSIST_FORMAT,
         ),
       },

--- a/packages/cli/src/lib/implementation/filter-kebab-case-keys.ts
+++ b/packages/cli/src/lib/implementation/filter-kebab-case-keys.ts
@@ -1,28 +1,19 @@
 export function filterKebabCaseKeys<T extends Record<string, unknown>>(
   obj: T,
 ): T {
-  const newObj: Record<string, unknown> = {};
-
-  Object.keys(obj).forEach(key => {
-    if (key.includes('-')) {
-      return;
-    }
-
-    if (
-      typeof obj[key] === 'string' ||
-      (typeof obj[key] === 'object' && Array.isArray(obj[key]))
-    ) {
-      newObj[key] = obj[key];
-    }
-
-    if (
-      typeof obj[key] === 'object' &&
-      !Array.isArray(obj[key]) &&
-      obj[key] != null
-    ) {
-      newObj[key] = filterKebabCaseKeys(obj[key] as Record<string, unknown>);
-    }
-  });
-
-  return newObj as T;
+  return Object.entries(obj)
+    .filter(([key]) => !key.includes('-'))
+    .reduce(
+      (acc, [key, value]) =>
+        typeof value === 'string' ||
+        (typeof value === 'object' && Array.isArray(obj[key]))
+          ? { ...acc, [key]: value }
+          : typeof value === 'object' && !Array.isArray(value) && value != null
+          ? {
+              ...acc,
+              [key]: filterKebabCaseKeys(value as Record<string, unknown>),
+            }
+          : { ...acc, [key]: value },
+      {},
+    ) as T;
 }

--- a/packages/cli/src/lib/implementation/model.ts
+++ b/packages/cli/src/lib/implementation/model.ts
@@ -3,6 +3,7 @@ import { Format } from '@code-pushup/models';
 
 export type GeneralCliOptions = { config: string } & GlobalOptions;
 
+/* eslint-disable @typescript-eslint/naming-convention */
 export type PersistConfigCliOptions = {
   'persist.outputDir': string;
   'persist.filename': string;
@@ -15,6 +16,7 @@ export type UploadConfigCliOptions = {
   'upload.apiKey': string;
   'upload.server': string;
 };
+/* eslint-enable @typescript-eslint/naming-convention */
 
 export type CoreConfigCliOptions = PersistConfigCliOptions &
   UploadConfigCliOptions;

--- a/packages/cli/src/lib/implementation/utils.ts
+++ b/packages/cli/src/lib/implementation/utils.ts
@@ -2,18 +2,19 @@ import { toArray } from '@code-pushup/utils';
 
 // log error and flush stdout so that Yargs doesn't suppress it
 // related issue: https://github.com/yargs/yargs/issues/2118
-export function logErrorBeforeThrow<
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  T extends (...args: any[]) => any,
->(fn: T): T {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function logErrorBeforeThrow<T extends (...args: any[]) => any>(
+  fn: T,
+): T {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return (async (...args: any[]) => {
     try {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-argument
       return await fn(...args);
-    } catch (err) {
-      console.error(err);
+    } catch (error) {
+      console.error(error);
       await new Promise(resolve => process.stdout.write('', resolve));
-      throw err;
+      throw error;
     }
   }) as T;
 }

--- a/packages/cli/src/lib/upload/upload-command.ts
+++ b/packages/cli/src/lib/upload/upload-command.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import { ArgumentsCamelCase, CommandModule } from 'yargs';
 import { UploadOptions, upload } from '@code-pushup/core';
-import { CLI_NAME } from '../cli';
+import { CLI_NAME } from '../constants';
 
 export function yargsUploadCommandObject() {
   const command = 'upload';

--- a/packages/cli/src/lib/yargs-cli.integration.test.ts
+++ b/packages/cli/src/lib/yargs-cli.integration.test.ts
@@ -53,7 +53,7 @@ describe('yargsCli', () => {
       ['--persist.format=md', '--persist.format=json'],
       { options },
     ).parseAsync();
-    expect(parsedArgv?.persist?.format).toEqual(['md', 'json']);
+    expect(parsedArgv.persist?.format).toEqual(['md', 'json']);
   });
 
   it('should parse global options correctly', async () => {

--- a/packages/cli/src/lib/yargs-cli.ts
+++ b/packages/cli/src/lib/yargs-cli.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines-per-function */
 import chalk from 'chalk';
 import yargs, {
   Argv,
@@ -31,10 +32,9 @@ export function yargsCli<T = unknown>(
   },
 ): Argv<T> {
   const { usageMessage, scriptName, noExitProcess } = cfg;
-  let { commands, options, middlewares } = cfg;
-  commands = Array.isArray(commands) ? commands : [];
-  middlewares = Array.isArray(middlewares) ? middlewares : [];
-  options = options || {};
+  const commands = cfg.commands ?? [];
+  const middlewares = cfg.middlewares ?? [];
+  const options = cfg.options ?? {};
   const cli = yargs(argv);
 
   // setup yargs
@@ -46,12 +46,9 @@ export function yargsCli<T = unknown>(
       'strip-dashed': true,
     } satisfies Partial<ParserConfigurationOptions>)
     .array('persist.format')
-    .coerce('config', (config: string | string[]) => {
-      if (Array.isArray(config)) {
-        return config[config.length - 1];
-      }
-      return config;
-    })
+    .coerce('config', (config: string | string[]) =>
+      Array.isArray(config) ? config.at(-1) : config,
+    )
     .options(options);
 
   // usage message
@@ -76,9 +73,7 @@ export function yargsCli<T = unknown>(
   commands.forEach(commandObj => {
     cli.command({
       ...commandObj,
-      ...(commandObj.handler && {
-        handler: logErrorBeforeThrow(commandObj.handler),
-      }),
+      handler: logErrorBeforeThrow(commandObj.handler),
       ...(typeof commandObj.builder === 'function' && {
         builder: logErrorBeforeThrow(commandObj.builder),
       }),


### PR DESCRIPTION
In this PR I focused on enabling ESLint rules, so that they can be used both for production and test code:
- I fixed most ESLint issues.
- I improved implementation or notation where applicable.
- I disabled ESLint where necessary.

Before: 
![image](https://github.com/code-pushup/cli/assets/6306671/8efd87ab-4b25-4134-ba27-1698f2d19e9b)

[After](https://quality-metrics-staging.web.app/portal/code-pushup/cli/branch/eslint-cli-fixes/dashboard):
![image](https://github.com/code-pushup/cli/assets/6306671/b5e4a4d5-9285-4eff-bd62-cb80c4eeccf6)
