### PR TITLE
fix(plugin-eslint): handle rules which emit column 0

### DIFF
--- a/packages/plugin-eslint/src/lib/runner/transform.ts
+++ b/packages/plugin-eslint/src/lib/runner/transform.ts
@@ -66,9 +66,13 @@ function convertIssue(issue: LintIssue): Issue {
       file: issue.filePath,
       position: {
         startLine: issue.line,
-        startColumn: issue.column,
-        endLine: issue.endLine,
-        endColumn: issue.endColumn,
+        ...(issue.column > 0 && { startColumn: issue.column }),
+        ...(issue.endLine &&
+          issue.endLine > 0 && {
+            endLine: issue.endLine,
+          }),
+        ...(issue.endColumn &&
+          issue.endColumn > 0 && { endColumn: issue.endColumn }),
       },
     },
   };

--- a/packages/plugin-eslint/src/lib/runner/transform.unit.test.ts
+++ b/packages/plugin-eslint/src/lib/runner/transform.unit.test.ts
@@ -61,6 +61,18 @@ describe('lintResultsToAudits', () => {
             ],
           },
           {
+            filePath: 'src/app/graphql/generated.ts',
+            messages: [
+              {
+                ruleId: 'unicorn/no-abusive-eslint-disable',
+                message: 'Specify the rules you want to disable',
+                severity: 1,
+                line: 1,
+                column: 0, // testing we omit non-positive columns
+              },
+            ],
+          },
+          {
             filePath: 'src/app/pages/settings.component.ts',
             messages: [
               {
@@ -78,13 +90,22 @@ describe('lintResultsToAudits', () => {
           'src/app/app.component.ts': {
             'max-lines': [500],
             '@typescript-eslint/no-explicit-any': [],
+            'unicorn/no-abusive-eslint-disable': [],
           },
           'src/app/pages/settings.component.ts': {
             'max-lines': [500],
+            '@typescript-eslint/no-explicit-any': [],
+            'unicorn/no-abusive-eslint-disable': [],
+          },
+          'src/app/graphql/generated.ts': {
+            'max-lines': [500],
+            '@typescript-eslint/no-explicit-any': [],
+            'unicorn/no-abusive-eslint-disable': [],
           },
           'src/app/app.component.spec.ts': {
             'max-lines': [800],
             '@typescript-eslint/no-explicit-any': [],
+            'unicorn/no-abusive-eslint-disable': [],
           },
         },
       }),
@@ -177,6 +198,24 @@ describe('lintResultsToAudits', () => {
               source: {
                 file: 'src/app/app.component.spec.ts',
                 position: { startLine: 801, startColumn: 1 },
+              },
+            },
+          ],
+        },
+      },
+      {
+        slug: 'unicorn-no-abusive-eslint-disable',
+        score: 0,
+        value: 1,
+        displayValue: '1 warning',
+        details: {
+          issues: [
+            {
+              message: 'Specify the rules you want to disable',
+              severity: 'warning',
+              source: {
+                file: 'src/app/graphql/generated.ts',
+                position: { startLine: 1 },
               },
             },
           ],


### PR DESCRIPTION
Fixed validation error coming from [unicorn/no-abusive-eslint-disable](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-abusive-eslint-disable.md) rule - column 0 wasn't handled and failed validation.

#### CI error

![image](https://github.com/code-pushup/cli/assets/34691111/0b307dd6-23e0-4f25-b2ba-83c74748c951)

#### Debugging

![image](https://github.com/code-pushup/cli/assets/34691111/1c885ed8-4c1f-4887-be72-c5247cee60d0)

![image](https://github.com/code-pushup/cli/assets/34691111/70b458aa-af79-4787-a1f1-ca83c63947e4)
