### PR TITLE
fix: stop CLI when a plugin fails

### DIFF
--- a/packages/plugin-coverage/src/bin.ts
+++ b/packages/plugin-coverage/src/bin.ts
@@ -1,3 +1,3 @@
 import { executeRunner } from './lib/runner';
 
-await executeRunner().catch(console.error);
+await executeRunner();

--- a/packages/plugin-coverage/src/lib/runner/index.ts
+++ b/packages/plugin-coverage/src/lib/runner/index.ts
@@ -20,14 +20,13 @@ export async function executeRunner(): Promise<void> {
   // Run coverage tool if provided
   if (coverageToolCommand != null) {
     const { command, args } = coverageToolCommand;
-
     try {
       await executeProcess({ command, args });
     } catch (error) {
       if (error instanceof ProcessError) {
-        console.info(chalk.bold('stdout from failed process:'));
-        console.info(error.stdout);
-        console.error(chalk.bold('stderr from failed process:'));
+        console.error(chalk.bold('stdout from failed coverage tool process:'));
+        console.error(error.stdout);
+        console.error(chalk.bold('stderr from failed coverage tool process:'));
         console.error(error.stderr);
       }
 

--- a/packages/plugin-eslint/src/bin.ts
+++ b/packages/plugin-eslint/src/bin.ts
@@ -1,3 +1,3 @@
 import { executeRunner } from './lib/runner';
 
-await executeRunner().catch(console.error);
+await executeRunner();


### PR DESCRIPTION
Related to #497 
Until now, the plugin failure was silent and ended up by failing during scoring the incomplete report (no Report parsing is done atm).

In this PR, I removed the `catch` which caused this behaviour in this PR so now the plugins fail after they are run.

I did not delve into the user experience of the logs (they are printed twice or three times still) in this PR, I only fixed the plugin fail behaviour.