### PR TITLE
test(utils): adapt to different process stdout behaviour

### DIFF
--- a/packages/utils/src/lib/execute-process.unit.test.ts
+++ b/packages/utils/src/lib/execute-process.unit.test.ts
@@ -20,7 +20,9 @@ describe('executeProcess', () => {
       args: ['-v'],
       observer: spyObserver,
     });
-    expect(spyObserver.onStdout).toHaveBeenCalledTimes(1);
+
+    // Note: called once or twice depending on environment (2nd time for a new line)
+    expect(spyObserver.onStdout).toHaveBeenCalled();
     expect(spyObserver.onComplete).toHaveBeenCalledTimes(1);
     expect(spyObserver.onError).toHaveBeenCalledTimes(0);
     expect(processResult.stdout).toMatch(/v\d{1,2}(\.\d{1,2}){0,2}/);


### PR DESCRIPTION
The `executeProcess` test was flaky due to environment-specific behaviour (pipelines vs local setup) where the `onStdout` spy was called once or twice (second call being with empty new line, see [here](https://github.com/code-pushup/cli/actions/runs/7785559898/job/21228444707)).

As a solution I removed the part of assertion demanding how many times the observer was called, leaving that it was called at least once and what its final value is. I think this is sufficient.