### PR TITLE
chore(utils): fix ESLint issues, loosen perf ESLint rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -97,6 +97,13 @@
       "files": "*.json",
       "parser": "jsonc-eslint-parser",
       "rules": {}
+    },
+    {
+      "files": ["perf/**/*.ts"],
+      "rules": {
+        "no-magic-numbers": "off",
+        "sonarjs/no-duplicate-string": "off"
+      }
     }
   ]
 }

--- a/packages/utils/.eslintrc.json
+++ b/packages/utils/.eslintrc.json
@@ -3,15 +3,9 @@
   // temporarily disable failing rules so `nx lint` passes
   // number of errors/warnings per rule recorded at Tue Nov 28 2023 15:38:36 GMT+0100 (Central European Standard Time)
   "rules": {
-    "arrow-body-style": "off", // 1 warning
-    "curly": "off", // 1 warning
     "max-lines-per-function": "off", // 6 warnings
-    "no-magic-numbers": "off", // 21 warnings
     "no-param-reassign": "off", // 25 errors
-    "prefer-template": "off", // 12 warnings
     "@typescript-eslint/consistent-type-assertions": "off", // 3 errors
-    "@typescript-eslint/consistent-type-definitions": "off", // 1 warning
-    "@typescript-eslint/naming-convention": "off", // 8 warnings
     "@typescript-eslint/no-floating-promises": "off", // 2 errors
     "@typescript-eslint/no-shadow": "off", // 8 warnings
     "@typescript-eslint/no-unnecessary-condition": "off", // 18 warnings
@@ -21,24 +15,9 @@
     "@typescript-eslint/no-unsafe-call": "off", // 2 errors
     "@typescript-eslint/no-unsafe-member-access": "off", // 12 errors
     "@typescript-eslint/no-unsafe-return": "off", // 13 errors
-    "@typescript-eslint/prefer-nullish-coalescing": "off", // 11 warnings
     "@typescript-eslint/restrict-plus-operands": "off", // 1 error
     "@typescript-eslint/restrict-template-expressions": "off", // 2 errors
     "functional/immutable-data": "off", // 25 errors
-    "functional/no-let": "off", // 12 warnings
-    "import/no-cycle": "off", // 2 errors
-    "import/no-named-as-default": "off", // 2 warnings
-    "import/no-useless-path-segments": "off", // 1 warning
-    "sonarjs/cognitive-complexity": "off", // 1 error
-    "sonarjs/no-duplicate-string": "off", // 1 warning
-    "unicorn/consistent-destructuring": "off", // 31 warnings
-    "unicorn/explicit-length-check": "off", // 2 warnings
-    "unicorn/import-style": "off", // 3 warnings
-    "unicorn/no-negated-condition": "off", // 1 warning
-    "unicorn/no-new-array": "off", // 6 warnings
-    "unicorn/numeric-separators-style": "off", // 12 warnings
-    "unicorn/prefer-number-properties": "off", // 4 warnings
-    "unicorn/prefer-spread": "off", // 7 warnings
-    "unicorn/prefer-ternary": "off" // 1 warning
+    "import/no-named-as-default": "off" // 2 warnings
   }
 }

--- a/packages/utils/perf/crawl-file-system/index.ts
+++ b/packages/utils/perf/crawl-file-system/index.ts
@@ -43,7 +43,7 @@ const listeners = {
           2,
         )} sec`,
       );
-      console.info('Fastest is ' + suite.filter('fastest').map('name'));
+      console.info(`Fastest is ${suite.filter('fastest').map('name')}`);
     }
   },
 };

--- a/packages/utils/perf/score-report/index.ts
+++ b/packages/utils/perf/score-report/index.ts
@@ -6,27 +6,27 @@ import { scoreReportOptimized1 } from './optimized1';
 import { scoreReportOptimized2 } from './optimized2';
 import { scoreReportOptimized3 } from './optimized3';
 
-interface MinimalReportOptions {
+type MinimalReportOptions = {
   numAuditsP1?: number;
   numAuditsP2?: number;
   numGroupRefs2?: number;
-}
+};
 
-const PROCESS_ARGUMENT_NUM_AUDITS_P1 = parseInt(
+const PROCESS_ARGUMENT_NUM_AUDITS_P1 = Number.parseInt(
   process.argv
     .find(arg => arg.startsWith('--numAudits1'))
     ?.split('=')
     .pop() || '0',
   10,
 );
-const PROCESS_ARGUMENT_NUM_AUDITS_P2 = parseInt(
+const PROCESS_ARGUMENT_NUM_AUDITS_P2 = Number.parseInt(
   process.argv
     .find(arg => arg.startsWith('--numAudits2'))
     ?.split('=')
     .pop() || '0',
   10,
 );
-const PROCESS_ARGUMENT_NUM_GROUPS_P2 = parseInt(
+const PROCESS_ARGUMENT_NUM_GROUPS_P2 = Number.parseInt(
   process.argv
     .find(arg => arg.startsWith('--numGroupRefs2'))
     ?.split('=')
@@ -58,7 +58,7 @@ const listeners = {
   complete: () => {
     if (typeof suite.filter === 'function') {
       console.info(' ');
-      console.info('Fastest is ' + suite.filter('fastest').map('name'));
+      console.info(`Fastest is ${suite.filter('fastest').map('name')}`);
     }
   },
 };
@@ -67,10 +67,10 @@ const listeners = {
 
 // Add tests
 suite.add('scoreReport', scoreReport);
-suite.add('scoreReportOptimized0', _scoreReportOptimized0);
-suite.add('scoreReportOptimized1', _scoreReportOptimized1);
-suite.add('scoreReportOptimized2', _scoreReportOptimized2);
-suite.add('scoreReportOptimized3', _scoreReportOptimized3);
+suite.add('scoreReportOptimized0', scoreMinimalReportOptimized0);
+suite.add('scoreReportOptimized1', scoreMinimalReportOptimized1);
+suite.add('scoreReportOptimized2', scoreMinimalReportOptimized2);
+suite.add('scoreReportOptimized3', scoreMinimalReportOptimized3);
 
 // ==================
 
@@ -107,28 +107,28 @@ suite.run({
 
 // ==============================================================
 
-function _scoreReportOptimized0() {
+function scoreMinimalReportOptimized0() {
   scoreReportOptimized0(minimalReport());
 }
 
-function _scoreReportOptimized1() {
+function scoreMinimalReportOptimized1() {
   scoreReportOptimized1(minimalReport());
 }
 
-function _scoreReportOptimized2() {
+function scoreMinimalReportOptimized2() {
   scoreReportOptimized2(minimalReport());
 }
 
-function _scoreReportOptimized3() {
+function scoreMinimalReportOptimized3() {
   scoreReportOptimized3(minimalReport());
 }
 
 // ==============================================================
 
 function minimalReport(opt?: MinimalReportOptions): Report {
-  const numAuditsP1 = opt?.numAuditsP1 || NUM_AUDITS_P1;
-  const numAuditsP2 = opt?.numAuditsP2 || NUM_AUDITS_P2;
-  const numGroupRefs2 = opt?.numGroupRefs2 || NUM_GROUPS_P2;
+  const numAuditsP1 = opt?.numAuditsP1 ?? NUM_AUDITS_P1;
+  const numAuditsP2 = opt?.numAuditsP2 ?? NUM_AUDITS_P2;
+  const numGroupRefs2 = opt?.numGroupRefs2 ?? NUM_GROUPS_P2;
 
   return {
     date: '2022-01-01',
@@ -137,7 +137,7 @@ function minimalReport(opt?: MinimalReportOptions): Report {
       {
         slug: 'c1_',
         title: 'Category 1',
-        refs: new Array(numAuditsP1).map((_, idx) => ({
+        refs: Array.from({ length: numAuditsP1 }).map((_, idx) => ({
           type: 'audit',
           plugin: SLUG_PLUGIN_P1,
           slug: `${AUDIT_P1_PREFIX}${idx}`,
@@ -148,7 +148,7 @@ function minimalReport(opt?: MinimalReportOptions): Report {
       {
         slug: 'c2_',
         title: 'Category 2',
-        refs: new Array(numAuditsP2).map((_, idx) => ({
+        refs: Array.from({ length: numAuditsP2 }).map((_, idx) => ({
           type: 'audit',
           plugin: SLUG_PLUGIN_P2,
           slug: `${AUDIT_P2_PREFIX}${idx}`,
@@ -164,7 +164,7 @@ function minimalReport(opt?: MinimalReportOptions): Report {
         slug: SLUG_PLUGIN_P1,
         title: 'Plugin 1',
         icon: 'slug',
-        audits: new Array(numAuditsP1).fill(null).map((_, idx) => ({
+        audits: Array.from({ length: numAuditsP1 }).map((_, idx) => ({
           value: 0,
           slug: `${AUDIT_P1_PREFIX}${idx}`,
           title: 'Default Title',
@@ -178,7 +178,7 @@ function minimalReport(opt?: MinimalReportOptions): Report {
         slug: SLUG_PLUGIN_P2,
         title: 'Plugin 2',
         icon: 'slug',
-        audits: new Array(numAuditsP2).map((_, idx) => ({
+        audits: Array.from({ length: numAuditsP2 }).map((_, idx) => ({
           value: 0,
           slug: `${AUDIT_P2_PREFIX}${idx}`,
           title: 'Default Title',
@@ -188,7 +188,7 @@ function minimalReport(opt?: MinimalReportOptions): Report {
           {
             title: 'Group 1',
             slug: GROUP_P2_PREFIX + 1,
-            refs: new Array(numGroupRefs2).map((_, idx) => ({
+            refs: Array.from({ length: numGroupRefs2 }).map((_, idx) => ({
               slug: `${AUDIT_P2_PREFIX}${idx}`,
               weight: 1,
             })),

--- a/packages/utils/perf/score-report/optimized0.ts
+++ b/packages/utils/perf/score-report/optimized0.ts
@@ -22,12 +22,9 @@ function categoryRefToScore(
   groups: EnrichedScoredGroup[],
 ) {
   return (ref: CategoryRef) => {
-    let audit;
-    let group;
-
     switch (ref.type) {
       case 'audit':
-        audit = audits.find(
+        const audit = audits.find(
           a => a.slug === ref.slug && a.plugin === ref.plugin,
         );
         if (!audit) {
@@ -38,7 +35,7 @@ function categoryRefToScore(
         return audit.score;
 
       case 'group':
-        group = groups.find(
+        const group = groups.find(
           g => g.slug === ref.slug && g.plugin === ref.plugin,
         );
         if (!group) {
@@ -67,17 +64,17 @@ export function calculateScore<T extends { weight: number }>(
 
 export function scoreReportOptimized0(report: Report): ScoredReport {
   const scoredPlugins = report.plugins.map(plugin => {
-    const { groups, audits } = plugin;
+    const { groups, audits, slug } = plugin;
     const preparedAudits = audits.map(audit => ({
       ...audit,
-      plugin: plugin.slug,
+      plugin: slug,
     }));
     const preparedGroups =
       groups?.map(group => ({
         ...group,
         score: calculateScore(group.refs, groupRefToScore(preparedAudits)),
-        plugin: plugin.slug,
-      })) || [];
+        plugin: slug,
+      })) ?? [];
 
     return {
       ...plugin,

--- a/packages/utils/perf/score-report/optimized1.ts
+++ b/packages/utils/perf/score-report/optimized1.ts
@@ -17,29 +17,29 @@ export function scoreReportOptimized1(report: Report): ScoredReport {
   const allScoredAuditsAndGroupsMap = new Map();
 
   report.plugins.forEach(plugin => {
-    const { groups, audits } = plugin;
+    const { groups, audits, slug } = plugin;
     audits.forEach(audit =>
-      allScoredAuditsAndGroupsMap.set(`${plugin.slug}-${audit.slug}-audit`, {
+      allScoredAuditsAndGroupsMap.set(`${slug}-${audit.slug}-audit`, {
         ...audit,
-        plugin: plugin.slug,
+        plugin: slug,
       }),
     );
 
     groups?.forEach(group => {
-      allScoredAuditsAndGroupsMap.set(`${plugin.slug}-${group.slug}-group`, {
+      allScoredAuditsAndGroupsMap.set(`${slug}-${group.slug}-group`, {
         ...group,
         score: calculateScore(group.refs, ref => {
           const score = allScoredAuditsAndGroupsMap.get(
-            `${plugin.slug}-${ref.slug}-audit`,
+            `${slug}-${ref.slug}-audit`,
           )?.score;
           if (score == null) {
             throw new Error(
-              `Group has invalid ref - audit with slug ${plugin.slug}-${ref.slug}-audit not found`,
+              `Group has invalid ref - audit with slug ${slug}-${ref.slug}-audit not found`,
             );
           }
           return score;
         }),
-        plugin: plugin.slug,
+        plugin: slug,
       });
     });
   });
@@ -67,7 +67,7 @@ export function scoreReportOptimized1(report: Report): ScoredReport {
 
   return {
     ...report,
-    categories: Array.from(scoredCategoriesMap.values()),
-    plugins: Array.from(allScoredAuditsAndGroupsMap.values()),
+    categories: [...scoredCategoriesMap.values()],
+    plugins: [...allScoredAuditsAndGroupsMap.values()],
   };
 }

--- a/packages/utils/perf/score-report/optimized2.ts
+++ b/packages/utils/perf/score-report/optimized2.ts
@@ -17,30 +17,30 @@ export function scoreReportOptimized2(report: Report): ScoredReport {
   const allScoredAuditsAndGroupsMap = new Map();
 
   report.plugins.forEach(plugin => {
-    const { groups, audits } = plugin;
+    const { groups, audits, slug } = plugin;
     audits.forEach(audit =>
-      allScoredAuditsAndGroupsMap.set(`${plugin.slug}-${audit.slug}-audit`, {
+      allScoredAuditsAndGroupsMap.set(`${slug}-${audit.slug}-audit`, {
         ...audit,
-        plugin: plugin.slug,
+        plugin: slug,
       }),
     );
 
     function groupScoreFn(ref: GroupRef) {
       const score = allScoredAuditsAndGroupsMap.get(
-        `${plugin.slug}-${ref.slug}-audit`,
+        `${slug}-${ref.slug}-audit`,
       )?.score;
       if (score == null) {
         throw new Error(
-          `Group has invalid ref - audit with slug ${plugin.slug}-${ref.slug}-audit not found`,
+          `Group has invalid ref - audit with slug ${slug}-${ref.slug}-audit not found`,
         );
       }
       return score;
     }
     groups?.forEach(group => {
-      allScoredAuditsAndGroupsMap.set(`${plugin.slug}-${group.slug}-group`, {
+      allScoredAuditsAndGroupsMap.set(`${slug}-${group.slug}-group`, {
         ...group,
         score: calculateScore(group.refs, groupScoreFn),
-        plugin: plugin.slug,
+        plugin: slug,
       });
     });
   });
@@ -69,7 +69,7 @@ export function scoreReportOptimized2(report: Report): ScoredReport {
 
   return {
     ...report,
-    categories: Array.from(scoredCategoriesMap.values()),
-    plugins: Array.from(allScoredAuditsAndGroupsMap.values()),
+    categories: [...scoredCategoriesMap.values()],
+    plugins: [...allScoredAuditsAndGroupsMap.values()],
   };
 }

--- a/packages/utils/perf/score-report/optimized3.ts
+++ b/packages/utils/perf/score-report/optimized3.ts
@@ -38,31 +38,31 @@ export function scoreReportOptimized3(report: Report): ScoredReport {
   const allScoredAuditsAndGroups = new Map();
 
   scoredReport.plugins?.forEach(plugin => {
-    const { audits } = plugin;
+    const { audits, slug } = plugin;
     const groups = plugin.groups || [];
 
     audits.forEach(audit => {
-      const key = `${plugin.slug}-${audit.slug}-audit`;
-      audit.plugin = plugin.slug;
+      const key = `${slug}-${audit.slug}-audit`;
+      audit.plugin = slug;
       allScoredAuditsAndGroups.set(key, audit);
     });
 
     function groupScoreFn(ref: GroupRef) {
       const score = allScoredAuditsAndGroups.get(
-        `${plugin.slug}-${ref.slug}-audit`,
+        `${slug}-${ref.slug}-audit`,
       )?.score;
       if (score == null) {
         throw new Error(
-          `Group has invalid ref - audit with slug ${plugin.slug}-${ref.slug}-audit not found`,
+          `Group has invalid ref - audit with slug ${slug}-${ref.slug}-audit not found`,
         );
       }
       return score;
     }
 
     groups.forEach(group => {
-      const key = `${plugin.slug}-${group.slug}-group`;
+      const key = `${slug}-${group.slug}-group`;
       group.score = calculateScore(group.refs, groupScoreFn);
-      group.plugin = plugin.slug;
+      group.plugin = slug;
       allScoredAuditsAndGroups.set(key, group);
     });
     plugin.groups = groups;
@@ -86,7 +86,7 @@ export function scoreReportOptimized3(report: Report): ScoredReport {
     scoredCategoriesMap.set(category.slug, category);
   }
 
-  scoredReport.categories = Array.from(scoredCategoriesMap.values());
+  scoredReport.categories = [...scoredCategoriesMap.values()];
 
   return scoredReport;
 }

--- a/packages/utils/src/lib/execute-process.ts
+++ b/packages/utils/src/lib/execute-process.ts
@@ -132,15 +132,17 @@ export type ProcessObserver = {
  * @param cfg - see {@link ProcessConfig}
  */
 export function executeProcess(cfg: ProcessConfig): Promise<ProcessResult> {
-  const { observer, cwd } = cfg;
-  const { onStdout, onError, onComplete } = observer || {};
+  const { observer, cwd, command, args } = cfg;
+  const { onStdout, onError, onComplete } = observer ?? {};
   const date = new Date().toISOString();
   const start = performance.now();
 
   return new Promise((resolve, reject) => {
     // shell:true tells Windows to use shell command for spawning a child process
-    const process = spawn(cfg.command, cfg.args, { cwd, shell: true });
+    const process = spawn(command, args, { cwd, shell: true });
+    // eslint-disable-next-line functional/no-let
     let stdout = '';
+    // eslint-disable-next-line functional/no-let
     let stderr = '';
 
     process.stdout.on('data', data => {

--- a/packages/utils/src/lib/file-system.ts
+++ b/packages/utils/src/lib/file-system.ts
@@ -54,10 +54,8 @@ export function logMultipleFileResults(
 ): void {
   const succeededCallback = (result: PromiseFulfilledResult<FileResult>) => {
     const [fileName, size] = result.value;
-    console.info(
-      `- ${chalk.bold(fileName)}` +
-        (size ? ` (${chalk.gray(formatBytes(size))})` : ''),
-    );
+    const formattedSize = size ? ` (${chalk.gray(formatBytes(size))})` : '';
+    console.info(`- ${chalk.bold(fileName)}${formattedSize}`);
   };
   const failedCallback = (result: PromiseRejectedResult) => {
     console.warn(`- ${chalk.bold(result.reason)}`);

--- a/packages/utils/src/lib/formatting.ts
+++ b/packages/utils/src/lib/formatting.ts
@@ -14,7 +14,7 @@ export function slugify(text: string): string {
 
 export function pluralize(text: string): string {
   if (text.endsWith('y')) {
-    return text.slice(0, -1) + 'ies';
+    return `${text.slice(0, -1)}ies`;
   }
   if (text.endsWith('s')) {
     return `${text}es`;
@@ -25,7 +25,9 @@ export function pluralize(text: string): string {
 export function formatBytes(bytes: number, decimals = 2) {
   bytes = Math.max(bytes, 0);
   // early exit
-  if (!bytes) return '0 B';
+  if (!bytes) {
+    return '0 B';
+  }
 
   const k = 1024;
   const dm = decimals < 0 ? 0 : decimals;
@@ -33,7 +35,9 @@ export function formatBytes(bytes: number, decimals = 2) {
 
   const i = Math.floor(Math.log(bytes) / Math.log(k));
 
-  return `${parseFloat((bytes / Math.pow(k, i)).toFixed(dm))} ${sizes[i]}`;
+  return `${Number.parseFloat((bytes / Math.pow(k, i)).toFixed(dm))} ${
+    sizes[i]
+  }`;
 }
 
 export function pluralizeToken(token: string, times: number = 0): string {

--- a/packages/utils/src/lib/log-results.ts
+++ b/packages/utils/src/lib/log-results.ts
@@ -30,7 +30,7 @@ export function logMultipleResults<T>(
 export function logPromiseResults<
   T extends PromiseFulfilledResult<unknown> | PromiseRejectedResult,
 >(results: T[], logMessage: string, callback: (result: T) => void): void {
-  if (results.length) {
+  if (results.length > 0) {
     if (results[0]?.status === 'fulfilled') {
       console.info(logMessage);
     } else {

--- a/packages/utils/src/lib/progress.ts
+++ b/packages/utils/src/lib/progress.ts
@@ -22,6 +22,7 @@ export type ProgressBar = {
   endProgress: (message?: string) => void;
 };
 
+// eslint-disable-next-line functional/no-let
 let mpb: MultiProgressBars;
 
 export function getSingletonProgressBars(

--- a/packages/utils/src/lib/reports/__snapshots__/sorting.integration.test.ts.snap
+++ b/packages/utils/src/lib/reports/__snapshots__/sorting.integration.test.ts.snap
@@ -84,9 +84,6 @@ exports[`sortReport > should sort the audits and audit groups in categories, plu
           "value": 3,
         },
         {
-          "details": {
-            "issues": [],
-          },
           "plugin": "cypress",
           "score": 1,
           "slug": "cypress-component-tests",
@@ -174,9 +171,6 @@ exports[`sortReport > should sort the audits and audit groups in categories, plu
           "value": 1,
         },
         {
-          "details": {
-            "issues": [],
-          },
           "plugin": "eslint",
           "score": 1,
           "slug": "eslint-jest-consistent-naming",
@@ -184,9 +178,6 @@ exports[`sortReport > should sort the audits and audit groups in categories, plu
           "value": 0,
         },
         {
-          "details": {
-            "issues": [],
-          },
           "plugin": "eslint",
           "score": 1,
           "slug": "eslint-cypress",
@@ -194,9 +185,6 @@ exports[`sortReport > should sort the audits and audit groups in categories, plu
           "value": 0,
         },
         {
-          "details": {
-            "issues": [],
-          },
           "plugin": "eslint",
           "score": 1,
           "slug": "typescript-eslint-enums",

--- a/packages/utils/src/lib/reports/constants.ts
+++ b/packages/utils/src/lib/reports/constants.ts
@@ -1,6 +1,9 @@
+export const TERMINAL_WIDTH = 80;
 export const NEW_LINE = '\n';
 
+/* eslint-disable no-magic-numbers */
 export const SCORE_COLOR_RANGE = {
   GREEN_MIN: 0.9,
   YELLOW_MIN: 0.5,
 };
+/* eslint-enable no-magic-numbers */

--- a/packages/utils/src/lib/reports/generate-md-report.ts
+++ b/packages/utils/src/lib/reports/generate-md-report.ts
@@ -40,24 +40,30 @@ export function generateMdReport(
   report: ScoredReport,
   commitData: CommitData | null,
 ): string {
-  // header section
-  let md = reportToHeaderSection() + NEW_LINE;
-
-  // overview section
-  md += reportToOverviewSection(report) + NEW_LINE + NEW_LINE;
-
-  // categories section
-  md += reportToCategoriesSection(report) + NEW_LINE + NEW_LINE;
-
-  // audits section
-  md += reportToAuditsSection(report) + NEW_LINE + NEW_LINE;
-
-  // about section
-  md += reportToAboutSection(report, commitData) + NEW_LINE + NEW_LINE;
-
-  // footer section
-  md += `${FOOTER_PREFIX} ${link(README_LINK, 'Code PushUp')}`;
-  return md;
+  return (
+    // header section
+    // eslint-disable-next-line prefer-template
+    reportToHeaderSection() +
+    NEW_LINE +
+    // overview section
+    reportToOverviewSection(report) +
+    NEW_LINE +
+    NEW_LINE +
+    // categories section
+    reportToCategoriesSection(report) +
+    NEW_LINE +
+    NEW_LINE +
+    // audits section
+    reportToAuditsSection(report) +
+    NEW_LINE +
+    NEW_LINE +
+    // about section
+    reportToAboutSection(report, commitData) +
+    NEW_LINE +
+    NEW_LINE +
+    // footer section
+    `${FOOTER_PREFIX} ${link(README_LINK, 'Code PushUp')}`
+  );
 }
 
 function reportToHeaderSection(): string {
@@ -65,13 +71,13 @@ function reportToHeaderSection(): string {
 }
 
 function reportToOverviewSection(report: ScoredReport): string {
-  const { categories } = report;
+  const { categories, plugins } = report;
   const tableContent: string[][] = [
     reportOverviewTableHeaders,
     ...categories.map(({ title, refs, score }) => [
       link(`#${slugify(title)}`, title),
       `${getRoundScoreMarker(score)} ${style(formatReportScore(score))}`,
-      countCategoryAudits(refs, report.plugins).toString(),
+      countCategoryAudits(refs, plugins).toString(),
     ]),
   ];
 
@@ -255,6 +261,7 @@ function reportToAboutSection(
   ];
 
   return (
+    // eslint-disable-next-line prefer-template
     h2('About') +
     NEW_LINE +
     NEW_LINE +

--- a/packages/utils/src/lib/reports/md/headline.ts
+++ b/packages/utils/src/lib/reports/md/headline.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-magic-numbers */
 export type Hierarchy = 1 | 2 | 3 | 4 | 5 | 6;
 
 /**
@@ -6,7 +7,7 @@ export type Hierarchy = 1 | 2 | 3 | 4 | 5 | 6;
  * \## {text} // hierarchy set to 2
  */
 export function headline(text: string, hierarchy: Hierarchy = 1): string {
-  return `${new Array(hierarchy).fill('#').join('')} ${text}`;
+  return `${'#'.repeat(hierarchy)} ${text}`;
 }
 
 export function h(text: string, hierarchy: Hierarchy = 1): string {

--- a/packages/utils/src/lib/reports/md/table.ts
+++ b/packages/utils/src/lib/reports/md/table.ts
@@ -21,10 +21,16 @@ export function tableMd(
   if (data.length === 0) {
     throw new Error("Data can't be empty");
   }
-  align = align || data[0]?.map(() => 'c');
-  const _data = data.map(arr => '|' + arr.join('|') + '|');
-  const secondRow = '|' + align?.map(s => alignString.get(s)).join('|') + '|';
-  return _data.shift() + NEW_LINE + secondRow + NEW_LINE + _data.join(NEW_LINE);
+  align ??= data[0]?.map(() => 'c');
+  const tableContent = data.map(arr => `|${arr.join('|')}|`);
+  const secondRow = `|${align?.map(s => alignString.get(s)).join('|')}|`;
+  return (
+    tableContent.shift() +
+    NEW_LINE +
+    secondRow +
+    NEW_LINE +
+    tableContent.join(NEW_LINE)
+  );
 }
 
 export function tableHtml(data: (string | number)[][]): string {
@@ -32,11 +38,13 @@ export function tableHtml(data: (string | number)[][]): string {
     throw new Error("Data can't be empty");
   }
 
-  const _data = data.map((arr, index) => {
+  const tableContent = data.map((arr, index) => {
     if (index === 0) {
-      return '<tr>' + arr.map(s => `<th>${s}</th>`).join('') + '</tr>';
+      const headerRow = arr.map(s => `<th>${s}</th>`).join('');
+      return `<tr>${headerRow}</tr>`;
     }
-    return '<tr>' + arr.map(s => `<td>${s}</td>`).join('') + '</tr>';
+    const row = arr.map(s => `<td>${s}</td>`).join('');
+    return `<tr>${row}</tr>`;
   });
-  return '<table>' + _data.join('') + '</table>';
+  return `<table>${tableContent.join('')}</table>`;
 }

--- a/packages/utils/src/lib/reports/scoring.ts
+++ b/packages/utils/src/lib/reports/scoring.ts
@@ -61,31 +61,31 @@ export function scoreReport(report: Report): ScoredReport {
   const allScoredAuditsAndGroups = new Map();
 
   scoredReport.plugins?.forEach(plugin => {
-    const { audits } = plugin;
+    const { slug, audits } = plugin;
     const groups = plugin.groups || [];
 
     audits.forEach(audit => {
-      const key = `${plugin.slug}-${audit.slug}-audit`;
-      audit.plugin = plugin.slug;
+      const key = `${slug}-${audit.slug}-audit`;
+      audit.plugin = slug;
       allScoredAuditsAndGroups.set(key, audit);
     });
 
     function groupScoreFn(ref: GroupRef) {
       const score = allScoredAuditsAndGroups.get(
-        `${plugin.slug}-${ref.slug}-audit`,
+        `${slug}-${ref.slug}-audit`,
       )?.score;
       if (score == null) {
         throw new Error(
-          `Group has invalid ref - audit with slug ${plugin.slug}-${ref.slug}-audit not found`,
+          `Group has invalid ref - audit with slug ${slug}-${ref.slug}-audit not found`,
         );
       }
       return score;
     }
 
     groups.forEach(group => {
-      const key = `${plugin.slug}-${group.slug}-group`;
+      const key = `${slug}-${group.slug}-group`;
       group.score = calculateScore(group.refs, groupScoreFn);
-      group.plugin = plugin.slug;
+      group.plugin = slug;
       allScoredAuditsAndGroups.set(key, group);
     });
     plugin.groups = groups;
@@ -109,7 +109,7 @@ export function scoreReport(report: Report): ScoredReport {
     scoredCategoriesMap.set(category.slug, category);
   }
 
-  scoredReport.categories = Array.from(scoredCategoriesMap.values());
+  scoredReport.categories = [...scoredCategoriesMap.values()];
 
   return scoredReport;
 }

--- a/packages/utils/src/lib/reports/sorting.ts
+++ b/packages/utils/src/lib/reports/sorting.ts
@@ -41,7 +41,7 @@ export function sortReport(report: ScoredReport): ScoredReport {
       ...groups,
       ...audits.sort(compareCategoryAudits),
     ];
-    const sortedRefs = category.refs.slice().sort((a, b) => {
+    const sortedRefs = [...category.refs].sort((a, b) => {
       const aIndex = sortedAuditsAndGroups.findIndex(
         ref => ref.slug === a.slug,
       );
@@ -60,7 +60,7 @@ export function sortReport(report: ScoredReport): ScoredReport {
       ...audit,
       details: {
         ...audit.details,
-        issues: audit?.details?.issues.slice().sort(compareIssues) || [],
+        issues: [...(audit?.details?.issues ?? [])].sort(compareIssues),
       },
     })),
   }));

--- a/packages/utils/src/lib/reports/sorting.ts
+++ b/packages/utils/src/lib/reports/sorting.ts
@@ -56,13 +56,17 @@ export function sortReport(report: ScoredReport): ScoredReport {
 
   const sortedPlugins = plugins.map(plugin => ({
     ...plugin,
-    audits: plugin.audits.sort(compareAudits).map(audit => ({
-      ...audit,
-      details: {
-        ...audit.details,
-        issues: [...(audit?.details?.issues ?? [])].sort(compareIssues),
-      },
-    })),
+    audits: [...plugin.audits].sort(compareAudits).map(audit =>
+      audit.details?.issues
+        ? {
+            ...audit,
+            details: {
+              ...audit.details,
+              issues: [...audit.details.issues].sort(compareIssues),
+            },
+          }
+        : audit,
+    ),
   }));
 
   return {

--- a/packages/utils/src/lib/reports/utils.ts
+++ b/packages/utils/src/lib/reports/utils.ts
@@ -95,7 +95,7 @@ export function getSeverityIcon(
 }
 
 export function calcDuration(start: number, stop?: number): number {
-  stop = stop !== undefined ? stop : performance.now();
+  stop ??= performance.now();
   return Math.floor(stop - start);
 }
 
@@ -112,23 +112,15 @@ export function countCategoryAudits(
   // Create lookup object for groups within each plugin
   const groupLookup = plugins.reduce<Record<string, Record<string, Group>>>(
     (lookup, plugin) => {
-      if (!plugin.groups.length) {
+      if (plugin.groups.length === 0) {
         return lookup;
       }
 
       return {
         ...lookup,
-        [plugin.slug]: {
-          ...plugin.groups.reduce<Record<string, Group>>(
-            (groupLookup, group) => {
-              return {
-                ...groupLookup,
-                [group.slug]: group,
-              };
-            },
-            {},
-          ),
-        },
+        [plugin.slug]: Object.fromEntries(
+          plugin.groups.map(group => [group.slug, group]),
+        ),
       };
     },
     {},
@@ -138,7 +130,7 @@ export function countCategoryAudits(
   return refs.reduce((acc, ref) => {
     if (ref.type === 'group') {
       const groupRefs = groupLookup[ref.plugin]?.[ref.slug]?.refs;
-      return acc + (groupRefs?.length || 0);
+      return acc + (groupRefs?.length ?? 0);
     }
     return acc + 1;
   }, 0);
@@ -296,7 +288,7 @@ export function compareIssues(a: Issue, b: Issue): number {
   }
 
   if (a.source?.file !== b.source?.file) {
-    return a.source?.file.localeCompare(b.source?.file || '') || 0;
+    return a.source?.file.localeCompare(b.source?.file || '') ?? 0;
   }
 
   if (!a.source?.position && b.source?.position) {
@@ -309,8 +301,8 @@ export function compareIssues(a: Issue, b: Issue): number {
 
   if (a.source?.position?.startLine !== b.source?.position?.startLine) {
     return (
-      (a.source?.position?.startLine || 0) -
-      (b.source?.position?.startLine || 0)
+      (a.source?.position?.startLine ?? 0) -
+      (b.source?.position?.startLine ?? 0)
     );
   }
 

--- a/packages/utils/src/lib/transform.ts
+++ b/packages/utils/src/lib/transform.ts
@@ -20,7 +20,7 @@ export function countOccurrences<T extends PropertyKey>(
 }
 
 export function distinct<T extends string | number | boolean>(array: T[]): T[] {
-  return Array.from(new Set(array));
+  return [...new Set(array)];
 }
 
 export function deepClone<T>(obj: T): T {
@@ -52,7 +52,8 @@ export function factorOf<T>(items: T[], filterFn: (i: T) => boolean): number {
 type ArgumentValue = number | string | boolean | string[];
 export type CliArgsObject<T extends object = Record<string, ArgumentValue>> =
   T extends never
-    ? Record<string, ArgumentValue | undefined> | { _: string }
+    ? // eslint-disable-next-line @typescript-eslint/naming-convention
+      Record<string, ArgumentValue | undefined> | { _: string }
     : T;
 
 /**
@@ -65,6 +66,7 @@ export type CliArgsObject<T extends object = Record<string, ArgumentValue>> =
  *   formats: ['json', 'md'] // --format=json --format=md
  * });
  */
+// eslint-disable-next-line sonarjs/cognitive-complexity
 export function objectToCliArgs<
   T extends object = Record<string, ArgumentValue>,
 >(params?: CliArgsObject<T>): string[] {
@@ -75,11 +77,7 @@ export function objectToCliArgs<
   return Object.entries(params).flatMap(([key, value]) => {
     // process/file/script
     if (key === '_') {
-      if (Array.isArray(value)) {
-        return value;
-      } else {
-        return [value + ''];
-      }
+      return Array.isArray(value) ? value : [`${value}`];
     }
     const prefix = key.length === 1 ? '-' : '--';
     // "-*" arguments (shorthands)
@@ -117,7 +115,7 @@ export function toUnixPath(
   const unixPath = path.replace(/\\/g, '/');
 
   if (options?.toRelative) {
-    return unixPath.replace(process.cwd().replace(/\\/g, '/') + '/', '');
+    return unixPath.replace(`${process.cwd().replace(/\\/g, '/')}/`, '');
   }
 
   return unixPath;


### PR DESCRIPTION
Closes #261 
Closes #270 

This PR is part 1 of utils ESLint issues. I mostly fixed unicorn and sonarjs issues.
I also loosened ruleset for `perf` folder as its nature is more experimental.

Before:
![image](https://github.com/code-pushup/cli/assets/6306671/261b4246-3c77-4d21-afbe-ae637200e279)

[After](https://quality-metrics-staging.web.app/portal/code-pushup/cli/branch/eslint-utils-fixes/dashboard):
![image](https://github.com/code-pushup/cli/assets/6306671/ba8c2d83-ef91-4155-91b6-26ad2964c879)
