### PR TITLE
build: migrate to ngx-deploy-npm v8

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -32,8 +32,7 @@
       "dependsOn": ["build"],
       "executor": "ngx-deploy-npm:deploy",
       "options": {
-        "access": "public",
-        "noBuild": true
+        "access": "public"
       }
     }
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@code-pushup/cli-source",
-  "version": "0.8.25",
+  "version": "0.10.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@code-pushup/cli-source",
-      "version": "0.8.25",
+      "version": "0.10.4",
       "license": "MIT",
       "dependencies": {
         "@code-pushup/portal-client": "^0.4.0",
@@ -76,7 +76,7 @@
         "lighthouse": "^11.0.0",
         "memfs": "^4.5.0",
         "moment": "^2.29.4",
-        "ngx-deploy-npm": "^7.1.0",
+        "ngx-deploy-npm": "8.0.0",
         "nx": "17.1.3",
         "prettier": "^2.6.2",
         "react": "^18.2.0",
@@ -3793,9 +3793,10 @@
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.19",
+      "version": "0.3.22",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.22.tgz",
+      "integrity": "sha512-Wf963MzWtA2sjrNt+g18IAln9lKnlRp+K2eH4jjIoF1wYeq3aMREpG09xhlhdzS0EjwU7qmUJYangWa+151vZw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -6030,9 +6031,10 @@
       }
     },
     "node_modules/@types/estree": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT"
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
+      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
+      "dev": true
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",
@@ -17281,9 +17283,9 @@
       }
     },
     "node_modules/ngx-deploy-npm": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/ngx-deploy-npm/-/ngx-deploy-npm-7.1.0.tgz",
-      "integrity": "sha512-zUv/C9giRVrhmOu3dIG3tjjN+1/bOV5xQzPGgXBZL74M5dgZo+/Dui1JxrVCZH9m8QogR4Zg+0Xq6FeXo2xKrg==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/ngx-deploy-npm/-/ngx-deploy-npm-8.0.0.tgz",
+      "integrity": "sha512-/sjvCYXp7fDc45uYsRwxCfJGZh82n2e7B3eazlS4jx6rE1DOvRtlbJIqptHL486iIDd63yCAQOXqeFqGvgGtRw==",
       "dev": true,
       "engines": {
         "node": ">=18.0.0"
@@ -19685,9 +19687,9 @@
       "dev": true
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.1.tgz",
-      "integrity": "sha512-owoXEFjWRllis8/M1Q+Cw5k8ZH40e3zhp/ovX+Xr/vi1qj6QesbyXXViFbpNvWvPNAD62SutwEXavefrLJWj7w==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -20419,9 +20421,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.24.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.24.0.tgz",
-      "integrity": "sha512-ZpGR4Hy3+wBEzVEnHvstMvqpD/nABNelQn/z2r0fjVWGQsN3bpOLzQlqDxmb4CDZnXq5lpjnQ+mHQLAOpfM5iw==",
+      "version": "5.27.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.27.0.tgz",
+      "integrity": "sha512-bi1HRwVRskAjheeYl291n3JC4GgO/Ty4z1nVs5AAsmonJulGxpSektecnNedrwK9C7vpvVtcX3cw00VSLt7U2A==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -20438,17 +20440,17 @@
       }
     },
     "node_modules/terser-webpack-plugin": {
-      "version": "5.3.9",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.9.tgz",
-      "integrity": "sha512-ZuXsqE07EcggTWQjXUj+Aot/OMcD0bMKGgF63f7UxYcu5/AJF53aIpK1YoP5xR9l6s/Hy2b+t1AM0bLNPRuhwA==",
+      "version": "5.3.10",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.10.tgz",
+      "integrity": "sha512-BKFPWlPDndPs+NGGCr1U59t0XScL5317Y0UReNrHaw9/FwhPENlq6bfgs+4yPfyP51vqC1bQ4rp1EfXW5ZSH9w==",
       "dev": true,
       "peer": true,
       "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.17",
+        "@jridgewell/trace-mapping": "^0.3.20",
         "jest-worker": "^27.4.5",
         "schema-utils": "^3.1.1",
         "serialize-javascript": "^6.0.1",
-        "terser": "^5.16.8"
+        "terser": "^5.26.0"
       },
       "engines": {
         "node": ">= 10.13.0"
@@ -22086,20 +22088,20 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/webpack": {
-      "version": "5.89.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.89.0.tgz",
-      "integrity": "sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==",
+      "version": "5.90.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.90.0.tgz",
+      "integrity": "sha512-bdmyXRCXeeNIePv6R6tGPyy20aUobw4Zy8r0LUS2EWO+U+Ke/gYDgsCh7bl5rB6jPpr4r0SZa6dPxBxLooDT3w==",
       "dev": true,
       "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
-        "@types/estree": "^1.0.0",
+        "@types/estree": "^1.0.5",
         "@webassemblyjs/ast": "^1.11.5",
         "@webassemblyjs/wasm-edit": "^1.11.5",
         "@webassemblyjs/wasm-parser": "^1.11.5",
         "acorn": "^8.7.1",
         "acorn-import-assertions": "^1.9.0",
-        "browserslist": "^4.14.5",
+        "browserslist": "^4.21.10",
         "chrome-trace-event": "^1.0.2",
         "enhanced-resolve": "^5.15.0",
         "es-module-lexer": "^1.2.1",
@@ -22113,7 +22115,7 @@
         "neo-async": "^2.6.2",
         "schema-utils": "^3.2.0",
         "tapable": "^2.1.1",
-        "terser-webpack-plugin": "^5.3.7",
+        "terser-webpack-plugin": "^5.3.10",
         "watchpack": "^2.4.0",
         "webpack-sources": "^3.2.3"
       },

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "lighthouse": "^11.0.0",
     "memfs": "^4.5.0",
     "moment": "^2.29.4",
-    "ngx-deploy-npm": "^7.1.0",
+    "ngx-deploy-npm": "8.0.0",
     "nx": "17.1.3",
     "prettier": "^2.6.2",
     "react": "^18.2.0",

--- a/packages/cli/project.json
+++ b/packages/cli/project.json
@@ -63,7 +63,11 @@
       },
       "dependsOn": ["build"]
     },
-    "deploy": {}
+    "deploy": {
+      "options": {
+        "distFolderPath": "dist/packages/cli"
+      }
+    }
   },
   "tags": ["scope:core", "type:app"]
 }

--- a/packages/core/project.json
+++ b/packages/core/project.json
@@ -45,7 +45,11 @@
         "reportsDirectory": "../../coverage/core/integration-tests"
       }
     },
-    "deploy": {}
+    "deploy": {
+      "options": {
+        "distFolderPath": "dist/packages/core"
+      }
+    }
   },
   "tags": ["scope:core", "type:feature"]
 }

--- a/packages/models/project.json
+++ b/packages/models/project.json
@@ -45,7 +45,11 @@
         "reportsDirectory": "../../coverage/models/integration-tests"
       }
     },
-    "deploy": {}
+    "deploy": {
+      "options": {
+        "distFolderPath": "dist/packages/models"
+      }
+    }
   },
   "tags": ["scope:shared", "type:util"]
 }

--- a/packages/nx-plugin/project.json
+++ b/packages/nx-plugin/project.json
@@ -67,7 +67,11 @@
         "reportsDirectory": "../../coverage/packages/models/integration-tests"
       }
     },
-    "deploy": {}
+    "deploy": {
+      "options": {
+        "distFolderPath": "dist/packages/nx-plugin"
+      }
+    }
   },
   "tags": ["scope:tooling", "type:feature"]
 }

--- a/packages/plugin-eslint/project.json
+++ b/packages/plugin-eslint/project.json
@@ -46,7 +46,11 @@
         "reportsDirectory": "../../coverage/plugin-eslint/integration-tests"
       }
     },
-    "deploy": {}
+    "deploy": {
+      "options": {
+        "distFolderPath": "dist/packages/plugin-eslint"
+      }
+    }
   },
   "tags": ["scope:plugin", "type:feature"]
 }

--- a/packages/plugin-lighthouse/project.json
+++ b/packages/plugin-lighthouse/project.json
@@ -41,7 +41,11 @@
         "reportsDirectory": "../../coverage/packages/plugin-lighthouse/integration-tests"
       }
     },
-    "deploy": {}
+    "deploy": {
+      "options": {
+        "distFolderPath": "dist/packages/plugin-lighthouse"
+      }
+    }
   },
   "tags": ["scope:plugin", "type:feature"]
 }

--- a/packages/utils/project.json
+++ b/packages/utils/project.json
@@ -57,7 +57,11 @@
         "reportsDirectory": "../../coverage/utils/integration-tests"
       }
     },
-    "deploy": {}
+    "deploy": {
+      "options": {
+        "distFolderPath": "dist/packages/utils"
+      }
+    }
   },
   "tags": ["scope:shared", "type:util"]
 }


### PR DESCRIPTION
ngx-deploy-npm introduces some breaking changes on version 8.0.0.

More information about the changes and their motivation can be found on this [blog post](https://dev.to/dianjuar/whats-coming-to-ngx-deploy-npm-v8-23gn)