### PR TITLE
chore: exclude fixtures from ESLint

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 node_modules
 **/*.mock.*
+**/mocks/fixtures/**


### PR DESCRIPTION
In this PR, I exclude fixtures from ESLint.

Our fixtures mostly contain static files such as configuration files but in ESLint plugin also include an example nx monorepo. Unfortunately, our ESLint finds its configuration and includes its ESLint issues in the [CLI report](https://quality-metrics-staging.web.app/portal/code-pushup/cli/commit/b2c87eb716a84f82b5d59e7238ffcae7147f707a/issues?categories=bug-prevention&categories=code-style).
![image](https://github.com/code-pushup/cli/assets/6306671/dc05f206-3bc2-455d-b91d-96544edfeb6c)

After the change, the fixtures are [excluded ](https://quality-metrics-staging.web.app/portal/code-pushup/cli/branch/disable-eslint-example-repo/issues?categories=bug-prevention&categories=code-style)from the report.