### PR TITLE
chore: fix core ESLint issues, validate persist.format values in CLI

### DIFF
--- a/e2e/cli-e2e/tests/collect.e2e.test.ts
+++ b/e2e/cli-e2e/tests/collect.e2e.test.ts
@@ -65,12 +65,7 @@ describe('CLI collect', () => {
   it('should print report summary to stdout', async () => {
     const { code, stdout, stderr } = await executeProcess({
       command: 'code-pushup',
-      args: [
-        'collect',
-        '--verbose',
-        '--persist.format=stdout',
-        '--no-progress',
-      ],
+      args: ['collect', '--no-progress'],
       cwd: 'examples/react-todos-app',
     });
 

--- a/packages/cli/src/lib/yargs-cli.integration.test.ts
+++ b/packages/cli/src/lib/yargs-cli.integration.test.ts
@@ -56,6 +56,15 @@ describe('yargsCli', () => {
     expect(parsedArgv.persist?.format).toEqual(['md', 'json']);
   });
 
+  it('should throw for an invalid persist format', () => {
+    expect(() =>
+      yargsCli<CoreConfig>(['--persist.format=md', '--persist.format=stdout'], {
+        options,
+        noExitProcess: true,
+      }).parse(),
+    ).toThrow('Invalid persist.format option');
+  });
+
   it('should parse global options correctly', async () => {
     const parsedArgv = await yargsCli<GeneralCliOptions>(
       ['--verbose', '--no-progress'],

--- a/packages/core/.eslintrc.json
+++ b/packages/core/.eslintrc.json
@@ -3,37 +3,6 @@
   // temporarily disable failing rules so `nx lint` passes
   // number of errors/warnings per rule recorded at Tue Nov 28 2023 15:38:21 GMT+0100 (Central European Standard Time)
   "rules": {
-    "max-lines-per-function": "off", // 1 warning
-    "prefer-template": "off", // 3 warnings
-    "@typescript-eslint/no-confusing-void-expression": "off", // 2 warnings
-    "@typescript-eslint/no-floating-promises": "off", // 5 errors
-    "@typescript-eslint/no-shadow": "off", // 2 warnings
-    "@typescript-eslint/no-unnecessary-condition": "off", // 4 warnings
-    "@typescript-eslint/no-unsafe-return": "off", // 1 error
-    "@typescript-eslint/prefer-nullish-coalescing": "off", // 2 warnings
-    "functional/immutable-data": "off", // 1 error, 2 warnings
-    "functional/no-let": "off", // 2 warnings
-    "n/no-sync": "off", // 6 warnings
-    "unicorn/catch-error-name": "off", // 3 warnings
-    "unicorn/explicit-length-check": "off", // 2 warnings
-    "unicorn/import-style": "off", // 6 warnings
-    "unicorn/prefer-spread": "off", // 2 warnings
-    "unicorn/prefer-ternary": "off" // 1 warning
-  },
-  "overrides": [
-    {
-      "files": [
-        "*.spec.ts",
-        "*.test.ts",
-        "**/test/**/*",
-        "**/mock/**/*",
-        "**/mocks/**/*",
-        "*.cy.ts",
-        "*.stories.ts"
-      ],
-      "rules": {
-        "@typescript-eslint/naming-convention": "off" // 4 warnings
-      }
-    }
-  ]
+    "@typescript-eslint/no-unnecessary-condition": "off" // 1 warning
+  }
 }

--- a/packages/core/src/lib/collect-and-persist.ts
+++ b/packages/core/src/lib/collect-and-persist.ts
@@ -18,9 +18,11 @@ export async function collectAndPersistReports(
 
   const report = await collect(options);
 
-  const persist = normalizePersistConfig(options?.persist);
+  const persist = normalizePersistConfig(options.persist);
   const persistResults = await persistReport(report, persist);
-  exec(() => logPersistedResults(persistResults));
+  exec(() => {
+    logPersistedResults(persistResults);
+  });
 
   // validate report and throw if invalid
   report.plugins.forEach(plugin => {

--- a/packages/core/src/lib/implementation/collect.integration.test.ts
+++ b/packages/core/src/lib/implementation/collect.integration.test.ts
@@ -28,15 +28,4 @@ describe('collect', () => {
       }),
     );
   });
-
-  it('should throw when no plugins are passed', async () => {
-    await expect(
-      collect({
-        ...MINIMAL_CONFIG_MOCK,
-        plugins: [],
-        verbose: true,
-        progress: false,
-      }),
-    ).rejects.toThrow('No plugins registered');
-  });
 });

--- a/packages/core/src/lib/implementation/collect.ts
+++ b/packages/core/src/lib/implementation/collect.ts
@@ -13,14 +13,9 @@ export type CollectOptions = Pick<CoreConfig, 'plugins' | 'categories'> &
  */
 export async function collect(options: CollectOptions): Promise<Report> {
   const { plugins, categories } = options;
-  if (!plugins?.length) {
-    // @TODO move this validation into the model or better a warning for DX
-    throw new Error('No plugins registered');
-  }
   const date = new Date().toISOString();
   const start = performance.now();
   const pluginOutputs = await executePlugins(plugins, options);
-
   return {
     packageName: name,
     version,

--- a/packages/core/src/lib/implementation/execute-plugin.unit.test.ts
+++ b/packages/core/src/lib/implementation/execute-plugin.unit.test.ts
@@ -119,7 +119,7 @@ describe('executePlugins', () => {
         { progress: false },
       ),
     ).rejects.toThrow(
-      'Plugins failed: 1 errors: Audit metadata not found for slug node-version',
+      /Plugins failed: 1 errors:.*Audit metadata not found for slug node-version/,
     );
   });
 

--- a/packages/core/src/lib/implementation/json-to-gql.ts
+++ b/packages/core/src/lib/implementation/json-to-gql.ts
@@ -4,71 +4,96 @@ import {
   IssueSeverity as PortalIssueSeverity,
   SaveReportMutationVariables,
 } from '@code-pushup/portal-client';
-import { IssueSeverity as CliIssueSeverity, Report } from '@code-pushup/models';
+import {
+  AuditReport,
+  CategoryConfig,
+  IssueSeverity as CliIssueSeverity,
+  Issue,
+  PluginReport,
+  Report,
+} from '@code-pushup/models';
+import { toArray } from '@code-pushup/utils';
 
-export function jsonToGql(report: Report) {
+export function jsonReportToGql(report: Report) {
   return {
     packageName: report.packageName,
     packageVersion: report.version,
     commandStartDate: report.date,
     commandDuration: report.duration,
-    plugins: report.plugins.map(plugin => ({
-      audits: plugin.audits.map(audit => ({
-        description: audit.description,
-        details: {
-          issues:
-            audit.details?.issues.map(issue => ({
-              message: issue.message,
-              severity: transformSeverity(issue.severity),
-              sourceEndColumn: issue.source?.position?.endColumn,
-              sourceEndLine: issue.source?.position?.endLine,
-              sourceFilePath: issue.source?.file,
-              sourceStartColumn: issue.source?.position?.startColumn,
-              sourceStartLine: issue.source?.position?.startLine,
-              sourceType: IssueSourceType.SourceCode,
-            })) || [],
-        },
-        docsUrl: audit.docsUrl,
-        formattedValue: audit.displayValue,
-        score: audit.score,
-        slug: audit.slug,
-        title: audit.title,
-        value: audit.value,
-      })),
-      description: plugin.description,
-      docsUrl: plugin.docsUrl,
-      groups: plugin.groups?.map(group => ({
-        slug: group.slug,
-        title: group.title,
-        description: group.description,
-        refs: group.refs.map(ref => ({ slug: ref.slug, weight: ref.weight })),
-      })),
-      icon: plugin.icon,
-      slug: plugin.slug,
-      title: plugin.title,
-      packageName: plugin.packageName,
-      packageVersion: plugin.version,
-      runnerDuration: plugin.duration,
-      runnerStartDate: plugin.date,
-    })),
-    categories: report.categories.map(category => ({
-      slug: category.slug,
-      title: category.title,
-      description: category.description,
-      refs: category.refs.map(ref => ({
-        plugin: ref.plugin,
-        type:
-          ref.type === 'audit'
-            ? CategoryConfigRefType.Audit
-            : CategoryConfigRefType.Group,
-        weight: ref.weight,
-        slug: ref.slug,
-      })),
-    })),
+    plugins: pluginReportsToGql(report.plugins),
+    categories: categoryConfigsToGql(toArray(report.categories)),
   } satisfies Omit<
     SaveReportMutationVariables,
     'organization' | 'project' | 'commit'
   >;
+}
+
+function pluginReportsToGql(plugins: PluginReport[]) {
+  return plugins.map(plugin => ({
+    audits: auditReportsToGql(plugin.audits),
+    description: plugin.description,
+    docsUrl: plugin.docsUrl,
+    groups: plugin.groups?.map(group => ({
+      slug: group.slug,
+      title: group.title,
+      description: group.description,
+      refs: group.refs.map(ref => ({ slug: ref.slug, weight: ref.weight })),
+    })),
+    icon: plugin.icon,
+    slug: plugin.slug,
+    title: plugin.title,
+    packageName: plugin.packageName,
+    packageVersion: plugin.version,
+    runnerDuration: plugin.duration,
+    runnerStartDate: plugin.date,
+  }));
+}
+
+function auditReportsToGql(audits: AuditReport[]) {
+  return audits.map(audit => ({
+    description: audit.description,
+    details: {
+      issues: issuesToGql(audit.details?.issues),
+    },
+    docsUrl: audit.docsUrl,
+    formattedValue: audit.displayValue,
+    score: audit.score,
+    slug: audit.slug,
+    title: audit.title,
+    value: audit.value,
+  }));
+}
+
+export function issuesToGql(issues: Issue[] | undefined) {
+  return (
+    issues?.map(issue => ({
+      message: issue.message,
+      severity: transformSeverity(issue.severity),
+      sourceEndColumn: issue.source?.position?.endColumn,
+      sourceEndLine: issue.source?.position?.endLine,
+      sourceFilePath: issue.source?.file,
+      sourceStartColumn: issue.source?.position?.startColumn,
+      sourceStartLine: issue.source?.position?.startLine,
+      sourceType: IssueSourceType.SourceCode,
+    })) ?? []
+  );
+}
+
+function categoryConfigsToGql(categories: CategoryConfig[]) {
+  return categories.map(category => ({
+    slug: category.slug,
+    title: category.title,
+    description: category.description,
+    refs: category.refs.map(ref => ({
+      plugin: ref.plugin,
+      type:
+        ref.type === 'audit'
+          ? CategoryConfigRefType.Audit
+          : CategoryConfigRefType.Group,
+      weight: ref.weight,
+      slug: ref.slug,
+    })),
+  }));
 }
 
 function transformSeverity(severity: CliIssueSeverity): PortalIssueSeverity {

--- a/packages/core/src/lib/implementation/json-to-gql.unit.test.ts
+++ b/packages/core/src/lib/implementation/json-to-gql.unit.test.ts
@@ -1,0 +1,36 @@
+import { describe } from 'vitest';
+import { Issue } from '@code-pushup/models';
+import { issuesToGql } from './json-to-gql';
+
+describe('issuesToGql', () => {
+  it('transforms issue to GraphQL query', () => {
+    expect(
+      issuesToGql([
+        {
+          message: 'No let, use const instead.',
+          severity: 'error',
+
+          source: {
+            file: 'cli.ts',
+            position: { startLine: 5, startColumn: 10, endColumn: 25 },
+          },
+        },
+      ] as Issue[]),
+    ).toStrictEqual([
+      {
+        message: 'No let, use const instead.',
+        severity: 'Error',
+        sourceType: 'SourceCode',
+        sourceFilePath: 'cli.ts',
+        sourceStartLine: 5,
+        sourceStartColumn: 10,
+        sourceEndLine: undefined,
+        sourceEndColumn: 25,
+      },
+    ]);
+  });
+
+  it('returns empty array for no issues', () => {
+    expect(issuesToGql([])).toEqual([]);
+  });
+});

--- a/packages/core/src/lib/implementation/persist.ts
+++ b/packages/core/src/lib/implementation/persist.ts
@@ -1,9 +1,9 @@
-import { existsSync, mkdirSync } from 'node:fs';
-import { stat, writeFile } from 'node:fs/promises';
+import { mkdir, stat, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { PersistConfig, Report } from '@code-pushup/models';
 import {
   MultipleFileResults,
+  directoryExists,
   generateMdReport,
   generateStdoutSummary,
   getLatestCommit,
@@ -34,59 +34,64 @@ export async function persistReport(
   console.info(generateStdoutSummary(sortedScoredReport));
 
   // collect physical format outputs
-  const results: { format: string; content: string }[] = [];
+  const results = await Promise.all(
+    format.map(async reportType => {
+      switch (reportType) {
+        case 'json':
+          return {
+            format: 'json',
+            content: JSON.stringify(report, null, 2),
+          };
+        case 'md':
+          const commitData = await getLatestCommit();
+          validateCommitData(commitData);
+          return {
+            format: 'md',
+            content: generateMdReport(sortedScoredReport, commitData),
+          };
+      }
+    }),
+  );
 
-  if (format.includes('json')) {
-    results.push({
-      format: 'json',
-      content: JSON.stringify(report, null, 2),
-    });
-  }
-
-  if (format.includes('md')) {
-    const commitData = await getLatestCommit();
-    validateCommitData(commitData);
-
-    results.push({
-      format: 'md',
-      content: generateMdReport(sortedScoredReport, commitData),
-    });
-  }
-
-  if (!existsSync(outputDir)) {
+  if (!(await directoryExists(outputDir))) {
     try {
-      mkdirSync(outputDir, { recursive: true });
-    } catch (e) {
-      console.warn(e);
+      await mkdir(outputDir, { recursive: true });
+    } catch (error) {
+      console.warn(error);
       throw new PersistDirError(outputDir);
     }
   }
 
   // write relevant format outputs to file system
   return Promise.allSettled(
-    results.map(({ format, content }) => {
-      const reportPath = join(outputDir, `${filename}.${format}`);
-
-      return (
-        writeFile(reportPath, content)
-          // return reportPath instead of void
-          .then(() => stat(reportPath))
-          .then(stats => [reportPath, stats.size] as const)
-          .catch(e => {
-            console.warn(e);
-            throw new PersistError(reportPath);
-          })
-      );
-    }),
+    results.map(result =>
+      persistResult(
+        join(outputDir, `${filename}.${result.format}`),
+        result.content,
+      ),
+    ),
   );
-}
-
-export function logPersistedResults(persistResults: MultipleFileResults) {
-  logMultipleFileResults(persistResults, 'Generated reports');
 }
 
 function validateCommitData(commitData?: unknown) {
   if (!commitData) {
     console.warn('no commit data available');
   }
+}
+
+async function persistResult(reportPath: string, content: string) {
+  return (
+    writeFile(reportPath, content)
+      // return reportPath instead of void
+      .then(() => stat(reportPath))
+      .then(stats => [reportPath, stats.size] as const)
+      .catch(error => {
+        console.warn(error);
+        throw new PersistError(reportPath);
+      })
+  );
+}
+
+export function logPersistedResults(persistResults: MultipleFileResults) {
+  logMultipleFileResults(persistResults, 'Generated reports');
 }

--- a/packages/core/src/lib/implementation/runner.ts
+++ b/packages/core/src/lib/implementation/runner.ts
@@ -27,14 +27,12 @@ export async function executeRunnerConfig(
   });
 
   // read process output from file system and parse it
-  let audits = await readJsonFile<AuditOutputs>(
+  const outputs = await readJsonFile<AuditOutputs>(
     join(process.cwd(), outputFile),
   );
 
   // transform unknownAuditOutputs to auditOutputs
-  if (outputTransform) {
-    audits = await outputTransform(audits);
-  }
+  const audits = outputTransform ? await outputTransform(outputs) : outputs;
 
   // create runner result
   return {

--- a/packages/core/src/lib/implementation/runner.ts
+++ b/packages/core/src/lib/implementation/runner.ts
@@ -1,16 +1,11 @@
 import { join } from 'node:path';
-import {
-  AuditOutputs,
-  OnProgress,
-  RunnerConfig,
-  RunnerFunction,
-} from '@code-pushup/models';
+import { OnProgress, RunnerConfig, RunnerFunction } from '@code-pushup/models';
 import { calcDuration, executeProcess, readJsonFile } from '@code-pushup/utils';
 
 export type RunnerResult = {
   date: string;
   duration: number;
-  audits: AuditOutputs;
+  audits: unknown;
 };
 
 export async function executeRunnerConfig(
@@ -27,9 +22,7 @@ export async function executeRunnerConfig(
   });
 
   // read process output from file system and parse it
-  const outputs = await readJsonFile<AuditOutputs>(
-    join(process.cwd(), outputFile),
-  );
+  const outputs = await readJsonFile(join(process.cwd(), outputFile));
 
   // transform unknownAuditOutputs to auditOutputs
   const audits = outputTransform ? await outputTransform(outputs) : outputs;

--- a/packages/core/src/lib/implementation/runner.unit.test.ts
+++ b/packages/core/src/lib/implementation/runner.unit.test.ts
@@ -36,7 +36,7 @@ describe('executeRunnerConfig', () => {
     const runnerResult = await executeRunnerConfig(MINIMAL_RUNNER_CONFIG_MOCK);
 
     // data sanity
-    expect(runnerResult.audits[0]?.slug).toBe('node-version');
+    expect((runnerResult.audits as AuditOutputs)[0]?.slug).toBe('node-version');
     expect(runnerResult.date).toMatch(ISO_STRING_REGEXP);
     expect(runnerResult.duration).toBeGreaterThanOrEqual(0);
 
@@ -59,9 +59,10 @@ describe('executeRunnerConfig', () => {
           },
         ]),
     });
+    const auditOutputs = runnerResult.audits as AuditOutputs;
 
-    expect(runnerResult.audits[0]?.slug).toBe('node-version');
-    expect(runnerResult.audits[0]?.displayValue).toBe('16.0.0');
+    expect(auditOutputs[0]?.slug).toBe('node-version');
+    expect(auditOutputs[0]?.displayValue).toBe('16.0.0');
   });
 
   it('should throw if outputTransform throws', async () => {
@@ -82,9 +83,10 @@ describe('executeRunnerFunction', () => {
     const runnerResult: RunnerResult = await executeRunnerFunction(
       MINIMAL_RUNNER_FUNCTION_MOCK,
     );
+    const auditOutputs = runnerResult.audits as AuditOutputs;
 
-    expect(runnerResult.audits[0]?.slug).toBe('node-version');
-    expect(runnerResult.audits[0]?.details?.issues).toEqual([
+    expect(auditOutputs[0]?.slug).toBe('node-version');
+    expect(auditOutputs[0]?.details?.issues).toEqual([
       expect.objectContaining({
         message: 'The required Node version to run Code PushUp CLI is 18.',
       }),

--- a/packages/core/src/lib/upload.ts
+++ b/packages/core/src/lib/upload.ts
@@ -1,7 +1,7 @@
 import { uploadToPortal } from '@code-pushup/portal-client';
 import { PersistConfig, Report, UploadConfig } from '@code-pushup/models';
 import { getLatestCommit, loadReport } from '@code-pushup/utils';
-import { jsonToGql } from './implementation/json-to-gql';
+import { jsonReportToGql } from './implementation/json-to-gql';
 import { normalizePersistConfig } from './normalize';
 import { GlobalOptions } from './types';
 
@@ -17,8 +17,8 @@ export async function upload(
   options: UploadOptions,
   uploadFn: typeof uploadToPortal = uploadToPortal,
 ) {
-  const persist = normalizePersistConfig(options?.persist);
-  if (!options?.upload) {
+  const persist = normalizePersistConfig(options.persist);
+  if (!options.upload) {
     throw new Error('upload config must be set');
   }
   const { apiKey, server, organization, project } = options.upload;
@@ -35,7 +35,7 @@ export async function upload(
     organization,
     project,
     commit: commitData.hash,
-    ...jsonToGql(report),
+    ...jsonReportToGql(report),
   };
 
   return uploadFn({ apiKey, server, data });

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -10,6 +10,7 @@ export {
   FileResult,
   MultipleFileResults,
   crawlFileSystem,
+  directoryExists,
   ensureDirectoryExists,
   fileExists,
   findLineNumberInText,

--- a/packages/utils/src/lib/file-system.ts
+++ b/packages/utils/src/lib/file-system.ts
@@ -24,6 +24,15 @@ export async function fileExists(path: string): Promise<boolean> {
   }
 }
 
+export async function directoryExists(path: string): Promise<boolean> {
+  try {
+    const stats = await stat(path);
+    return stats.isDirectory();
+  } catch {
+    return false;
+  }
+}
+
 export async function ensureDirectoryExists(baseDir: string) {
   try {
     await mkdir(baseDir, { recursive: true });

--- a/testing-utils/src/lib/utils/minimal-config.mock.ts
+++ b/testing-utils/src/lib/utils/minimal-config.mock.ts
@@ -1,5 +1,6 @@
 import type {
   AuditOutput,
+  CoreConfig,
   PluginConfig,
   RunnerConfig,
   RunnerFunction,
@@ -45,7 +46,7 @@ export const MINIMAL_PLUGIN_CONFIG_MOCK: PluginConfig = {
   runner: MINIMAL_RUNNER_FUNCTION_MOCK,
 };
 
-export const MINIMAL_CONFIG_MOCK = {
+export const MINIMAL_CONFIG_MOCK: CoreConfig = {
   upload: {
     organization: 'code-pushup',
     project: 'cli',

--- a/testing-utils/src/lib/utils/report.mock.ts
+++ b/testing-utils/src/lib/utils/report.mock.ts
@@ -1,6 +1,6 @@
 import type { Report } from '@code-pushup/models';
 
-export const MINIMAL_REPORT_MOCK = {
+export const MINIMAL_REPORT_MOCK: Report = {
   packageName: '@code-pushup/core',
   version: '0.0.1',
   date: '2023-08-16T09:00:00.000Z',
@@ -36,9 +36,9 @@ export const MINIMAL_REPORT_MOCK = {
       duration: 420,
     },
   ],
-} satisfies Report;
+};
 
-export const REPORT_MOCK = {
+export const REPORT_MOCK: Report = {
   packageName: '@code-pushup/core',
   version: '1.0.0',
   date: '2023-08-16T09:00:00.000Z',
@@ -241,4 +241,4 @@ export const REPORT_MOCK = {
       ],
     },
   ],
-} satisfies Report;
+};


### PR DESCRIPTION
In this PR, I attempted to resolve ESLint issues in the `core` package. Currently, only one rule is turned off due to type inconsistencies encountered both in `cli` and `core` that is raised in a separate issue #411.

Notable changes:
- Since `exists` is deprecated, I had to use `stat` with an additional directory check and extracted the function to `utils`.
- Aside from ESLint issues, I added validation for `persist.format` during `yargs` parsing in order to prevent invalid values being passed as an incorrect type throughout the CLI flow.

Before:
![image](https://github.com/code-pushup/cli/assets/6306671/bc47906c-17f3-4131-ac78-98ba91dba8a7)

[After](https://quality-metrics-staging.web.app/portal/code-pushup/cli/branch/eslint-core-fixes/dashboard):
![image](https://github.com/code-pushup/cli/assets/6306671/825fdde3-f179-4993-8e14-14d9119ef9e5)
