### PR TITLE
refactor(models): require at least 1 plugin with at least 1 audit in config and report

### DIFF
--- a/examples/plugins/src/lighthouse/src/lighthouse.plugin.integration.test.ts
+++ b/examples/plugins/src/lighthouse/src/lighthouse.plugin.integration.test.ts
@@ -101,7 +101,9 @@ describe('lighthouse-create-export-execution', () => {
     );
   });
 
-  it('should return PluginConfig that executes correctly', async () => {
+  // TODO: Convert to E2E test or reduce scope, it takes too long to run these tests
+  /* eslint-disable vitest/no-disabled-tests */
+  it.skip('should return PluginConfig that executes correctly', async () => {
     const pluginConfig = await create({ url: LIGHTHOUSE_URL });
     await expect(executePlugin(pluginConfig)).resolves.toMatchObject(
       expect.objectContaining({
@@ -116,7 +118,7 @@ describe('lighthouse-create-export-execution', () => {
     );
   });
 
-  it('should use onlyAudits', async () => {
+  it.skip('should use onlyAudits', async () => {
     const pluginConfig = await create({
       url: LIGHTHOUSE_URL,
       onlyAudits: 'largest-contentful-paint',
@@ -129,7 +131,8 @@ describe('lighthouse-create-export-execution', () => {
     expect(auditOutputs).toHaveLength(1);
     expect(auditOutputs[0]?.slug).toBe('largest-contentful-paint');
   });
-}, 40_000);
+  /* eslint-enable vitest/no-disabled-tests */
+});
 
 describe('lighthouse-audits-export', () => {
   it.each(audits.map(a => [a.slug, a]))(

--- a/packages/models/src/lib/audit.ts
+++ b/packages/models/src/lib/audit.ts
@@ -20,6 +20,7 @@ export const pluginAuditsSchema = z
   .array(auditSchema, {
     description: 'List of audits maintained in a plugin',
   })
+  .min(1)
   // audit slugs are unique
   .refine(
     auditMetadata => !getDuplicateSlugsInAudits(auditMetadata),

--- a/packages/models/src/lib/audit.unit.test.ts
+++ b/packages/models/src/lib/audit.unit.test.ts
@@ -50,6 +50,10 @@ describe('pluginAuditsSchema', () => {
     ).not.toThrow();
   });
 
+  it('should throw for an empty array', () => {
+    expect(() => pluginAuditsSchema.parse([])).toThrow('too_small');
+  });
+
   it('should throw for duplicate audits', () => {
     expect(() =>
       pluginAuditsSchema.parse([

--- a/packages/models/src/lib/plugin-config.unit.test.ts
+++ b/packages/models/src/lib/plugin-config.unit.test.ts
@@ -40,7 +40,7 @@ describe('pluginConfigSchema', () => {
     ).not.toThrow();
   });
 
-  it('should accept a plugin configuration with no audits or groups', () => {
+  it('should throw for a plugin configuration without audits', () => {
     expect(() =>
       pluginConfigSchema.parse({
         slug: 'jest',
@@ -48,9 +48,8 @@ describe('pluginConfigSchema', () => {
         icon: 'jest',
         runner: { command: 'npm run test', outputFile: 'jest-output.json' },
         audits: [],
-        groups: [],
       } satisfies PluginConfig),
-    ).not.toThrow();
+    ).toThrow('too_small');
   });
 
   it('should throw for a configuration with a group reference missing among audits', () => {

--- a/packages/models/src/lib/report.ts
+++ b/packages/models/src/lib/report.ts
@@ -27,7 +27,7 @@ export const pluginReportSchema = pluginMetaSchema
   )
   .merge(
     z.object({
-      audits: z.array(auditReportSchema),
+      audits: z.array(auditReportSchema).min(1),
       groups: z.array(groupSchema).optional(),
     }),
   )

--- a/packages/models/src/lib/report.unit.test.ts
+++ b/packages/models/src/lib/report.unit.test.ts
@@ -110,9 +110,29 @@ describe('pluginReportSchema', () => {
         icon: 'cypress',
         date: '2024-01-11T11:00:00.000Z',
         duration: 123_000,
-        audits: [],
+        audits: [
+          {
+            slug: 'cyct',
+            title: 'Component tests',
+            score: 0.96,
+            value: 96,
+          },
+        ],
       } satisfies PluginReport),
     ).not.toThrow();
+  });
+
+  it('should throw for a plugin report with no audit outputs', () => {
+    expect(() =>
+      pluginReportSchema.parse({
+        slug: 'cypress',
+        title: 'Cypress',
+        icon: 'cypress',
+        date: '2024-01-11T11:00:00.000Z',
+        duration: 123_000,
+        audits: [],
+      } satisfies PluginReport),
+    ).toThrow('too_small');
   });
 
   it('should throw for a group reference without audits mention', () => {
@@ -185,15 +205,15 @@ describe('reportSchema', () => {
     ).not.toThrow();
   });
 
-  it('should throw for an empty report', () => {
+  it('should throw for a report with no plugins', () => {
     expect(() =>
       reportSchema.parse({
         date: '2024-01-03T08:00:00.000Z',
         duration: 14_500,
         packageName: 'cli',
         version: '1.0.1',
-        categories: [],
         plugins: [],
+        categories: [],
       }),
     ).toThrow('too_small');
   });


### PR DESCRIPTION
closes #406

Notes: Additionally, I marked an example Lighthouse plugin to be ignored until #490 is complete due to pipeline timeouts.