### PR TITLE
fix(plugin-eslint): pass arguments via config file instead of argv

### DIFF
--- a/packages/plugin-coverage/src/lib/runner/index.ts
+++ b/packages/plugin-coverage/src/lib/runner/index.ts
@@ -10,7 +10,7 @@ import {
 } from '@code-pushup/utils';
 import { FinalCoveragePluginConfig } from '../config';
 import { applyMaxScoreAboveThreshold } from '../utils';
-import { PLUGIN_CONFIG_PATH, RUNNER_OUTPUT_PATH, WORKDIR } from './constants';
+import { PLUGIN_CONFIG_PATH, RUNNER_OUTPUT_PATH } from './constants';
 import { lcovResultsToAuditOutputs } from './lcov/lcov-runner';
 
 export async function executeRunner(): Promise<void> {
@@ -48,7 +48,7 @@ export async function createRunnerConfig(
   config: FinalCoveragePluginConfig,
 ): Promise<RunnerConfig> {
   // Create JSON config for executeRunner
-  await ensureDirectoryExists(WORKDIR);
+  await ensureDirectoryExists(dirname(PLUGIN_CONFIG_PATH));
   await writeFile(PLUGIN_CONFIG_PATH, JSON.stringify(config));
 
   const threshold = config.perfectScoreThreshold;

--- a/packages/plugin-eslint/src/lib/__snapshots__/eslint-plugin.integration.test.ts.snap
+++ b/packages/plugin-eslint/src/lib/__snapshots__/eslint-plugin.integration.test.ts.snap
@@ -509,10 +509,6 @@ exports[`eslintPlugin > should initialize ESLint plugin for React application 1`
   "runner": {
     "args": [
       "<dirname>/bin.js",
-      "no-cond-assign,no-const-assign,no-debugger,no-invalid-regexp,no-undef,no-unreachable-loop,no-unsafe-negation,no-unsafe-optional-chaining,no-unused-vars,use-isnan,valid-typeof,arrow-body-style,camelcase,curly,eqeqeq,max-lines-per-function,max-lines,no-shadow,no-var,object-shorthand,prefer-arrow-callback,prefer-const,prefer-object-spread,yoda,react-jsx-key,react-prop-types,react-react-in-jsx-scope,react-hooks-rules-of-hooks,react-hooks-exhaustive-deps,react-display-name,react-jsx-no-comment-textnodes,react-jsx-no-duplicate-props,react-jsx-no-target-blank,react-jsx-no-undef,react-jsx-uses-react,react-jsx-uses-vars,react-no-children-prop,react-no-danger-with-children,react-no-deprecated,react-no-direct-mutation-state,react-no-find-dom-node,react-no-is-mounted,react-no-render-return-value,react-no-string-refs,react-no-unescaped-entities,react-no-unknown-property,react-require-render-return",
-      ".eslintrc.js",
-      "'src/**/*.js'",
-      "'src/**/*.jsx'",
     ],
     "command": "node",
     "outputFile": "node_modules/.code-pushup/eslint/runner-output.json",

--- a/packages/plugin-eslint/src/lib/config.ts
+++ b/packages/plugin-eslint/src/lib/config.ts
@@ -18,3 +18,9 @@ export const eslintPluginConfigSchema = z.object({
 });
 
 export type ESLintPluginConfig = z.infer<typeof eslintPluginConfigSchema>;
+
+export type ESLintPluginRunnerConfig = {
+  eslintrc: string;
+  slugs: string[];
+  patterns: string[];
+};

--- a/packages/plugin-eslint/src/lib/eslint-plugin.ts
+++ b/packages/plugin-eslint/src/lib/eslint-plugin.ts
@@ -61,7 +61,7 @@ export async function eslintPlugin(
     audits,
     groups,
 
-    runner: createRunnerConfig(
+    runner: await createRunnerConfig(
       runnerScriptPath,
       audits,
       eslintrcPath,

--- a/packages/plugin-eslint/src/lib/runner.integration.test.ts
+++ b/packages/plugin-eslint/src/lib/runner.integration.test.ts
@@ -1,15 +1,16 @@
 import { ESLint } from 'eslint';
-import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { rm, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { SpyInstance, describe, expect, it } from 'vitest';
 import type { AuditOutput, AuditOutputs, Issue } from '@code-pushup/models';
 import { osAgnosticAuditOutputs } from '@code-pushup/test-utils';
-import { readJsonFile } from '@code-pushup/utils';
+import { ensureDirectoryExists, readJsonFile } from '@code-pushup/utils';
 import { listAuditsAndGroups } from './meta';
 import {
   ESLINTRC_PATH,
+  PLUGIN_CONFIG_PATH,
   RUNNER_OUTPUT_PATH,
   createRunnerConfig,
   executeRunner,
@@ -20,17 +21,11 @@ describe('executeRunner', () => {
   let cwdSpy: SpyInstance;
   let platformSpy: SpyInstance;
 
-  const createArgv = async (eslintrc: string) => {
+  const createPluginConfig = async (eslintrc: string) => {
     const patterns = ['src/**/*.js', 'src/**/*.jsx'];
     const eslint = setupESLint(eslintrc);
     const { audits } = await listAuditsAndGroups(eslint, patterns);
-    const runnerConfig = createRunnerConfig(
-      'bin.js',
-      audits,
-      eslintrc,
-      patterns,
-    );
-    return [runnerConfig.command, ...(runnerConfig.args ?? [])];
+    await createRunnerConfig('bin.js', audits, eslintrc, patterns);
   };
 
   const appDir = join(
@@ -50,7 +45,7 @@ describe('executeRunner', () => {
     const config: ESLint.ConfigData = {
       extends: '@code-pushup',
     };
-    await mkdir(dirname(ESLINTRC_PATH), { recursive: true });
+    await ensureDirectoryExists(dirname(ESLINTRC_PATH));
     await writeFile(ESLINTRC_PATH, JSON.stringify(config));
   });
 
@@ -59,21 +54,20 @@ describe('executeRunner', () => {
     platformSpy.mockRestore();
 
     await rm(ESLINTRC_PATH, { force: true });
+    await rm(PLUGIN_CONFIG_PATH, { force: true });
   });
 
   it('should execute ESLint and create audit results for React application', async () => {
-    const argv = await createArgv('.eslintrc.js');
-
-    await executeRunner(argv);
+    await createPluginConfig('.eslintrc.js');
+    await executeRunner();
 
     const json = await readJsonFile<AuditOutputs>(RUNNER_OUTPUT_PATH);
     expect(osAgnosticAuditOutputs(json)).toMatchSnapshot();
   });
 
   it('should execute runner with inline config using @code-pushup/eslint-config', async () => {
-    const argv = await createArgv(ESLINTRC_PATH);
-
-    await executeRunner(argv);
+    await createPluginConfig(ESLINTRC_PATH);
+    await executeRunner();
 
     const json = await readJsonFile<AuditOutput[]>(RUNNER_OUTPUT_PATH);
     // expect warnings from unicorn/filename-case rule from default config


### PR DESCRIPTION
**WIP**
Closes #529 

In this PR, I rework the ESLint plugin to pass arguments to the runner via a configuration file.
When running the ESLint plugin locally now, the correct output is produced instead of `The command line is too long.`

<details>
  <summary> Part of the output </summary>

  ![image](https://github.com/code-pushup/cli/assets/6306671/0732c2d7-9130-49c3-843e-8eaca59f872d)
</details>