### PR TITLE
chore(utils): update test names, fix snapshot

### DIFF
--- a/packages/utils/src/lib/reports/__snapshots__/generate-md-report.integration.test.ts.snap
+++ b/packages/utils/src/lib/reports/__snapshots__/generate-md-report.integration.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`report-to-md > should contain all sections when using the fixture report 1`] = `
+exports[`generateMdReport > should contain all sections when using the fixture report 1`] = `
 "# Code PushUp Report
 
 |🏷 Category|⭐ Score|🛡 Audits|
@@ -437,7 +437,7 @@ The following plugins were run:
 Made with ❤ by [Code PushUp](https://github.com/flowup/quality-metrics-cli#readme)"
 `;
 
-exports[`report-to-md > should not contain category sections when categories are empty 1`] = `
+exports[`generateMdReport > should not contain category sections when categories are empty 1`] = `
 "# Code PushUp Report
 
 ## 🛡️ Audits

--- a/packages/utils/src/lib/reports/__snapshots__/generate-stdout-summary.integration.test.ts.snap
+++ b/packages/utils/src/lib/reports/__snapshots__/generate-stdout-summary.integration.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`report-to-stdout > should contain all sections when using the fixture report 1`] = `
+exports[`generateStdoutSummary > should contain all sections when using the fixture report 1`] = `
 "Code PushUp Report - @code-pushup/core@0.0.1
 
 
@@ -89,84 +89,7 @@ Made with ❤ by code-pushup.dev
 "
 `;
 
-exports[`report-to-stdout > should not contain category section when categories are empty 1`] = `
-"Code PushUp Report - @code-pushup/core@0.0.1
-
-
-ESLint audits
-
-● Disallow missing props validation in a React component definition   6 warnings
-● Disallow variable declarations from shadowing variables declared    3 warnings
-  in the outer scope
-● Require or disallow method and property shorthand syntax for        3 warnings
-  object literals
-● verifies the list of dependencies for Hooks like useEffect and      2 warnings
-  similar
-● Disallow missing \`key\` props in iterators/collection literals       1 warning
-● Disallow unused variables                                           1 warning
-● Enforce a maximum number of lines of code in a function             1 warning
-● Require \`const\` declarations for variables that are never           1 warning
-  reassigned after declared
-● Require braces around arrow function bodies                         1 warning
-● Require the use of \`===\` and \`!==\`                                  1 warning
-● Disallow \`target=\\"_blank\\"\` attribute without \`rel=\\"noreferrer\\"\`     passed
-● Disallow assignment operators in conditional expressions            passed
-● Disallow comments from being inserted as text nodes                 passed
-● Disallow direct mutation of this.state                              passed
-● Disallow duplicate properties in JSX                                passed
-● Disallow invalid regular expression strings in \`RegExp\`             passed
-  constructors
-● Disallow loops with a body that allows only one iteration           passed
-● Disallow missing displayName in a React component definition        passed
-● Disallow missing React when using JSX                               passed
-● Disallow negating the left operand of relational operators          passed
-● Disallow passing of children as props                               passed
-● Disallow React to be incorrectly marked as unused                   passed
-● Disallow reassigning \`const\` variables                              passed
-● Disallow the use of \`debugger\`                                      passed
-● Disallow the use of undeclared variables unless mentioned in        passed
-  \`/*global */\` comments
-● Disallow undeclared variables in JSX                                passed
-● Disallow unescaped HTML entities from appearing in markup           passed
-● Disallow usage of deprecated methods                                passed
-● Disallow usage of findDOMNode                                       passed
-● Disallow usage of isMounted                                         passed
-● Disallow usage of the return value of ReactDOM.render               passed
-● Disallow usage of unknown DOM property                              passed
-● Disallow use of optional chaining in contexts where the             passed
-  \`undefined\` value is not allowed
-● Disallow using Object.assign with an object literal as the first    passed
-  argument and prefer the use of object spread instead
-● Disallow using string references                                    passed
-● Disallow variables used in JSX to be incorrectly marked as unused   passed
-● Disallow when a DOM element is using both children and              passed
-  dangerouslySetInnerHTML
-● Enforce a maximum number of lines per file                          passed
-● Enforce camelcase naming convention                                 passed
-● Enforce comparing \`typeof\` expressions against valid strings        passed
-● Enforce consistent brace style for all control statements           passed
-● Enforce ES5 or ES6 class for returning value in render function     passed
-● enforces the Rules of Hooks                                         passed
-● Require \`let\` or \`const\` instead of \`var\`                           passed
-● Require calls to \`isNaN()\` when checking for \`NaN\`                  passed
-● Require or disallow \\"Yoda\\" conditions                               passed
-● Require using arrow functions for callbacks                         passed
-
-
-Lighthouse audits
-
-● First Contentful Paint                                              1.2 s
-● Largest Contentful Paint                                            1.5 s
-● Speed Index                                                         1.2 s
-● Cumulative Layout Shift                                             0
-● Total Blocking Time                                                 0 ms
-
-
-Made with ❤ by code-pushup.dev
-"
-`;
-
-exports[`report-to-stdout > should not contain category sections when categories are empty 1`] = `
+exports[`generateStdoutSummary > should not contain category section when categories are empty 1`] = `
 "Code PushUp Report - @code-pushup/core@0.0.1
 
 

--- a/packages/utils/src/lib/reports/generate-md-report.integration.test.ts
+++ b/packages/utils/src/lib/reports/generate-md-report.integration.test.ts
@@ -4,7 +4,7 @@ import { generateMdReport } from './generate-md-report';
 import { scoreReport } from './scoring';
 import { sortReport } from './sorting';
 
-describe('report-to-md', () => {
+describe('generateMdReport', () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2021-09-15'));

--- a/packages/utils/src/lib/reports/generate-stdout-summary.integration.test.ts
+++ b/packages/utils/src/lib/reports/generate-stdout-summary.integration.test.ts
@@ -4,7 +4,7 @@ import { generateStdoutSummary } from './generate-stdout-summary';
 import { scoreReport } from './scoring';
 import { sortReport } from './sorting';
 
-describe('report-to-stdout', () => {
+describe('generateStdoutSummary', () => {
   it('should contain all sections when using the fixture report', () => {
     const logOutput = generateStdoutSummary(
       sortReport(scoreReport(reportMock())),


### PR DESCRIPTION
For some reason, an extra snapshot was generated for the `stdout` summary integration test.
I fixed that along with updating the name of the test suites based on updated function names.