### PR TITLE
chore(utils): fix ESLint issues, enable ESLint rules

### DIFF
--- a/packages/utils/.eslintrc.json
+++ b/packages/utils/.eslintrc.json
@@ -1,15 +1,8 @@
 {
   "extends": ["./code-pushup.eslintrc.json"],
   // temporarily disable failing rules so `nx lint` passes
-  // number of errors/warnings per rule recorded at Tue Nov 28 2023 15:38:36 GMT+0100 (Central European Standard Time)
+  // number of errors/warnings per rule recorded at Wed Jan 17 2024 15:00:00 GMT+0100 (Central European Standard Time)
   "rules": {
-    "@typescript-eslint/no-unnecessary-condition": "off", // 18 warnings
-    "@typescript-eslint/no-unsafe-argument": "off", // 1 error
-    "@typescript-eslint/no-unsafe-assignment": "off", // 15 errors
-    "@typescript-eslint/no-unsafe-call": "off", // 2 errors
-    "@typescript-eslint/no-unsafe-member-access": "off", // 12 errors
-    "@typescript-eslint/no-unsafe-return": "off", // 13 errors
-    "@typescript-eslint/restrict-plus-operands": "off", // 1 error
-    "@typescript-eslint/restrict-template-expressions": "off" // 2 errors
+    "@typescript-eslint/no-unnecessary-condition": "off" // 5 warnings
   }
 }

--- a/packages/utils/.eslintrc.json
+++ b/packages/utils/.eslintrc.json
@@ -3,21 +3,13 @@
   // temporarily disable failing rules so `nx lint` passes
   // number of errors/warnings per rule recorded at Tue Nov 28 2023 15:38:36 GMT+0100 (Central European Standard Time)
   "rules": {
-    "max-lines-per-function": "off", // 6 warnings
-    "no-param-reassign": "off", // 25 errors
-    "@typescript-eslint/consistent-type-assertions": "off", // 3 errors
-    "@typescript-eslint/no-floating-promises": "off", // 2 errors
-    "@typescript-eslint/no-shadow": "off", // 8 warnings
     "@typescript-eslint/no-unnecessary-condition": "off", // 18 warnings
-    "@typescript-eslint/no-unnecessary-type-assertion": "off", // 1 error
     "@typescript-eslint/no-unsafe-argument": "off", // 1 error
     "@typescript-eslint/no-unsafe-assignment": "off", // 15 errors
     "@typescript-eslint/no-unsafe-call": "off", // 2 errors
     "@typescript-eslint/no-unsafe-member-access": "off", // 12 errors
     "@typescript-eslint/no-unsafe-return": "off", // 13 errors
     "@typescript-eslint/restrict-plus-operands": "off", // 1 error
-    "@typescript-eslint/restrict-template-expressions": "off", // 2 errors
-    "functional/immutable-data": "off", // 25 errors
-    "import/no-named-as-default": "off" // 2 warnings
+    "@typescript-eslint/restrict-template-expressions": "off" // 2 errors
   }
 }

--- a/packages/utils/perf/crawl-file-system/index.ts
+++ b/packages/utils/perf/crawl-file-system/index.ts
@@ -6,19 +6,16 @@ import {
 } from '../../src/lib/file-system';
 import { crawlFileSystemOptimized0 } from './optimized0';
 
-// TODO pls double check me here... also, is pop that much faster that ESLint should be disabled instead?
-const PROCESS_ARGUMENT_TARGET_DIRECTORY = String(
+const PROCESS_ARGUMENT_TARGET_DIRECTORY =
   process.argv
     .find(arg => arg.startsWith('--directory'))
     ?.split('=')
-    .slice(0, -1)[0] ?? '',
-);
-const PROCESS_ARGUMENT_PATTERN = String(
+    .at(-1) ?? '';
+const PROCESS_ARGUMENT_PATTERN =
   process.argv
     .find(arg => arg.startsWith('--pattern'))
     ?.split('=')
-    .slice(0, -1)[0] ?? '',
-);
+    .at(-1) ?? '';
 
 const suite = new Benchmark.Suite('report-scoring');
 
@@ -44,7 +41,7 @@ const listeners = {
           2,
         )} sec`,
       );
-      console.info(`Fastest is ${suite.filter('fastest').map('name')}`);
+      console.info(`Fastest is ${String(suite.filter('fastest').map('name'))}`);
     }
   },
 };

--- a/packages/utils/perf/crawl-file-system/index.ts
+++ b/packages/utils/perf/crawl-file-system/index.ts
@@ -6,17 +6,18 @@ import {
 } from '../../src/lib/file-system';
 import { crawlFileSystemOptimized0 } from './optimized0';
 
+// TODO pls double check me here... also, is pop that much faster that ESLint should be disabled instead?
 const PROCESS_ARGUMENT_TARGET_DIRECTORY = String(
   process.argv
     .find(arg => arg.startsWith('--directory'))
     ?.split('=')
-    .pop() || '',
+    .slice(0, -1)[0] ?? '',
 );
 const PROCESS_ARGUMENT_PATTERN = String(
   process.argv
     .find(arg => arg.startsWith('--pattern'))
     ?.split('=')
-    .pop() || '',
+    .slice(0, -1)[0] ?? '',
 );
 
 const suite = new Benchmark.Suite('report-scoring');

--- a/packages/utils/perf/score-report/index.ts
+++ b/packages/utils/perf/score-report/index.ts
@@ -16,21 +16,21 @@ const PROCESS_ARGUMENT_NUM_AUDITS_P1 = Number.parseInt(
   process.argv
     .find(arg => arg.startsWith('--numAudits1'))
     ?.split('=')
-    .slice(0, -1)[0] ?? '0',
+    .at(-1) ?? '0',
   10,
 );
 const PROCESS_ARGUMENT_NUM_AUDITS_P2 = Number.parseInt(
   process.argv
     .find(arg => arg.startsWith('--numAudits2'))
     ?.split('=')
-    .slice(0, -1)[0] ?? '0',
+    .at(-1) ?? '0',
   10,
 );
 const PROCESS_ARGUMENT_NUM_GROUPS_P2 = Number.parseInt(
   process.argv
     .find(arg => arg.startsWith('--numGroupRefs2'))
     ?.split('=')
-    .slice(0, -1)[0] ?? '0',
+    .at(-1) ?? '0',
   10,
 );
 
@@ -58,7 +58,7 @@ const listeners = {
   complete: () => {
     if (typeof suite.filter === 'function') {
       console.info(' ');
-      console.info(`Fastest is ${suite.filter('fastest').map('name')}`);
+      console.info(`Fastest is ${String(suite.filter('fastest').map('name'))}`);
     }
   },
 };

--- a/packages/utils/perf/score-report/index.ts
+++ b/packages/utils/perf/score-report/index.ts
@@ -16,21 +16,21 @@ const PROCESS_ARGUMENT_NUM_AUDITS_P1 = Number.parseInt(
   process.argv
     .find(arg => arg.startsWith('--numAudits1'))
     ?.split('=')
-    .pop() || '0',
+    .slice(0, -1)[0] ?? '0',
   10,
 );
 const PROCESS_ARGUMENT_NUM_AUDITS_P2 = Number.parseInt(
   process.argv
     .find(arg => arg.startsWith('--numAudits2'))
     ?.split('=')
-    .pop() || '0',
+    .slice(0, -1)[0] ?? '0',
   10,
 );
 const PROCESS_ARGUMENT_NUM_GROUPS_P2 = Number.parseInt(
   process.argv
     .find(arg => arg.startsWith('--numGroupRefs2'))
     ?.split('=')
-    .pop() || '0',
+    .slice(0, -1)[0] ?? '0',
   10,
 );
 
@@ -125,6 +125,7 @@ function scoreMinimalReportOptimized3() {
 
 // ==============================================================
 
+// eslint-disable-next-line max-lines-per-function
 function minimalReport(opt?: MinimalReportOptions): Report {
   const numAuditsP1 = opt?.numAuditsP1 ?? NUM_AUDITS_P1;
   const numAuditsP2 = opt?.numAuditsP2 ?? NUM_AUDITS_P2;

--- a/packages/utils/perf/score-report/optimized0.ts
+++ b/packages/utils/perf/score-report/optimized0.ts
@@ -44,8 +44,6 @@ function categoryRefToScore(
           );
         }
         return group.score;
-      default:
-        throw new Error(`Type ${ref.type} is unknown`);
     }
   };
 }

--- a/packages/utils/perf/score-report/optimized1.ts
+++ b/packages/utils/perf/score-report/optimized1.ts
@@ -1,5 +1,8 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-assignment */
+// Note: The plugins of the ScoredReport are not structured correctly, hence the ESLint disables.
 import { Report } from '@code-pushup/models';
 import { ScoredReport } from '../../src';
+import { ScoredCategoryConfig } from '../../src/lib/reports/scoring';
 
 export function calculateScore<T extends { weight: number }>(
   refs: T[],
@@ -63,7 +66,7 @@ export function scoreReportOptimized1(report: Report): ScoredReport {
       });
       return categoryMap;
     },
-    new Map(),
+    new Map<string, ScoredCategoryConfig>(),
   );
 
   return {

--- a/packages/utils/perf/score-report/optimized1.ts
+++ b/packages/utils/perf/score-report/optimized1.ts
@@ -13,6 +13,7 @@ export function calculateScore<T extends { weight: number }>(
   return numerator / denominator;
 }
 
+// eslint-disable-next-line max-lines-per-function
 export function scoreReportOptimized1(report: Report): ScoredReport {
   const allScoredAuditsAndGroupsMap = new Map();
 

--- a/packages/utils/perf/score-report/optimized2.ts
+++ b/packages/utils/perf/score-report/optimized2.ts
@@ -1,5 +1,8 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-assignment */
+// Note: The plugins of the ScoredReport are not structured correctly, hence the ESLint disables.
 import { CategoryRef, GroupRef, Report } from '@code-pushup/models';
 import { ScoredReport } from '../../src';
+import { ScoredCategoryConfig } from '../../src/lib/reports/scoring';
 
 export function calculateScore<T extends { weight: number }>(
   refs: T[],
@@ -65,7 +68,7 @@ export function scoreReportOptimized2(report: Report): ScoredReport {
       });
       return categoryMap;
     },
-    new Map(),
+    new Map<string, ScoredCategoryConfig>(),
   );
 
   return {

--- a/packages/utils/perf/score-report/optimized2.ts
+++ b/packages/utils/perf/score-report/optimized2.ts
@@ -13,6 +13,7 @@ export function calculateScore<T extends { weight: number }>(
   return numerator / denominator;
 }
 
+// eslint-disable-next-line max-lines-per-function
 export function scoreReportOptimized2(report: Report): ScoredReport {
   const allScoredAuditsAndGroupsMap = new Map();
 

--- a/packages/utils/perf/score-report/optimized3.ts
+++ b/packages/utils/perf/score-report/optimized3.ts
@@ -1,8 +1,12 @@
-/* eslint-disable no-param-reassign */
-
-/* eslint-disable functional/immutable-data */
+/* eslint-disable no-param-reassign, functional/immutable-data */
+// Note: The mutability issues are resolved in production code
 import { CategoryRef, GroupRef, Report } from '@code-pushup/models';
 import { ScoredReport } from '../../src';
+import {
+  EnrichedAuditReport,
+  EnrichedScoredGroup,
+  ScoredCategoryConfig,
+} from '../../src/lib/reports/scoring';
 
 export function calculateScore<T extends { weight: number }>(
   refs: T[],
@@ -37,9 +41,13 @@ export function deepClone<T>(obj: T): T {
   return cloned;
 }
 
+// eslint-disable-next-line max-lines-per-function
 export function scoreReportOptimized3(report: Report): ScoredReport {
   const scoredReport = deepClone(report) as ScoredReport;
-  const allScoredAuditsAndGroups = new Map();
+  const allScoredAuditsAndGroups = new Map<
+    string,
+    EnrichedAuditReport | EnrichedScoredGroup
+  >();
 
   scoredReport.plugins?.forEach(plugin => {
     const { audits, slug } = plugin;
@@ -83,7 +91,7 @@ export function scoreReportOptimized3(report: Report): ScoredReport {
     return item.score;
   }
 
-  const scoredCategoriesMap = new Map();
+  const scoredCategoriesMap = new Map<string, ScoredCategoryConfig>();
   // eslint-disable-next-line functional/no-loop-statements
   for (const category of scoredReport.categories) {
     category.score = calculateScore(category.refs, catScoreFn);

--- a/packages/utils/perf/score-report/optimized3.ts
+++ b/packages/utils/perf/score-report/optimized3.ts
@@ -1,3 +1,6 @@
+/* eslint-disable no-param-reassign */
+
+/* eslint-disable functional/immutable-data */
 import { CategoryRef, GroupRef, Report } from '@code-pushup/models';
 import { ScoredReport } from '../../src';
 
@@ -23,6 +26,7 @@ export function deepClone<T>(obj: T): T {
     return obj;
   }
 
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   const cloned: T = Array.isArray(obj) ? ([] as T) : ({} as T);
   // eslint-disable-next-line functional/no-loop-statements
   for (const key in obj) {

--- a/packages/utils/src/lib/execute-process.ts
+++ b/packages/utils/src/lib/execute-process.ts
@@ -146,12 +146,12 @@ export function executeProcess(cfg: ProcessConfig): Promise<ProcessResult> {
     let stderr = '';
 
     process.stdout.on('data', data => {
-      stdout += data.toString();
-      onStdout?.(data);
+      stdout += String(data);
+      onStdout?.(String(data));
     });
 
     process.stderr.on('data', data => {
-      stderr += data.toString();
+      stderr += String(data);
     });
 
     process.on('error', err => {

--- a/packages/utils/src/lib/file-system.ts
+++ b/packages/utils/src/lib/file-system.ts
@@ -12,7 +12,7 @@ export async function readTextFile(path: string): Promise<string> {
 
 export async function readJsonFile<T = unknown>(path: string): Promise<T> {
   const text = await readTextFile(path);
-  return JSON.parse(text);
+  return JSON.parse(text) as T;
 }
 
 export async function fileExists(path: string): Promise<boolean> {
@@ -76,7 +76,7 @@ export class NoExportError extends Error {
 }
 
 export async function importEsmModule(options: Options): Promise<unknown> {
-  const { mod } = await bundleRequire({
+  const { mod } = await bundleRequire<object>({
     format: 'esm',
     ...options,
   });
@@ -84,7 +84,6 @@ export async function importEsmModule(options: Options): Promise<unknown> {
   if (!('default' in mod)) {
     throw new NoExportError(options.filepath);
   }
-
   return mod.default;
 }
 

--- a/packages/utils/src/lib/formatting.ts
+++ b/packages/utils/src/lib/formatting.ts
@@ -23,9 +23,10 @@ export function pluralize(text: string): string {
 }
 
 export function formatBytes(bytes: number, decimals = 2) {
-  bytes = Math.max(bytes, 0);
+  const positiveBytes = Math.max(bytes, 0);
+
   // early exit
-  if (!bytes) {
+  if (positiveBytes === 0) {
     return '0 B';
   }
 
@@ -33,9 +34,9 @@ export function formatBytes(bytes: number, decimals = 2) {
   const dm = decimals < 0 ? 0 : decimals;
   const sizes = ['B', 'kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
 
-  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  const i = Math.floor(Math.log(positiveBytes) / Math.log(k));
 
-  return `${Number.parseFloat((bytes / Math.pow(k, i)).toFixed(dm))} ${
+  return `${Number.parseFloat((positiveBytes / Math.pow(k, i)).toFixed(dm))} ${
     sizes[i]
   }`;
 }

--- a/packages/utils/src/lib/git.ts
+++ b/packages/utils/src/lib/git.ts
@@ -15,5 +15,5 @@ export async function getLatestCommit() {
     maxCount: 1,
     format: { hash: '%H', message: '%s', author: '%an', date: '%ad' },
   });
-  return log?.latest;
+  return log.latest;
 }

--- a/packages/utils/src/lib/git.ts
+++ b/packages/utils/src/lib/git.ts
@@ -1,4 +1,4 @@
-import simpleGit from 'simple-git';
+import { simpleGit } from 'simple-git';
 
 export type CommitData = {
   hash: string;

--- a/packages/utils/src/lib/group-by-status.ts
+++ b/packages/utils/src/lib/group-by-status.ts
@@ -6,15 +6,10 @@ export function groupByStatus<T>(results: PromiseSettledResult<T>[]): {
     fulfilled: PromiseFulfilledResult<T>[];
     rejected: PromiseRejectedResult[];
   }>(
-    (acc, result) => {
-      if (result.status === 'fulfilled') {
-        return { ...acc, fulfilled: [...acc.fulfilled, result] };
-      }
-      if (result.status === 'rejected') {
-        return { ...acc, rejected: [...acc.rejected, result] };
-      }
-      return acc;
-    },
+    (acc, result) =>
+      result.status === 'fulfilled'
+        ? { ...acc, fulfilled: [...acc.fulfilled, result] }
+        : { ...acc, rejected: [...acc.rejected, result] },
     { fulfilled: [], rejected: [] },
   );
 }

--- a/packages/utils/src/lib/reports/generate-md-report.ts
+++ b/packages/utils/src/lib/reports/generate-md-report.ts
@@ -14,6 +14,7 @@ import {
   tableMd,
 } from './md';
 import {
+  EnrichedAuditReport,
   EnrichedScoredGroupWithAudits,
   ScoredReport,
   WeighedAuditReport,
@@ -93,15 +94,15 @@ function reportToCategoriesSection(report: ScoredReport): string {
       category.score,
     )} Score:  ${style(formatReportScore(category.score))}`;
     const categoryDocs = getDocsAndDescription(category);
-    const categoryMDItems = category.refs.reduce((acc, ref) => {
+    const categoryMDItems = category.refs.reduce((refAcc, ref) => {
       if (ref.type === 'group') {
         const group = getGroupWithAudits(ref.slug, ref.plugin, plugins);
         const mdGroupItem = groupItemToCategorySection(group, plugins);
-        return acc + mdGroupItem + NEW_LINE;
+        return refAcc + mdGroupItem + NEW_LINE;
       } else {
         const audit = getAuditByRef(ref, plugins);
         const mdAuditItem = auditItemToCategorySection(audit, plugins);
-        return acc + mdAuditItem + NEW_LINE;
+        return refAcc + mdAuditItem + NEW_LINE;
       }
     }, '');
 
@@ -151,82 +152,77 @@ function groupItemToCategorySection(
       `#${slugify(audit.title)}-${slugify(pluginTitle)}`,
       audit?.title,
     );
-    acc += `  ${li(
+    return `${acc}  ${li(
       `${getSquaredScoreMarker(audit.score)} ${auditTitle} - ${getAuditResult(
         audit,
       )}`,
-    )}`;
-    acc += NEW_LINE;
-    return acc;
+    )}${NEW_LINE}`;
   }, '');
 
   return groupTitle + NEW_LINE + groupAudits;
 }
 
 function reportToAuditsSection(report: ScoredReport): string {
-  const auditsSection = report.plugins.reduce((acc, plugin) => {
-    const auditsData = plugin.audits.reduce((acc, audit) => {
+  const auditsSection = report.plugins.reduce((pluginAcc, plugin) => {
+    const auditsData = plugin.audits.reduce((auditAcc, audit) => {
       const auditTitle = `${audit.title} (${getPluginNameFromSlug(
         audit.plugin,
         report.plugins,
       )})`;
-      const detailsTitle = `${getSquaredScoreMarker(
-        audit.score,
-      )} ${getAuditResult(audit, true)} (score: ${formatReportScore(
-        audit.score,
-      )})`;
-      const docsItem = getDocsAndDescription(audit);
 
-      acc += h3(auditTitle);
-
-      acc += NEW_LINE;
-      acc += NEW_LINE;
-
-      if (!audit.details?.issues?.length) {
-        acc += detailsTitle;
-        acc += NEW_LINE;
-        acc += NEW_LINE;
-        acc += docsItem;
-        return acc;
-      }
-
-      const detailsTableData = [
-        detailsTableHeaders,
-        ...audit.details.issues.map((issue: Issue) => {
-          const severity = `${getSeverityIcon(issue.severity)} <i>${
-            issue.severity
-          }</i>`;
-          const message = issue.message;
-
-          if (!issue.source) {
-            return [severity, message, '', ''];
-          }
-          // TODO: implement file links, ticket #149
-          const file = `<code>${issue.source?.file}</code>`;
-          if (!issue.source.position) {
-            return [severity, message, file, ''];
-          }
-          const { startLine, endLine } = issue.source.position;
-          const line = `${startLine || ''}${
-            endLine && startLine !== endLine ? `-${endLine}` : ''
-          }`;
-
-          return [severity, message, file, line];
-        }),
-      ];
-      const detailsTable = `<h4>Issues</h4>${tableHtml(detailsTableData)}`;
-
-      acc += details(detailsTitle, detailsTable);
-      acc += NEW_LINE;
-      acc += NEW_LINE;
-      acc += docsItem;
-
-      return acc;
+      return (
+        auditAcc +
+        h3(auditTitle) +
+        NEW_LINE +
+        NEW_LINE +
+        reportToDetailsSection(audit) +
+        NEW_LINE +
+        NEW_LINE +
+        getDocsAndDescription(audit)
+      );
     }, '');
-    return acc + auditsData;
+    return pluginAcc + auditsData;
   }, '');
 
   return h2('🛡️ Audits') + NEW_LINE + NEW_LINE + auditsSection;
+}
+
+function reportToDetailsSection(audit: EnrichedAuditReport) {
+  const detailsTitle = `${getSquaredScoreMarker(audit.score)} ${getAuditResult(
+    audit,
+    true,
+  )} (score: ${formatReportScore(audit.score)})`;
+
+  if (!audit.details?.issues?.length) {
+    return detailsTitle;
+  }
+
+  const detailsTableData = [
+    detailsTableHeaders,
+    ...audit.details.issues.map((issue: Issue) => {
+      const severity = `${getSeverityIcon(issue.severity)} <i>${
+        issue.severity
+      }</i>`;
+      const message = issue.message;
+
+      if (!issue.source) {
+        return [severity, message, '', ''];
+      }
+      // TODO: implement file links, ticket #149
+      const file = `<code>${issue.source?.file}</code>`;
+      if (!issue.source.position) {
+        return [severity, message, file, ''];
+      }
+      const { startLine, endLine } = issue.source.position;
+      const line = `${startLine || ''}${
+        endLine && startLine !== endLine ? `-${endLine}` : ''
+      }`;
+
+      return [severity, message, file, line];
+    }),
+  ];
+  const detailsTable = `<h4>Issues</h4>${tableHtml(detailsTableData)}`;
+  return details(detailsTitle, detailsTable);
 }
 
 function reportToAboutSection(
@@ -252,11 +248,11 @@ function reportToAboutSection(
 
   const pluginMetaTable = [
     pluginMetaTableHeaders,
-    ...plugins.map(({ title, version, duration, audits }) => [
-      title,
-      audits.length.toString(),
-      style(version || '', ['c']),
-      formatDuration(duration),
+    ...plugins.map(plugin => [
+      plugin.title,
+      plugin.audits.length.toString(),
+      style(plugin.version || '', ['c']),
+      formatDuration(plugin.duration),
     ]),
   ];
 

--- a/packages/utils/src/lib/reports/generate-md-report.ts
+++ b/packages/utils/src/lib/reports/generate-md-report.ts
@@ -129,7 +129,7 @@ function auditItemToCategorySection(
   const pluginTitle = getPluginNameFromSlug(audit.plugin, plugins);
   const auditTitle = link(
     `#${slugify(audit.title)}-${slugify(pluginTitle)}`,
-    audit?.title,
+    audit.title,
   );
   return li(
     `${getSquaredScoreMarker(
@@ -150,7 +150,7 @@ function groupItemToCategorySection(
   const groupAudits = group.audits.reduce((acc, audit) => {
     const auditTitle = link(
       `#${slugify(audit.title)}-${slugify(pluginTitle)}`,
-      audit?.title,
+      audit.title,
     );
     return `${acc}  ${li(
       `${getSquaredScoreMarker(audit.score)} ${auditTitle} - ${getAuditResult(
@@ -193,7 +193,7 @@ function reportToDetailsSection(audit: EnrichedAuditReport) {
     true,
   )} (score: ${formatReportScore(audit.score)})`;
 
-  if (!audit.details?.issues?.length) {
+  if (!audit.details?.issues.length) {
     return detailsTitle;
   }
 
@@ -209,7 +209,7 @@ function reportToDetailsSection(audit: EnrichedAuditReport) {
         return [severity, message, '', ''];
       }
       // TODO: implement file links, ticket #149
-      const file = `<code>${issue.source?.file}</code>`;
+      const file = `<code>${issue.source.file}</code>`;
       if (!issue.source.position) {
         return [severity, message, file, ''];
       }

--- a/packages/utils/src/lib/reports/generate-stdout-summary.ts
+++ b/packages/utils/src/lib/reports/generate-stdout-summary.ts
@@ -1,6 +1,6 @@
 import cliui from '@isaacs/cliui';
 import chalk from 'chalk';
-import Table from 'cli-table3';
+import CliTable3 from 'cli-table3';
 import { NEW_LINE, SCORE_COLOR_RANGE, TERMINAL_WIDTH } from './constants';
 import { ScoredReport } from './scoring';
 import {
@@ -38,20 +38,20 @@ function reportToDetailSection(report: ScoredReport): string {
     const { title, audits } = plugin;
     const ui = cliui({ width: TERMINAL_WIDTH });
 
-    audits.forEach(({ score, title, displayValue, value }) => {
+    audits.forEach(audit => {
       ui.div(
         {
-          text: withColor({ score, text: '●' }),
+          text: withColor({ score: audit.score, text: '●' }),
           width: 2,
           padding: [0, 1, 0, 0],
         },
         {
-          text: title,
+          text: audit.title,
           // eslint-disable-next-line no-magic-numbers
           padding: [0, 3, 0, 0],
         },
         {
-          text: chalk.cyanBright(displayValue || `${value}`),
+          text: chalk.cyanBright(audit.displayValue || `${audit.value}`),
           width: 10,
           padding: [0, 0, 0, 0],
         },
@@ -72,7 +72,7 @@ function reportToOverviewSection({
   categories,
   plugins,
 }: ScoredReport): string {
-  const table = new Table({
+  const table = new CliTable3({
     head: reportRawOverviewTableHeaders,
     colAligns: ['left', 'right', 'right'],
     style: {

--- a/packages/utils/src/lib/reports/md/table.ts
+++ b/packages/utils/src/lib/reports/md/table.ts
@@ -21,15 +21,17 @@ export function tableMd(
   if (data.length === 0) {
     throw new Error("Data can't be empty");
   }
-  align ??= data[0]?.map(() => 'c');
+  const alignmentSetting = align ?? data[0]?.map(() => 'c');
   const tableContent = data.map(arr => `|${arr.join('|')}|`);
-  const secondRow = `|${align?.map(s => alignString.get(s)).join('|')}|`;
+  const alignmentRow = `|${alignmentSetting
+    ?.map(s => alignString.get(s))
+    .join('|')}|`;
   return (
-    tableContent.shift() +
+    tableContent[0] +
     NEW_LINE +
-    secondRow +
+    alignmentRow +
     NEW_LINE +
-    tableContent.join(NEW_LINE)
+    tableContent.slice(1).join(NEW_LINE)
   );
 }
 

--- a/packages/utils/src/lib/reports/scoring.ts
+++ b/packages/utils/src/lib/reports/scoring.ts
@@ -56,8 +56,12 @@ export function calculateScore<T extends { weight: number }>(
   return numerator / denominator;
 }
 
+// eslint-disable-next-line max-lines-per-function
 export function scoreReport(report: Report): ScoredReport {
-  const allScoredAuditsAndGroups = new Map();
+  const allScoredAuditsAndGroups = new Map<
+    string,
+    EnrichedAuditReport | EnrichedScoredGroup
+  >();
 
   const scoredPlugins = report.plugins.map(plugin => {
     const { slug, audits, groups } = plugin;
@@ -109,7 +113,6 @@ export function scoreReport(report: Report): ScoredReport {
     ...category,
     score: calculateScore(category.refs, catScoreFn),
   }));
-
   return {
     ...deepClone(report),
     plugins: scoredPlugins,

--- a/packages/utils/src/lib/reports/sorting.ts
+++ b/packages/utils/src/lib/reports/sorting.ts
@@ -1,5 +1,7 @@
-import { CategoryRef } from '@code-pushup/models';
+import { CategoryRef, PluginReport } from '@code-pushup/models';
 import {
+  EnrichedAuditReport,
+  EnrichedScoredGroup,
   EnrichedScoredGroupWithAudits,
   ScoredReport,
   WeighedAuditReport,
@@ -39,7 +41,7 @@ export function sortReport(report: ScoredReport): ScoredReport {
     );
     const sortedAuditsAndGroups = [
       ...groups,
-      ...audits.sort(compareCategoryAudits),
+      ...[...audits].sort(compareCategoryAudits),
     ];
     const sortedRefs = [...category.refs].sort((a, b) => {
       const aIndex = sortedAuditsAndGroups.findIndex(
@@ -54,7 +56,20 @@ export function sortReport(report: ScoredReport): ScoredReport {
     return { ...category, refs: sortedRefs };
   });
 
-  const sortedPlugins = plugins.map(plugin => ({
+  return {
+    ...report,
+    categories: sortedCategories,
+    plugins: sortPlugins(plugins),
+  };
+}
+
+function sortPlugins(
+  plugins: (Omit<PluginReport, 'audits' | 'groups'> & {
+    audits: EnrichedAuditReport[];
+    groups: EnrichedScoredGroup[];
+  })[],
+) {
+  return plugins.map(plugin => ({
     ...plugin,
     audits: [...plugin.audits].sort(compareAudits).map(audit =>
       audit.details?.issues
@@ -68,10 +83,4 @@ export function sortReport(report: ScoredReport): ScoredReport {
         : audit,
     ),
   }));
-
-  return {
-    ...report,
-    categories: sortedCategories,
-    plugins: sortedPlugins,
-  };
 }

--- a/packages/utils/src/lib/reports/utils.ts
+++ b/packages/utils/src/lib/reports/utils.ts
@@ -95,8 +95,7 @@ export function getSeverityIcon(
 }
 
 export function calcDuration(start: number, stop?: number): number {
-  stop ??= performance.now();
-  return Math.floor(stop - start);
+  return Math.floor((stop ?? performance.now()) - start);
 }
 
 export function countWeightedRefs(refs: CategoryRef[]) {
@@ -140,7 +139,7 @@ export function getAuditByRef(
   { slug, weight, plugin }: CategoryRef,
   plugins: ScoredReport['plugins'],
 ): WeighedAuditReport {
-  const auditPlugin = plugins.find(({ slug }) => slug === plugin);
+  const auditPlugin = plugins.find(p => p.slug === plugin);
   if (!auditPlugin) {
     throwIsNotPresentError(`Plugin ${plugin}`, 'report');
   }
@@ -174,17 +173,18 @@ export function getGroupWithAudits(
   const groupAudits = groupWithAudits.refs.reduce<WeighedAuditReport[]>(
     (acc: WeighedAuditReport[], ref) => {
       const audit = getAuditByRef(
-        { ...ref, plugin: refPlugin } as CategoryRef,
+        { ...ref, plugin: refPlugin, type: 'audit' },
         plugins,
       );
+
       if (audit) {
         return [...acc, audit];
       }
       return [...acc];
     },
     [],
-  ) as WeighedAuditReport[];
-  const audits = groupAudits.sort(compareCategoryAudits);
+  );
+  const audits = [...groupAudits].sort(compareCategoryAudits);
 
   return {
     ...groupWithAudits,

--- a/packages/utils/src/lib/reports/utils.ts
+++ b/packages/utils/src/lib/reports/utils.ts
@@ -143,11 +143,11 @@ export function getAuditByRef(
   if (!auditPlugin) {
     throwIsNotPresentError(`Plugin ${plugin}`, 'report');
   }
-  const audit = auditPlugin?.audits.find(
+  const audit = auditPlugin.audits.find(
     ({ slug: auditSlug }) => auditSlug === slug,
   );
   if (!audit) {
-    throwIsNotPresentError(`Audit ${slug}`, auditPlugin?.slug);
+    throwIsNotPresentError(`Audit ${slug}`, auditPlugin.slug);
   }
   return {
     ...audit,
@@ -165,10 +165,10 @@ export function getGroupWithAudits(
   if (!plugin) {
     throwIsNotPresentError(`Plugin ${refPlugin}`, 'report');
   }
-  const groupWithAudits = plugin?.groups?.find(({ slug }) => slug === refSlug);
+  const groupWithAudits = plugin.groups?.find(({ slug }) => slug === refSlug);
 
   if (!groupWithAudits) {
-    throwIsNotPresentError(`Group ${refSlug}`, plugin?.slug);
+    throwIsNotPresentError(`Group ${refSlug}`, plugin.slug);
   }
   const groupAudits = groupWithAudits.refs.reduce<WeighedAuditReport[]>(
     (acc: WeighedAuditReport[], ref) => {
@@ -176,11 +176,7 @@ export function getGroupWithAudits(
         { ...ref, plugin: refPlugin, type: 'audit' },
         plugins,
       );
-
-      if (audit) {
-        return [...acc, audit];
-      }
-      return [...acc];
+      return [...acc, audit];
     },
     [],
   );
@@ -251,11 +247,11 @@ export async function loadReport<T extends Format>(
 
   if (format === 'json') {
     const content = await readJsonFile(filePath);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return reportSchema.parse(content) as any;
+    return reportSchema.parse(content) as LoadedReportFormat<T>;
   }
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return readTextFile(filePath) as any;
+
+  const text = await readTextFile(filePath);
+  return text as LoadedReportFormat<T>;
 }
 
 export function throwIsNotPresentError(

--- a/packages/utils/src/lib/reports/utils.unit.test.ts
+++ b/packages/utils/src/lib/reports/utils.unit.test.ts
@@ -58,11 +58,12 @@ describe('countWeightedRefs', () => {
 
 describe('compareIssueSeverity', () => {
   it('should order severities in logically ascending order when used as compareFn with .sort()', () => {
-    expect(
-      (['error', 'info', 'warning'] satisfies IssueSeverity[]).sort(
-        compareIssueSeverity,
-      ),
-    ).toEqual(['info', 'warning', 'error']);
+    const severityArr = ['error', 'info', 'warning'] satisfies IssueSeverity[];
+    expect([...severityArr].sort(compareIssueSeverity)).toEqual([
+      'info',
+      'warning',
+      'error',
+    ]);
   });
 });
 

--- a/packages/utils/src/lib/transform.ts
+++ b/packages/utils/src/lib/transform.ts
@@ -63,9 +63,11 @@ export function objectToCliArgs<
     return [];
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
   return Object.entries(params).flatMap(([key, value]) => {
     // process/file/script
     if (key === '_') {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
       return Array.isArray(value) ? value : [`${value}`];
     }
     const prefix = key.length === 1 ? '-' : '--';

--- a/packages/utils/src/lib/transform.ts
+++ b/packages/utils/src/lib/transform.ts
@@ -24,18 +24,7 @@ export function distinct<T extends string | number | boolean>(array: T[]): T[] {
 }
 
 export function deepClone<T>(obj: T): T {
-  if (obj == null || typeof obj !== 'object') {
-    return obj;
-  }
-
-  const cloned: T = Array.isArray(obj) ? ([] as T) : ({} as T);
-  // eslint-disable-next-line functional/no-loop-statements
-  for (const key in obj) {
-    if (Object.prototype.hasOwnProperty.call(obj, key)) {
-      cloned[key as keyof T] = deepClone(obj[key]);
-    }
-  }
-  return cloned;
+  return obj == null || typeof obj !== 'object' ? obj : structuredClone(obj);
 }
 
 export function factorOf<T>(items: T[], filterFn: (i: T) => boolean): number {


### PR DESCRIPTION
Closes #265 
Closes #267 
Closes #268 
Closes #269 
Closes #271 
In this PR, I tackle the rest of the ESLint issues in `utils`. Notable changes and findings:
- Again, I was not able to resolve `no-unnecessary-condition` due to #421
- In perf files, some of the types are wrong. For the sake of its experimental nature, however, I opted to disable ESLint rules instead. Relevant notes were added there.
- There is one case where I hesitated - replacing `pop` with `slice`. Should I leave it or not? 🙏 

Before:
![image](https://github.com/code-pushup/cli/assets/6306671/1b20677e-26cf-4d8d-8656-24f17f1b20df)

[After](https://quality-metrics-staging.web.app/portal/code-pushup/cli/branch/eslint-utils-fixes-vol2/dashboard):
![image](https://github.com/code-pushup/cli/assets/6306671/c47ae39f-68eb-4935-9ed7-4f61fd4524cb)
