### PR TITLE
test: fix reportsDirectory for test-utils

### DIFF
--- a/testing/test-utils/project.json
+++ b/testing/test-utils/project.json
@@ -27,7 +27,7 @@
       "outputs": ["{options.reportsDirectory}"],
       "options": {
         "config": "testing/test-utils/vite.config.unit.ts",
-        "reportsDirectory": "../coverage/test-utils/unit-tests"
+        "reportsDirectory": "../../coverage/test-utils/unit-tests"
       }
     }
   },


### PR DESCRIPTION
The coverage folder was not properly defined for `test-utils`. Fixed here.