### PR TITLE
refactor(models): import material icons from different package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@code-pushup/cli-source",
-  "version": "0.16.5",
+  "version": "0.16.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@code-pushup/cli-source",
-      "version": "0.16.5",
+      "version": "0.16.7",
       "license": "MIT",
       "dependencies": {
         "@code-pushup/portal-client": "^0.5.0",
@@ -19,6 +19,7 @@
         "multi-progress-bars": "^5.0.3",
         "parse-lcov": "^1.0.4",
         "simple-git": "^3.20.0",
+        "vscode-material-icons": "^0.1.0",
         "yargs": "^17.7.2",
         "zod": "^3.22.4"
       },
@@ -22444,6 +22445,11 @@
           "optional": true
         }
       }
+    },
+    "node_modules/vscode-material-icons": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-material-icons/-/vscode-material-icons-0.1.0.tgz",
+      "integrity": "sha512-/fO1x+6JTg6QMB4W8VsIY5vwJEe/vELIg49yGIV2NLDrmLRr2nuyGo/IMMngkxu/ol4s8uQhwHFHTpdoyP6U5g=="
     },
     "node_modules/w3c-xmlserializer": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "multi-progress-bars": "^5.0.3",
     "parse-lcov": "^1.0.4",
     "simple-git": "^3.20.0",
+    "vscode-material-icons": "^0.1.0",
     "yargs": "^17.7.2",
     "zod": "^3.22.4"
   },

--- a/packages/models/package.json
+++ b/packages/models/package.json
@@ -4,6 +4,6 @@
   "license": "MIT",
   "dependencies": {
     "zod": "^3.22.1",
-    "@code-pushup/portal-client": "^0.5.0"
+    "vscode-material-icons": "^0.1.0"
   }
 }

--- a/packages/models/src/index.ts
+++ b/packages/models/src/index.ts
@@ -34,6 +34,7 @@ export {
   MAX_TITLE_LENGTH,
 } from './lib/implementation/limits';
 export {
+  MaterialIcon,
   fileNameSchema,
   filePathSchema,
   materialIconSchema,

--- a/packages/models/src/lib/implementation/schemas.ts
+++ b/packages/models/src/lib/implementation/schemas.ts
@@ -1,5 +1,5 @@
+import { MATERIAL_ICONS } from 'vscode-material-icons';
 import { ZodObject, ZodOptional, ZodString, z } from 'zod';
-import { MATERIAL_ICONS, MaterialIcon } from '@code-pushup/portal-client';
 import {
   MAX_DESCRIPTION_LENGTH,
   MAX_SLUG_LENGTH,
@@ -207,10 +207,10 @@ export function scorableSchema<T extends ReturnType<typeof weightedRefSchema>>(
   );
 }
 
-export const materialIconSchema = z.enum(
-  MATERIAL_ICONS as [MaterialIcon, MaterialIcon, ...MaterialIcon[]],
-  { description: 'Icon from VSCode Material Icons extension' },
-);
+export const materialIconSchema = z.enum(MATERIAL_ICONS, {
+  description: 'Icon from VSCode Material Icons extension',
+});
+export type MaterialIcon = z.infer<typeof materialIconSchema>;
 
 type Ref = { weight: number };
 


### PR DESCRIPTION
Pre-requisite for:
- #474 

Since we want to import `@code-pushup/portal-client` dynamically for uploads only, then we can no longer use it for validating material icons in plugin metadata. So I extracted it to a different package.

Package links:
- [NPM](https://www.npmjs.com/package/vscode-material-icons)
- [GitHub](https://github.com/matejchalk/vscode-material-icons)