### PR TITLE
test(cli-e2e): fix uninstallation of dependencies in E2E teardown

### DIFF
--- a/global-setup.e2e.ts
+++ b/global-setup.e2e.ts
@@ -17,6 +17,6 @@ export async function teardown() {
   stopLocalRegistry();
   execSync('npm uninstall @code-pushup/cli');
   execSync('npm uninstall @code-pushup/eslint-plugin');
-  execSync('npm uninstall @code-pushup/coverage-plugin@e2e');
+  execSync('npm uninstall @code-pushup/coverage-plugin');
   await teardownTestFolder('tmp');
 }


### PR DESCRIPTION
In this PR, I fix the uninstallation step after E2E are run. Until now, the dependencies stayed in `node_modules` which broke running subsequent test (`@code-pushup/...` was used from the node modules instead of from dist I believe).

By omitting the `@e2e` during uninstall, all dependencies are now correctly uninstalled.