### PR TITLE
build: fix race condition in build scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,10 +130,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: E2E test affected projects
-        uses: Wandalen/wretry.action@master
-        with:
-          command: npx nx affected:e2e --parallel=3
-          attempt_limit: 2
+        run: npx nx affected:e2e --parallel=3
 
   build:
     runs-on: ubuntu-latest

--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -1,4 +1,3 @@
-const esbuild = require('esbuild');
 const { execSync } = require('child_process');
 const { readFileSync, writeFileSync, existsSync } = require('fs');
 
@@ -9,7 +8,7 @@ const projectPath = project.startsWith('test-')
   ? 'examples/plugins'
   : `packages/${project}`;
 
-esbuild.build({
+module.exports = {
   plugins: [
     {
       name: 'TypeScriptDeclarations',
@@ -79,4 +78,4 @@ esbuild.build({
       },
     },
   ],
-});
+};


### PR DESCRIPTION
Fixes #493 

The problem was a misunderstanding in how `@nx/esbuild` interprets the `"esbuildConfig": "esbuild.config.js"` option. It's not meant to be [a build script as described in ESBuild docs](https://esbuild.github.io/getting-started/#build-scripts). It's only supposed to export additional ESBuild options (only way to define ESBuild plugins), the Nx executor [`require`s it under the hood](https://github.com/nrwl/nx/blob/17.1.3/packages/esbuild/src/executors/esbuild/lib/normalize.ts#L44-L54). The Nx executor also [copies the source `package.json` to `dist` output](https://github.com/nrwl/nx/blob/17.1.3/packages/esbuild/src/executors/esbuild/lib/normalize.ts#L15-L24), which was in a race condition with our custom `PackageJson` plugin triggered by calling `esbuild.build(...)` (which is async) in `esbuild.config.js` as a side-effect of `require`.