### PR TITLE
refactor(utils): check scoring prerequisites

### DIFF
--- a/packages/utils/src/lib/reports/scoring.unit.test.ts
+++ b/packages/utils/src/lib/reports/scoring.unit.test.ts
@@ -56,7 +56,16 @@ describe('calculateScore', () => {
   it('should throw for an empty reference array', () => {
     expect(() =>
       calculateScore<{ weight: number }>([], ref => ref.weight),
-    ).toThrow('0 division for score');
+    ).toThrow('Reference array cannot be empty.');
+  });
+
+  it('should throw negative weight', () => {
+    expect(() =>
+      calculateScore(
+        [{ slug: 'first-contentful-paint', weight: -1, score: 0.5 }],
+        ref => ref.score,
+      ),
+    ).toThrow('Weight cannot be negative.');
   });
 
   it('should throw for a reference array full of zero weights', () => {
@@ -66,9 +75,27 @@ describe('calculateScore', () => {
           { slug: 'first-contentful-paint', weight: 0, score: 0 },
           { slug: 'cumulative-layout-shift', weight: 0, score: 1 },
         ],
-        ref => ref.weight,
+        ref => ref.score,
       ),
-    ).toThrow('0 division for score');
+    ).toThrow('All references cannot have zero weight.');
+  });
+
+  it('should throw for a negative score', () => {
+    expect(() =>
+      calculateScore(
+        [{ slug: 'first-contentful-paint', weight: 1, score: -0.8 }],
+        ref => ref.score,
+      ),
+    ).toThrow('All scores must be in range 0-1.');
+  });
+
+  it('should throw for score above 1', () => {
+    expect(() =>
+      calculateScore(
+        [{ slug: 'first-contentful-paint', weight: 1, score: 2 }],
+        ref => ref.score,
+      ),
+    ).toThrow('All scores must be in range 0-1.');
   });
 });
 

--- a/packages/utils/src/lib/reports/utils.unit.test.ts
+++ b/packages/utils/src/lib/reports/utils.unit.test.ts
@@ -70,23 +70,15 @@ describe('compareIssueSeverity', () => {
 
 describe('formatReportScore', () => {
   it.each([
-    [Number.NaN, 'NaN'],
-    [Number.POSITIVE_INFINITY, 'Infinity'],
-    [Number.NEGATIVE_INFINITY, '-Infinity'],
-    [-1, '-100'],
-    [-0.1, '-10'],
     [0, '0'],
     [0.0049, '0'],
     [0.005, '1'],
     [0.01, '1'],
     [0.123, '12'],
-    [0.245, '25'],
-    [0.2449, '24'],
     [0.99, '99'],
     [0.994, '99'],
     [0.995, '100'],
     [1, '100'],
-    [1.1, '110'],
   ] satisfies readonly [number, string][])(
     "should format a score of %d as '%s'",
     (score, expected) => {


### PR DESCRIPTION
Until now the `calculatedScore` output value was only verified for division by 0. This meant that invalid values could get further into the report.
I added other checks that would make invalid references throw.