### PR TITLE
chore(workflows): include unit test coverage in release packages for now

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,7 +179,7 @@ jobs:
           cache: npm
       - name: Install dependencies
         run: npm ci
-      - name: Collect unit test coverage
+      - name: Collect unit test coverage (temporary due to coverage plugin)
         run: npx nx run-many -t unit-test --coverage
       - name: Collect Code PushUp report
         run: npx nx run-collect

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,6 +90,8 @@ jobs:
         run: |
           echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> .npmrc
           npx nx run-many -t=deploy --exclude=plugin-lighthouse,nx-plugin
+      - name: Collect unit test coverage (temporary due to coverage plugin)
+        run: npx nx run-many -t unit-test --coverage
       - name: Collect and upload Code PushUp report
         run: npx nx run-autorun
         env:


### PR DESCRIPTION
This PR fixes the release packages workflow by providing coverage results before running autorun.

Logs [here](https://github.com/code-pushup/cli/actions/runs/7782083778/job/21217772516).