### PR TITLE
feat(core): make all issue file paths relative to git root after executing plugin

### DIFF
--- a/e2e/cli-e2e/tests/__snapshots__/collect.e2e.test.ts.snap
+++ b/e2e/cli-e2e/tests/__snapshots__/collect.e2e.test.ts.snap
@@ -469,7 +469,7 @@ exports[`CLI collect > should run ESLint plugin and create report.json 1`] = `
                 "message": "'loading' is assigned a value but never used.",
                 "severity": "warning",
                 "source": {
-                  "file": "src/App.jsx",
+                  "file": "examples/react-todos-app/src/App.jsx",
                   "position": {
                     "endColumn": 18,
                     "endLine": 8,
@@ -519,7 +519,7 @@ exports[`CLI collect > should run ESLint plugin and create report.json 1`] = `
                 "message": "Unexpected block statement surrounding arrow body; move the returned value immediately after the \`=>\`.",
                 "severity": "warning",
                 "source": {
-                  "file": "src/components/TodoFilter.jsx",
+                  "file": "examples/react-todos-app/src/components/TodoFilter.jsx",
                   "position": {
                     "endColumn": 2,
                     "endLine": 25,
@@ -569,7 +569,7 @@ exports[`CLI collect > should run ESLint plugin and create report.json 1`] = `
                 "message": "Expected '===' and instead saw '=='.",
                 "severity": "warning",
                 "source": {
-                  "file": "src/hooks/useTodos.js",
+                  "file": "examples/react-todos-app/src/hooks/useTodos.js",
                   "position": {
                     "endColumn": 43,
                     "endLine": 41,
@@ -595,7 +595,7 @@ exports[`CLI collect > should run ESLint plugin and create report.json 1`] = `
                 "message": "Arrow function has too many lines (71). Maximum allowed is 50.",
                 "severity": "warning",
                 "source": {
-                  "file": "src/hooks/useTodos.js",
+                  "file": "examples/react-todos-app/src/hooks/useTodos.js",
                   "position": {
                     "endColumn": 2,
                     "endLine": 73,
@@ -633,7 +633,7 @@ exports[`CLI collect > should run ESLint plugin and create report.json 1`] = `
                 "message": "'data' is already declared in the upper scope on line 5 column 10.",
                 "severity": "warning",
                 "source": {
-                  "file": "src/hooks/useTodos.js",
+                  "file": "examples/react-todos-app/src/hooks/useTodos.js",
                   "position": {
                     "endColumn": 17,
                     "endLine": 11,
@@ -646,7 +646,7 @@ exports[`CLI collect > should run ESLint plugin and create report.json 1`] = `
                 "message": "'data' is already declared in the upper scope on line 5 column 10.",
                 "severity": "warning",
                 "source": {
-                  "file": "src/hooks/useTodos.js",
+                  "file": "examples/react-todos-app/src/hooks/useTodos.js",
                   "position": {
                     "endColumn": 21,
                     "endLine": 29,
@@ -659,7 +659,7 @@ exports[`CLI collect > should run ESLint plugin and create report.json 1`] = `
                 "message": "'data' is already declared in the upper scope on line 5 column 10.",
                 "severity": "warning",
                 "source": {
-                  "file": "src/hooks/useTodos.js",
+                  "file": "examples/react-todos-app/src/hooks/useTodos.js",
                   "position": {
                     "endColumn": 17,
                     "endLine": 41,
@@ -697,7 +697,7 @@ exports[`CLI collect > should run ESLint plugin and create report.json 1`] = `
                 "message": "Expected property shorthand.",
                 "severity": "warning",
                 "source": {
-                  "file": "src/hooks/useTodos.js",
+                  "file": "examples/react-todos-app/src/hooks/useTodos.js",
                   "position": {
                     "endColumn": 19,
                     "endLine": 19,
@@ -710,7 +710,7 @@ exports[`CLI collect > should run ESLint plugin and create report.json 1`] = `
                 "message": "Expected property shorthand.",
                 "severity": "warning",
                 "source": {
-                  "file": "src/hooks/useTodos.js",
+                  "file": "examples/react-todos-app/src/hooks/useTodos.js",
                   "position": {
                     "endColumn": 19,
                     "endLine": 32,
@@ -723,7 +723,7 @@ exports[`CLI collect > should run ESLint plugin and create report.json 1`] = `
                 "message": "Expected property shorthand.",
                 "severity": "warning",
                 "source": {
-                  "file": "src/hooks/useTodos.js",
+                  "file": "examples/react-todos-app/src/hooks/useTodos.js",
                   "position": {
                     "endColumn": 25,
                     "endLine": 33,
@@ -761,7 +761,7 @@ exports[`CLI collect > should run ESLint plugin and create report.json 1`] = `
                 "message": "'root' is never reassigned. Use 'const' instead.",
                 "severity": "warning",
                 "source": {
-                  "file": "src/index.jsx",
+                  "file": "examples/react-todos-app/src/index.jsx",
                   "position": {
                     "endColumn": 9,
                     "endLine": 5,
@@ -811,7 +811,7 @@ exports[`CLI collect > should run ESLint plugin and create report.json 1`] = `
                 "message": "Missing \\"key\\" prop for element in iterator",
                 "severity": "warning",
                 "source": {
-                  "file": "src/components/TodoList.jsx",
+                  "file": "examples/react-todos-app/src/components/TodoList.jsx",
                   "position": {
                     "endColumn": 12,
                     "endLine": 28,
@@ -837,7 +837,7 @@ exports[`CLI collect > should run ESLint plugin and create report.json 1`] = `
                 "message": "'onCreate' is missing in props validation",
                 "severity": "warning",
                 "source": {
-                  "file": "src/components/CreateTodo.jsx",
+                  "file": "examples/react-todos-app/src/components/CreateTodo.jsx",
                   "position": {
                     "endColumn": 23,
                     "endLine": 15,
@@ -850,7 +850,7 @@ exports[`CLI collect > should run ESLint plugin and create report.json 1`] = `
                 "message": "'setQuery' is missing in props validation",
                 "severity": "warning",
                 "source": {
-                  "file": "src/components/TodoFilter.jsx",
+                  "file": "examples/react-todos-app/src/components/TodoFilter.jsx",
                   "position": {
                     "endColumn": 25,
                     "endLine": 10,
@@ -863,7 +863,7 @@ exports[`CLI collect > should run ESLint plugin and create report.json 1`] = `
                 "message": "'setHideComplete' is missing in props validation",
                 "severity": "warning",
                 "source": {
-                  "file": "src/components/TodoFilter.jsx",
+                  "file": "examples/react-todos-app/src/components/TodoFilter.jsx",
                   "position": {
                     "endColumn": 34,
                     "endLine": 18,
@@ -876,7 +876,7 @@ exports[`CLI collect > should run ESLint plugin and create report.json 1`] = `
                 "message": "'todos' is missing in props validation",
                 "severity": "warning",
                 "source": {
-                  "file": "src/components/TodoList.jsx",
+                  "file": "examples/react-todos-app/src/components/TodoList.jsx",
                   "position": {
                     "endColumn": 17,
                     "endLine": 6,
@@ -889,7 +889,7 @@ exports[`CLI collect > should run ESLint plugin and create report.json 1`] = `
                 "message": "'todos.map' is missing in props validation",
                 "severity": "warning",
                 "source": {
-                  "file": "src/components/TodoList.jsx",
+                  "file": "examples/react-todos-app/src/components/TodoList.jsx",
                   "position": {
                     "endColumn": 21,
                     "endLine": 6,
@@ -902,7 +902,7 @@ exports[`CLI collect > should run ESLint plugin and create report.json 1`] = `
                 "message": "'onEdit' is missing in props validation",
                 "severity": "warning",
                 "source": {
-                  "file": "src/components/TodoList.jsx",
+                  "file": "examples/react-todos-app/src/components/TodoList.jsx",
                   "position": {
                     "endColumn": 27,
                     "endLine": 13,
@@ -952,7 +952,7 @@ exports[`CLI collect > should run ESLint plugin and create report.json 1`] = `
                 "message": "React Hook useCallback does nothing when called with only one argument. Did you forget to pass an array of dependencies?",
                 "severity": "warning",
                 "source": {
-                  "file": "src/hooks/useTodos.js",
+                  "file": "examples/react-todos-app/src/hooks/useTodos.js",
                   "position": {
                     "endColumn": 31,
                     "endLine": 17,
@@ -965,7 +965,7 @@ exports[`CLI collect > should run ESLint plugin and create report.json 1`] = `
                 "message": "React Hook useCallback does nothing when called with only one argument. Did you forget to pass an array of dependencies?",
                 "severity": "warning",
                 "source": {
-                  "file": "src/hooks/useTodos.js",
+                  "file": "examples/react-todos-app/src/hooks/useTodos.js",
                   "position": {
                     "endColumn": 29,
                     "endLine": 40,

--- a/examples/plugins/vite.config.integration.ts
+++ b/examples/plugins/vite.config.integration.ts
@@ -18,6 +18,7 @@ export default defineConfig({
     globalSetup: ['global-setup.ts'],
     setupFiles: [
       '../../testing-utils/src/lib/setup/fs.mock.ts',
+      '../../testing-utils/src/lib/setup/git.mock.ts',
       '../../testing-utils/src/lib/setup/console.mock.ts',
       '../../testing-utils/src/lib/setup/reset.mocks.ts',
     ],

--- a/examples/plugins/vite.config.unit.ts
+++ b/examples/plugins/vite.config.unit.ts
@@ -18,6 +18,7 @@ export default defineConfig({
     globalSetup: ['global-setup.ts'],
     setupFiles: [
       '../../testing-utils/src/lib/setup/fs.mock.ts',
+      '../../testing-utils/src/lib/setup/git.mock.ts',
       '../../testing-utils/src/lib/setup/console.mock.ts',
       '../../testing-utils/src/lib/setup/reset.mocks.ts',
     ],

--- a/examples/react-todos-app/project.json
+++ b/examples/react-todos-app/project.json
@@ -51,6 +51,19 @@
           "buildTarget": "react-todos-app:build:production"
         }
       }
+    },
+    "run-collect": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "npx ../../dist/packages/cli collect --no-progress",
+        "cwd": "examples/react-todos-app"
+      },
+      "dependsOn": [
+        {
+          "projects": ["cli", "plugin-eslint"],
+          "target": "build"
+        }
+      ]
     }
   },
   "tags": ["scope:internal", "type:app"]

--- a/packages/cli/docs/custom-plugins.md
+++ b/packages/cli/docs/custom-plugins.md
@@ -495,7 +495,7 @@ We will extend the `fileSizeAuditOutput` with `details` show which files exceed 
 // file-size.plugin.ts
 // ...
 import { basename } from 'path';
-import { formatBytes, toUnixPath } from '@code-pushup/utils';
+import { formatBytes } from '@code-pushup/utils';
 import { AuditOutput } from './plugin-process-output';
 
 async function runnerFunction(options: Options): Promise<AuditOutputs> {
@@ -521,8 +521,7 @@ async function runnerFunction(options: Options): Promise<AuditOutputs> {
 export function assertFileSize(file: string, size: number, budget?: number): Issue {
   const auditOutputBase = {
     source: {
-      // format path to be in scope of the repository
-      file: toUnixPath(file, { toRelative: true }),
+      file,
     },
   } satisfies AuditOutput['source'];
 

--- a/packages/cli/vite.config.unit.ts
+++ b/packages/cli/vite.config.unit.ts
@@ -18,6 +18,7 @@ export default defineConfig({
     globalSetup: ['global-setup.ts'],
     setupFiles: [
       '../../testing-utils/src/lib/setup/fs.mock.ts',
+      '../../testing-utils/src/lib/setup/git.mock.ts',
       '../../testing-utils/src/lib/setup/console.mock.ts',
       '../../testing-utils/src/lib/setup/portal-client.mock.ts',
       '../../testing-utils/src/lib/setup/reset.mocks.ts',

--- a/packages/core/src/lib/implementation/execute-plugin.ts
+++ b/packages/core/src/lib/implementation/execute-plugin.ts
@@ -14,6 +14,7 @@ import {
   groupByStatus,
   logMultipleResults,
 } from '@code-pushup/utils';
+import { normalizeAuditOutputs } from '../normalize';
 import { executeRunnerConfig, executeRunnerFunction } from './runner';
 
 /**
@@ -71,8 +72,10 @@ export async function executePlugin(
   const auditOutputs = auditOutputsSchema.parse(unvalidatedAuditOutputs);
   auditOutputsCorrelateWithPluginOutput(auditOutputs, pluginConfigAudits);
 
+  const normalizedAuditOutputs = await normalizeAuditOutputs(auditOutputs);
+
   // enrich `AuditOutputs` to `AuditReport`
-  const auditReports: AuditReport[] = auditOutputs.map(
+  const auditReports: AuditReport[] = normalizedAuditOutputs.map(
     (auditOutput: AuditOutput) => ({
       ...auditOutput,
       ...(pluginConfigAudits.find(

--- a/packages/core/src/lib/normalize.ts
+++ b/packages/core/src/lib/normalize.ts
@@ -1,15 +1,51 @@
 import {
+  type AuditOutputs,
   PERSIST_FILENAME,
   PERSIST_FORMAT,
   PERSIST_OUTPUT_DIR,
   PersistConfig,
 } from '@code-pushup/models';
+import { formatGitPath, getGitRoot } from '@code-pushup/utils';
 
-export const normalizePersistConfig = (
+export function normalizePersistConfig(
   cfg?: Partial<PersistConfig>,
-): Required<PersistConfig> => ({
-  outputDir: PERSIST_OUTPUT_DIR,
-  filename: PERSIST_FILENAME,
-  format: PERSIST_FORMAT,
-  ...cfg,
-});
+): Required<PersistConfig> {
+  return {
+    outputDir: PERSIST_OUTPUT_DIR,
+    filename: PERSIST_FILENAME,
+    format: PERSIST_FORMAT,
+    ...cfg,
+  };
+}
+
+export async function normalizeAuditOutputs(
+  audits: AuditOutputs,
+): Promise<AuditOutputs> {
+  const gitRoot = await getGitRoot();
+
+  return audits.map(audit => {
+    if (
+      audit.details?.issues == null ||
+      audit.details.issues.every(issue => issue.source == null)
+    ) {
+      return audit;
+    }
+    return {
+      ...audit,
+      details: {
+        ...audit.details,
+        issues: audit.details.issues.map(issue =>
+          issue.source == null
+            ? issue
+            : {
+                ...issue,
+                source: {
+                  ...issue.source,
+                  file: formatGitPath(issue.source.file, gitRoot),
+                },
+              },
+        ),
+      },
+    };
+  });
+}

--- a/packages/core/vite.config.unit.ts
+++ b/packages/core/vite.config.unit.ts
@@ -18,6 +18,7 @@ export default defineConfig({
     globalSetup: ['global-setup.ts'],
     setupFiles: [
       '../../testing-utils/src/lib/setup/fs.mock.ts',
+      '../../testing-utils/src/lib/setup/git.mock.ts',
       '../../testing-utils/src/lib/setup/console.mock.ts',
       '../../testing-utils/src/lib/setup/reset.mocks.ts',
       '../../testing-utils/src/lib/setup/portal-client.mock.ts',

--- a/packages/plugin-coverage/src/lib/runner/lcov/lcov-runner.integration.test.ts
+++ b/packages/plugin-coverage/src/lib/runner/lcov/lcov-runner.integration.test.ts
@@ -1,6 +1,7 @@
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, it } from 'vitest';
+import { osAgnosticAuditOutputs } from '@code-pushup/testing-utils';
 import { lcovResultsToAuditOutputs } from './lcov-runner';
 
 describe('lcovResultsToAuditOutputs', () => {
@@ -23,11 +24,11 @@ describe('lcovResultsToAuditOutputs', () => {
             'mocks',
             'single-record-lcov.info',
           ),
-          pathToProject: join('packages', 'cli'),
+          pathToProject: 'packages/cli',
         },
       ],
       ['branch', 'function', 'line'],
     );
-    expect(results).toMatchSnapshot();
+    expect(osAgnosticAuditOutputs(results)).toMatchSnapshot();
   });
 });

--- a/packages/plugin-coverage/src/lib/runner/lcov/transform.ts
+++ b/packages/plugin-coverage/src/lib/runner/lcov/transform.ts
@@ -1,6 +1,6 @@
 import { LCOVRecord } from 'parse-lcov';
 import { AuditOutput, Issue } from '@code-pushup/models';
-import { toNumberPrecision, toOrdinal, toUnixPath } from '@code-pushup/utils';
+import { toNumberPrecision, toOrdinal } from '@code-pushup/utils';
 import { CoverageType } from '../../config';
 import { LCOVStat } from './types';
 import { calculateCoverage, mergeConsecutiveNumbers } from './utils';
@@ -18,7 +18,7 @@ export function lcovReportToFunctionStat(record: LCOVRecord): LCOVStat {
                 message: `Function ${detail.name} is not called in any test case.`,
                 severity: 'error',
                 source: {
-                  file: toUnixPath(record.file),
+                  file: record.file,
                   position: { startLine: detail.line },
                 },
               }),
@@ -51,7 +51,7 @@ export function lcovReportToLineStat(record: LCOVRecord): LCOVStat {
             message: `${lineReference} not covered in any test case.`,
             severity: 'warning',
             source: {
-              file: toUnixPath(record.file),
+              file: record.file,
               position: {
                 startLine: linePosition.start,
                 endLine: linePosition.end,
@@ -78,7 +78,7 @@ export function lcovReportToBranchStat(record: LCOVRecord): LCOVStat {
                 )} branch is not taken in any test case.`,
                 severity: 'error',
                 source: {
-                  file: toUnixPath(record.file),
+                  file: record.file,
                   position: { startLine: detail.line },
                 },
               }),

--- a/packages/plugin-eslint/src/lib/__snapshots__/runner.integration.test.ts.snap
+++ b/packages/plugin-eslint/src/lib/__snapshots__/runner.integration.test.ts.snap
@@ -81,7 +81,7 @@ exports[`executeRunner > should execute ESLint and create audit results for Reac
           "message": "'loading' is assigned a value but never used.",
           "severity": "warning",
           "source": {
-            "file": "src/App.jsx",
+            "file": "<CWD>/src/App.jsx",
             "position": {
               "endColumn": 18,
               "endLine": 8,
@@ -122,7 +122,7 @@ exports[`executeRunner > should execute ESLint and create audit results for Reac
           "message": "Unexpected block statement surrounding arrow body; move the returned value immediately after the \`=>\`.",
           "severity": "warning",
           "source": {
-            "file": "src/components/TodoFilter.jsx",
+            "file": "<CWD>/src/components/TodoFilter.jsx",
             "position": {
               "endColumn": 2,
               "endLine": 25,
@@ -163,7 +163,7 @@ exports[`executeRunner > should execute ESLint and create audit results for Reac
           "message": "Expected '===' and instead saw '=='.",
           "severity": "warning",
           "source": {
-            "file": "src/hooks/useTodos.js",
+            "file": "<CWD>/src/hooks/useTodos.js",
             "position": {
               "endColumn": 43,
               "endLine": 41,
@@ -186,7 +186,7 @@ exports[`executeRunner > should execute ESLint and create audit results for Reac
           "message": "Arrow function has too many lines (71). Maximum allowed is 50.",
           "severity": "warning",
           "source": {
-            "file": "src/hooks/useTodos.js",
+            "file": "<CWD>/src/hooks/useTodos.js",
             "position": {
               "endColumn": 2,
               "endLine": 73,
@@ -218,7 +218,7 @@ exports[`executeRunner > should execute ESLint and create audit results for Reac
           "message": "'data' is already declared in the upper scope on line 5 column 10.",
           "severity": "warning",
           "source": {
-            "file": "src/hooks/useTodos.js",
+            "file": "<CWD>/src/hooks/useTodos.js",
             "position": {
               "endColumn": 17,
               "endLine": 11,
@@ -231,7 +231,7 @@ exports[`executeRunner > should execute ESLint and create audit results for Reac
           "message": "'data' is already declared in the upper scope on line 5 column 10.",
           "severity": "warning",
           "source": {
-            "file": "src/hooks/useTodos.js",
+            "file": "<CWD>/src/hooks/useTodos.js",
             "position": {
               "endColumn": 21,
               "endLine": 29,
@@ -244,7 +244,7 @@ exports[`executeRunner > should execute ESLint and create audit results for Reac
           "message": "'data' is already declared in the upper scope on line 5 column 10.",
           "severity": "warning",
           "source": {
-            "file": "src/hooks/useTodos.js",
+            "file": "<CWD>/src/hooks/useTodos.js",
             "position": {
               "endColumn": 17,
               "endLine": 41,
@@ -276,7 +276,7 @@ exports[`executeRunner > should execute ESLint and create audit results for Reac
           "message": "Expected property shorthand.",
           "severity": "warning",
           "source": {
-            "file": "src/hooks/useTodos.js",
+            "file": "<CWD>/src/hooks/useTodos.js",
             "position": {
               "endColumn": 19,
               "endLine": 19,
@@ -289,7 +289,7 @@ exports[`executeRunner > should execute ESLint and create audit results for Reac
           "message": "Expected property shorthand.",
           "severity": "warning",
           "source": {
-            "file": "src/hooks/useTodos.js",
+            "file": "<CWD>/src/hooks/useTodos.js",
             "position": {
               "endColumn": 19,
               "endLine": 32,
@@ -302,7 +302,7 @@ exports[`executeRunner > should execute ESLint and create audit results for Reac
           "message": "Expected property shorthand.",
           "severity": "warning",
           "source": {
-            "file": "src/hooks/useTodos.js",
+            "file": "<CWD>/src/hooks/useTodos.js",
             "position": {
               "endColumn": 25,
               "endLine": 33,
@@ -334,7 +334,7 @@ exports[`executeRunner > should execute ESLint and create audit results for Reac
           "message": "'root' is never reassigned. Use 'const' instead.",
           "severity": "warning",
           "source": {
-            "file": "src/index.jsx",
+            "file": "<CWD>/src/index.jsx",
             "position": {
               "endColumn": 9,
               "endLine": 5,
@@ -375,7 +375,7 @@ exports[`executeRunner > should execute ESLint and create audit results for Reac
           "message": "Missing \\"key\\" prop for element in iterator",
           "severity": "warning",
           "source": {
-            "file": "src/components/TodoList.jsx",
+            "file": "<CWD>/src/components/TodoList.jsx",
             "position": {
               "endColumn": 12,
               "endLine": 28,
@@ -398,7 +398,7 @@ exports[`executeRunner > should execute ESLint and create audit results for Reac
           "message": "'onCreate' is missing in props validation",
           "severity": "warning",
           "source": {
-            "file": "src/components/CreateTodo.jsx",
+            "file": "<CWD>/src/components/CreateTodo.jsx",
             "position": {
               "endColumn": 23,
               "endLine": 15,
@@ -411,7 +411,7 @@ exports[`executeRunner > should execute ESLint and create audit results for Reac
           "message": "'setQuery' is missing in props validation",
           "severity": "warning",
           "source": {
-            "file": "src/components/TodoFilter.jsx",
+            "file": "<CWD>/src/components/TodoFilter.jsx",
             "position": {
               "endColumn": 25,
               "endLine": 10,
@@ -424,7 +424,7 @@ exports[`executeRunner > should execute ESLint and create audit results for Reac
           "message": "'setHideComplete' is missing in props validation",
           "severity": "warning",
           "source": {
-            "file": "src/components/TodoFilter.jsx",
+            "file": "<CWD>/src/components/TodoFilter.jsx",
             "position": {
               "endColumn": 34,
               "endLine": 18,
@@ -437,7 +437,7 @@ exports[`executeRunner > should execute ESLint and create audit results for Reac
           "message": "'todos' is missing in props validation",
           "severity": "warning",
           "source": {
-            "file": "src/components/TodoList.jsx",
+            "file": "<CWD>/src/components/TodoList.jsx",
             "position": {
               "endColumn": 17,
               "endLine": 6,
@@ -450,7 +450,7 @@ exports[`executeRunner > should execute ESLint and create audit results for Reac
           "message": "'todos.map' is missing in props validation",
           "severity": "warning",
           "source": {
-            "file": "src/components/TodoList.jsx",
+            "file": "<CWD>/src/components/TodoList.jsx",
             "position": {
               "endColumn": 21,
               "endLine": 6,
@@ -463,7 +463,7 @@ exports[`executeRunner > should execute ESLint and create audit results for Reac
           "message": "'onEdit' is missing in props validation",
           "severity": "warning",
           "source": {
-            "file": "src/components/TodoList.jsx",
+            "file": "<CWD>/src/components/TodoList.jsx",
             "position": {
               "endColumn": 27,
               "endLine": 13,
@@ -504,7 +504,7 @@ exports[`executeRunner > should execute ESLint and create audit results for Reac
           "message": "React Hook useCallback does nothing when called with only one argument. Did you forget to pass an array of dependencies?",
           "severity": "warning",
           "source": {
-            "file": "src/hooks/useTodos.js",
+            "file": "<CWD>/src/hooks/useTodos.js",
             "position": {
               "endColumn": 31,
               "endLine": 17,
@@ -517,7 +517,7 @@ exports[`executeRunner > should execute ESLint and create audit results for Reac
           "message": "React Hook useCallback does nothing when called with only one argument. Did you forget to pass an array of dependencies?",
           "severity": "warning",
           "source": {
-            "file": "src/hooks/useTodos.js",
+            "file": "<CWD>/src/hooks/useTodos.js",
             "position": {
               "endColumn": 29,
               "endLine": 40,

--- a/packages/plugin-eslint/src/lib/runner.integration.test.ts
+++ b/packages/plugin-eslint/src/lib/runner.integration.test.ts
@@ -4,7 +4,8 @@ import os from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { SpyInstance, describe, expect, it } from 'vitest';
-import type { AuditOutput, Issue } from '@code-pushup/models';
+import type { AuditOutput, AuditOutputs, Issue } from '@code-pushup/models';
+import { osAgnosticAuditOutputs } from '@code-pushup/testing-utils';
 import { readJsonFile } from '@code-pushup/utils';
 import { listAuditsAndGroups } from './meta';
 import {
@@ -32,15 +33,16 @@ describe('executeRunner', () => {
     return [runnerConfig.command, ...(runnerConfig.args ?? [])];
   };
 
+  const appDir = join(
+    fileURLToPath(dirname(import.meta.url)),
+    '..',
+    '..',
+    'mocks',
+    'fixtures',
+    'todos-app',
+  );
+
   beforeAll(async () => {
-    const appDir = join(
-      fileURLToPath(dirname(import.meta.url)),
-      '..',
-      '..',
-      'mocks',
-      'fixtures',
-      'todos-app',
-    );
     cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(appDir);
     // Windows does not require additional quotation marks for globs
     platformSpy = vi.spyOn(os, 'platform').mockReturnValue('win32');
@@ -64,8 +66,8 @@ describe('executeRunner', () => {
 
     await executeRunner(argv);
 
-    const json = await readJsonFile(RUNNER_OUTPUT_PATH);
-    expect(json).toMatchSnapshot();
+    const json = await readJsonFile<AuditOutputs>(RUNNER_OUTPUT_PATH);
+    expect(osAgnosticAuditOutputs(json)).toMatchSnapshot();
   });
 
   it('should execute runner with inline config using @code-pushup/eslint-config', async () => {
@@ -86,7 +88,7 @@ describe('executeRunner', () => {
               message:
                 'Filename is not in kebab case. Rename it to `use-todos.js`.',
               source: expect.objectContaining({
-                file: 'src/hooks/useTodos.js',
+                file: join(appDir, 'src', 'hooks', 'useTodos.js'),
               } satisfies Partial<Issue['source']>),
             } satisfies Issue,
           ]),

--- a/packages/plugin-eslint/src/lib/runner/lint.ts
+++ b/packages/plugin-eslint/src/lib/runner/lint.ts
@@ -1,8 +1,8 @@
 import type { Linter } from 'eslint';
-import { distinct, toArray, toUnixPath } from '@code-pushup/utils';
+import { distinct, toArray } from '@code-pushup/utils';
 import { ESLintPluginConfig } from '../config';
 import { setupESLint } from '../setup';
-import type { LintResult, LinterOutput, RuleOptionsPerFile } from './types';
+import type { LinterOutput, RuleOptionsPerFile } from './types';
 
 export async function lint({
   eslintrc,
@@ -10,16 +10,10 @@ export async function lint({
 }: ESLintPluginConfig): Promise<LinterOutput> {
   const eslint = setupESLint(eslintrc);
 
-  const lintResults = await eslint.lintFiles(patterns);
-  const results = lintResults.map(
-    (result): LintResult => ({
-      ...result,
-      relativeFilePath: toUnixPath(result.filePath, { toRelative: true }),
-    }),
-  );
+  const results = await eslint.lintFiles(patterns);
 
   const ruleOptionsPerFile = await results.reduce(
-    async (acc, { filePath, relativeFilePath, messages }) => {
+    async (acc, { filePath, messages }) => {
       const filesMap = await acc;
       const config = (await eslint.calculateConfigForFile(
         filePath,
@@ -37,8 +31,8 @@ export async function lint({
       );
       return {
         ...filesMap,
-        [relativeFilePath]: {
-          ...filesMap[relativeFilePath],
+        [filePath]: {
+          ...filesMap[filePath],
           ...rulesMap,
         },
       };

--- a/packages/plugin-eslint/src/lib/runner/lint.unit.test.ts
+++ b/packages/plugin-eslint/src/lib/runner/lint.unit.test.ts
@@ -60,30 +60,17 @@ describe('lint', () => {
     vi.clearAllMocks();
   });
 
-  it('should add relativeFilePath to each lint result', async () => {
-    const { results } = await lint(config);
-    expect(results).toEqual([
-      expect.objectContaining({ relativeFilePath: 'src/app/app.component.ts' }),
-      expect.objectContaining({
-        relativeFilePath: 'src/app/app.component.spec.ts',
-      }),
-      expect.objectContaining({
-        relativeFilePath: 'src/app/pages/settings.component.ts',
-      }),
-    ]);
-  });
-
   it('should get rule options for each file', async () => {
     const { ruleOptionsPerFile } = await lint(config);
     expect(ruleOptionsPerFile).toEqual({
-      'src/app/app.component.ts': {
+      [`${process.cwd()}/src/app/app.component.ts`]: {
         'max-lines': [500],
         '@typescript-eslint/no-explicit-any': [],
       },
-      'src/app/pages/settings.component.ts': {
+      [`${process.cwd()}/src/app/pages/settings.component.ts`]: {
         'max-lines': [500],
       },
-      'src/app/app.component.spec.ts': {
+      [`${process.cwd()}/src/app/app.component.spec.ts`]: {
         'max-lines': [800],
         '@typescript-eslint/no-explicit-any': [],
       },

--- a/packages/plugin-eslint/src/lib/runner/transform.ts
+++ b/packages/plugin-eslint/src/lib/runner/transform.ts
@@ -11,7 +11,7 @@ import { ruleIdToSlug } from '../meta/hash';
 import type { LinterOutput } from './types';
 
 type LintIssue = Linter.LintMessage & {
-  relativeFilePath: string;
+  filePath: string;
 };
 
 export function lintResultsToAudits({
@@ -19,16 +19,16 @@ export function lintResultsToAudits({
   ruleOptionsPerFile,
 }: LinterOutput): AuditOutput[] {
   const issuesPerAudit = results
-    .flatMap(({ messages, relativeFilePath }) =>
-      messages.map((message): LintIssue => ({ ...message, relativeFilePath })),
+    .flatMap(({ messages, filePath }) =>
+      messages.map((message): LintIssue => ({ ...message, filePath })),
     )
     .reduce<Record<string, LintIssue[]>>((acc, issue) => {
-      const { ruleId, message, relativeFilePath } = issue;
+      const { ruleId, message, filePath } = issue;
       if (!ruleId) {
         console.warn(`ESLint core error - ${message}`);
         return acc;
       }
-      const options = ruleOptionsPerFile[relativeFilePath]?.[ruleId] ?? [];
+      const options = ruleOptionsPerFile[filePath]?.[ruleId] ?? [];
       const auditSlug = ruleIdToSlug(ruleId, options);
       return { ...acc, [auditSlug]: [...(acc[auditSlug] ?? []), issue] };
     }, {});
@@ -63,7 +63,7 @@ function convertIssue(issue: LintIssue): Issue {
     message: truncateIssueMessage(issue.message),
     severity: convertSeverity(issue.severity),
     source: {
-      file: issue.relativeFilePath,
+      file: issue.filePath,
       position: {
         startLine: issue.line,
         startColumn: issue.column,

--- a/packages/plugin-eslint/src/lib/runner/transform.unit.test.ts
+++ b/packages/plugin-eslint/src/lib/runner/transform.unit.test.ts
@@ -1,6 +1,6 @@
+import type { ESLint } from 'eslint';
 import type { AuditOutput } from '@code-pushup/models';
 import { lintResultsToAudits } from './transform';
-import type { LintResult } from './types';
 
 describe('lintResultsToAudits', () => {
   it('should convert ESLint results with custom options to Code PushUp audits', () => {
@@ -8,8 +8,7 @@ describe('lintResultsToAudits', () => {
       lintResultsToAudits({
         results: [
           {
-            filePath: `${process.cwd()}/src/app/app.component.ts`,
-            relativeFilePath: 'src/app/app.component.ts',
+            filePath: 'src/app/app.component.ts',
             messages: [
               {
                 ruleId: 'max-lines',
@@ -40,8 +39,7 @@ describe('lintResultsToAudits', () => {
             ],
           },
           {
-            filePath: `${process.cwd()}/src/app/app.component.spec.ts`,
-            relativeFilePath: 'src/app/app.component.spec.ts',
+            filePath: 'src/app/app.component.spec.ts',
             messages: [
               {
                 ruleId: 'max-lines',
@@ -63,8 +61,7 @@ describe('lintResultsToAudits', () => {
             ],
           },
           {
-            filePath: `${process.cwd()}/src/app/pages/settings.component.ts`,
-            relativeFilePath: 'src/app/pages/settings.component.ts',
+            filePath: 'src/app/pages/settings.component.ts',
             messages: [
               {
                 ruleId: 'max-lines',
@@ -76,7 +73,7 @@ describe('lintResultsToAudits', () => {
               },
             ],
           },
-        ] as LintResult[],
+        ] as ESLint.LintResult[],
         ruleOptionsPerFile: {
           'src/app/app.component.ts': {
             'max-lines': [500],

--- a/packages/plugin-eslint/src/lib/runner/types.ts
+++ b/packages/plugin-eslint/src/lib/runner/types.ts
@@ -1,12 +1,8 @@
 import type { ESLint } from 'eslint';
 
 export type LinterOutput = {
-  results: LintResult[];
+  results: ESLint.LintResult[];
   ruleOptionsPerFile: RuleOptionsPerFile;
-};
-
-export type LintResult = ESLint.LintResult & {
-  relativeFilePath: string;
 };
 
 export type RuleOptionsPerFile = {

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -23,6 +23,10 @@ export {
   removeDirectoryIfExists,
 } from './lib/file-system';
 export {
+  filterAuditsBySlug,
+  filterGroupsByAuditSlug,
+} from './lib/filter-by-slug';
+export {
   formatBytes,
   formatDuration,
   pluralize,
@@ -33,13 +37,20 @@ export {
   truncateText,
   truncateTitle,
 } from './lib/formatting';
-export { getLatestCommit, git, validateCommitData } from './lib/git';
+export {
+  formatGitPath,
+  getGitRoot,
+  getLatestCommit,
+  toGitPath,
+  validateCommitData,
+} from './lib/git';
 export { groupByStatus } from './lib/group-by-status';
 export {
   isPromiseFulfilledResult,
   isPromiseRejectedResult,
 } from './lib/guards';
 export { logMultipleResults } from './lib/log-results';
+export { link } from './lib/logging';
 export { ProgressBar, getProgressBar } from './lib/progress';
 export { TERMINAL_WIDTH } from './lib/reports/constants';
 export { generateMdReport } from './lib/reports/generate-md-report';
@@ -71,8 +82,3 @@ export {
   toUnixPath,
 } from './lib/transform';
 export { verboseUtils } from './lib/verbose-utils';
-export { link } from './lib/logging';
-export {
-  filterAuditsBySlug,
-  filterGroupsByAuditSlug,
-} from './lib/filter-by-slug';

--- a/packages/utils/src/lib/git.integration.test.ts
+++ b/packages/utils/src/lib/git.integration.test.ts
@@ -1,18 +1,63 @@
+import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { type SimpleGit, simpleGit } from 'simple-git';
 import { expect } from 'vitest';
-import { getLatestCommit } from './git';
+import { getGitRoot, getLatestCommit, toGitPath } from './git';
+import { toUnixPath } from './transform';
 
-const gitCommitDateRegex =
-  /^(Mon|Tue|Wed|Thu|Fri|Sat|Sun) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d{1,2} \d{2}:\d{2}:\d{2} \d{4} [+|-]\d{4}$/;
+describe('git utils', () => {
+  const baseDir = join(process.cwd(), 'tmp', 'testing-git-repo');
+  let git: SimpleGit;
 
-describe('getLatestCommit', () => {
+  beforeAll(async () => {
+    await mkdir(baseDir, { recursive: true });
+    await writeFile(join(baseDir, 'README.md'), '# hello-world\n');
+
+    git = simpleGit(baseDir);
+    await git.init();
+
+    await git.addConfig('user.name', 'John Doe');
+    await git.addConfig('user.email', 'john.doe@example.com');
+
+    await git.add('README.md');
+    await git.commit('Create README');
+  });
+
+  afterAll(async () => {
+    await rm(baseDir, { recursive: true, force: true });
+  });
+
   it('should log latest commit', async () => {
-    await expect(getLatestCommit()).resolves.toEqual(
-      expect.objectContaining({
-        hash: expect.stringMatching(/^[\da-f]{40}$/),
-        message: expect.stringMatching(/.+/),
-        author: expect.stringMatching(/.+/),
-        date: expect.stringMatching(gitCommitDateRegex),
-      }),
+    const gitCommitDateRegex =
+      /^(Mon|Tue|Wed|Thu|Fri|Sat|Sun) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d{1,2} \d{2}:\d{2}:\d{2} \d{4} [+|-]\d{4}$/;
+
+    await expect(getLatestCommit(git)).resolves.toEqual({
+      hash: expect.stringMatching(/^[\da-f]{40}$/),
+      message: 'Create README',
+      author: 'John Doe',
+      date: expect.stringMatching(gitCommitDateRegex),
+    });
+  });
+
+  it('should find Git root', async () => {
+    await expect(getGitRoot(git)).resolves.toBe(toUnixPath(baseDir));
+  });
+
+  it('should convert absolute path to relative Git path', async () => {
+    await expect(
+      toGitPath(join(process.cwd(), 'src', 'utils.ts')),
+    ).resolves.toBe('src/utils.ts');
+  });
+
+  it('should convert relative Windows path to relative Git path', async () => {
+    await expect(toGitPath('Backend\\API\\Startup.cs')).resolves.toBe(
+      'Backend/API/Startup.cs',
+    );
+  });
+
+  it('should keep relative Unix path as is (already a Git path)', async () => {
+    await expect(toGitPath('Backend/API/Startup.cs')).resolves.toBe(
+      'Backend/API/Startup.cs',
     );
   });
 });

--- a/packages/utils/src/lib/transform.ts
+++ b/packages/utils/src/lib/transform.ts
@@ -105,17 +105,8 @@ export function objectToCliArgs<
   });
 }
 
-export function toUnixPath(
-  path: string,
-  options?: { toRelative?: boolean },
-): string {
-  const unixPath = path.replace(/\\/g, '/');
-
-  if (options?.toRelative) {
-    return unixPath.replace(`${process.cwd().replace(/\\/g, '/')}/`, '');
-  }
-
-  return unixPath;
+export function toUnixPath(path: string): string {
+  return path.replace(/\\/g, '/');
 }
 
 export function toUnixNewlines(text: string): string {

--- a/packages/utils/src/lib/transform.unit.test.ts
+++ b/packages/utils/src/lib/transform.unit.test.ts
@@ -181,14 +181,6 @@ describe('toUnixPath', () => {
   ])('should transform "%s" to valid slug "%s"', (path, unixPath) => {
     expect(toUnixPath(path)).toBe(unixPath);
   });
-
-  it('should transform absolute Windows path to relative UNIX path', () => {
-    expect(
-      toUnixPath(`${process.cwd()}\\windows\\path\\config.ts`, {
-        toRelative: true,
-      }),
-    ).toBe('windows/path/config.ts');
-  });
 });
 
 describe('capitalize', () => {

--- a/testing-utils/src/index.ts
+++ b/testing-utils/src/index.ts
@@ -1,6 +1,8 @@
 export * from './lib/constants';
 export * from './lib/setup/test-folder.setup';
 export * from './lib/utils/execute-process-helper.mock';
+export * from './lib/utils/os-agnostic-paths';
+
 // static mocks
 export * from './lib/utils/core-config.mock';
 export * from './lib/utils/minimal-config.mock';

--- a/testing-utils/src/lib/setup/git.mock.ts
+++ b/testing-utils/src/lib/setup/git.mock.ts
@@ -1,0 +1,17 @@
+import { vi } from 'vitest';
+import { MEMFS_VOLUME } from '../constants';
+
+vi.mock('simple-git', () => ({
+  simpleGit: () => ({
+    revparse: () => Promise.resolve(MEMFS_VOLUME),
+    log: () =>
+      Promise.resolve({
+        latest: {
+          hash: '0123456789abcdef0123456789abcdef01234567',
+          message: 'Minor fixes',
+          author: 'John Doe',
+          date: 'Wed Feb 14 16:00:00 2024 +0100',
+        },
+      }),
+  }),
+}));

--- a/testing-utils/src/lib/utils/os-agnostic-paths.ts
+++ b/testing-utils/src/lib/utils/os-agnostic-paths.ts
@@ -1,0 +1,40 @@
+import type {
+  AuditOutput,
+  AuditOutputs,
+  AuditReport,
+} from '@code-pushup/models';
+
+export function osAgnosticPath(path: string): string {
+  return path.replace(process.cwd(), '<CWD>').replace(/\\/g, '/');
+}
+
+export function osAgnosticAudit<T extends AuditOutput | AuditReport>(
+  audit: T,
+): T {
+  if (
+    !audit.details?.issues.length ||
+    audit.details.issues.every(issue => issue.source == null)
+  ) {
+    return audit;
+  }
+  return {
+    ...audit,
+    details: {
+      issues: audit.details.issues.map(issue =>
+        issue.source == null
+          ? issue
+          : {
+              ...issue,
+              source: {
+                ...issue.source,
+                file: osAgnosticPath(issue.source.file),
+              },
+            },
+      ),
+    },
+  };
+}
+
+export function osAgnosticAuditOutputs(audits: AuditOutputs): AuditOutputs {
+  return audits.map(osAgnosticAudit);
+}


### PR DESCRIPTION
Fixes #465 

Removed all usages of `toUnixPath` in plugins. Since it would be inconvenient to use the new helper function in each plugin - it's now async and we don't want to run the Git command for each issue - I transferred that responsibility to `core`. Created testing utils for making paths OS-agnostic for snapshot tests. And refactored Git tests to run against a temporary git repo (I recommend applying this approach to #469).