### PR TITLE
chore(examples-plugins): increase lighthouse example plugin timeout

### DIFF
--- a/examples/plugins/src/lighthouse/src/lighthouse.plugin.integration.test.ts
+++ b/examples/plugins/src/lighthouse/src/lighthouse.plugin.integration.test.ts
@@ -100,6 +100,7 @@ describe('lighthouse-create-export-execution', () => {
       MEMFS_VOLUME,
     );
   });
+
   it('should return PluginConfig that executes correctly', async () => {
     const pluginConfig = await create({ url: LIGHTHOUSE_URL });
     await expect(executePlugin(pluginConfig)).resolves.toMatchObject(
@@ -128,7 +129,7 @@ describe('lighthouse-create-export-execution', () => {
     expect(auditOutputs).toHaveLength(1);
     expect(auditOutputs[0]?.slug).toBe('largest-contentful-paint');
   });
-}, 30_000);
+}, 40_000);
 
 describe('lighthouse-audits-export', () => {
   it.each(audits.map(a => [a.slug, a]))(


### PR DESCRIPTION
Currently, the pipelines are failing due to a very long lasting integration test (locally it takes roughly 25 seconds).
In this PR, I increased this timeout for windows pipelines which are known to take even longer.

A follow-up issue has been created to reduce the base test time. #490 

![image](https://github.com/code-pushup/cli/assets/6306671/eb09e3ea-c764-413c-9cfa-acbb007b575c)
