### PR TITLE
test: prevent console logging in test output

### DIFF
--- a/testing-utils/src/lib/setup/console.mock.ts
+++ b/testing-utils/src/lib/setup/console.mock.ts
@@ -7,15 +7,15 @@ let consoleErrorSpy: SpyInstance | undefined;
 beforeEach(() => {
   // In multi-progress-bars, console methods are overriden
   if (console.info != null) {
-    consoleInfoSpy = vi.spyOn(console, 'info');
+    consoleInfoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
   }
 
   if (console.warn != null) {
-    consoleWarnSpy = vi.spyOn(console, 'warn');
+    consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
   }
 
   if (console.error != null) {
-    consoleErrorSpy = vi.spyOn(console, 'error');
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
   }
 });
 


### PR DESCRIPTION
Related to #357 
I prevented console from logging into our test outputs.

Note: I found out one output that still appears - directly from `bundle-require`. Not sure why.

Before:
![image](https://github.com/code-pushup/cli/assets/6306671/23d64349-241b-4ef1-b0bd-68c69a84f78a)
 
After:
![image](https://github.com/code-pushup/cli/assets/6306671/300b4ef0-74fe-4a50-812b-5d834bb093c7)
