### PR TITLE
feat(core): add upload timeout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@code-pushup/cli-source",
-  "version": "0.8.8",
+  "version": "0.8.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@code-pushup/cli-source",
-      "version": "0.8.8",
+      "version": "0.8.25",
       "license": "MIT",
       "dependencies": {
-        "@code-pushup/portal-client": "^0.3.0",
+        "@code-pushup/portal-client": "^0.4.0",
         "@isaacs/cliui": "^8.0.2",
         "@swc/helpers": "0.5.3",
         "bundle-require": "^4.0.1",
@@ -2129,9 +2129,9 @@
       }
     },
     "node_modules/@code-pushup/portal-client": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@code-pushup/portal-client/-/portal-client-0.3.0.tgz",
-      "integrity": "sha512-ghT1Rj0JL6NE56FkPJ9aAh2QGCIMFGA5ymVpXP9zm6mq9KYTlBIZkOyqf1oaWFRXdrXbYjQGhyhJfiacXyLn9Q==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@code-pushup/portal-client/-/portal-client-0.4.0.tgz",
+      "integrity": "sha512-M8kwXNj3Oo6Ehd3PQVDjwh5pcw79jWKWNjarwPlUIvxKKsKT0tghhHESyVG4XCtdyV6JEKEqPcaF/JheiWAQZg==",
       "dependencies": {
         "graphql-request": "^6.1.0",
         "graphql-tag": "^2.12.6"

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "node": ">=18.16"
   },
   "dependencies": {
-    "@code-pushup/portal-client": "^0.3.0",
+    "@code-pushup/portal-client": "^0.4.0",
     "@isaacs/cliui": "^8.0.2",
     "@swc/helpers": "0.5.3",
     "bundle-require": "^4.0.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "@code-pushup/models": "*",
     "@code-pushup/utils": "*",
-    "@code-pushup/portal-client": "^0.3.0",
+    "@code-pushup/portal-client": "^0.4.0",
     "chalk": "^5.3.0"
   },
   "type": "commonjs",

--- a/packages/core/src/lib/upload.ts
+++ b/packages/core/src/lib/upload.ts
@@ -5,7 +5,7 @@ import { jsonReportToGql } from './implementation/json-to-gql';
 import { normalizePersistConfig } from './normalize';
 import { GlobalOptions } from './types';
 
-export type UploadOptions = { upload: Required<UploadConfig> } & {
+export type UploadOptions = { upload: UploadConfig } & {
   persist: Required<PersistConfig>;
 } & GlobalOptions;
 
@@ -21,7 +21,7 @@ export async function upload(
   if (!options.upload) {
     throw new Error('upload config must be set');
   }
-  const { apiKey, server, organization, project } = options.upload;
+  const { apiKey, server, organization, project, timeout } = options.upload;
   const report: Report = await loadReport({
     ...persist,
     format: 'json',
@@ -38,5 +38,5 @@ export async function upload(
     ...jsonReportToGql(report),
   };
 
-  return uploadFn({ apiKey, server, data });
+  return uploadFn({ apiKey, server, data, timeout });
 }

--- a/packages/models/package.json
+++ b/packages/models/package.json
@@ -3,6 +3,6 @@
   "version": "0.8.25",
   "dependencies": {
     "zod": "^3.22.1",
-    "@code-pushup/portal-client": "^0.3.0"
+    "@code-pushup/portal-client": "^0.4.0"
   }
 }

--- a/packages/models/src/lib/upload-config.ts
+++ b/packages/models/src/lib/upload-config.ts
@@ -9,6 +9,11 @@ export const uploadConfigSchema = z.object({
   }),
   organization: slugSchema('Organization slug from Code PushUp portal'),
   project: slugSchema('Project slug from Code PushUp portal'),
+  timeout: z
+    .number({ description: 'Request timeout in minutes (default is 5)' })
+    .positive()
+    .int()
+    .optional(),
 });
 
 export type UploadConfig = z.infer<typeof uploadConfigSchema>;


### PR DESCRIPTION
Long-running upload requests are unlikely to ever resolve past a certain interval. To prevent hanging CI jobs (which cost money), a default timeout of 5 minutes is set (in `@code-pushup/portal-client` - see https://github.com/code-pushup/portal/pull/230) after which upload will fail. This value is customizable via `upload.timeout` in config file.