### PR TITLE
test(plugin-eslint): enable integration tests

### DIFF
--- a/packages/plugin-eslint/src/lib/runner.integration.test.ts
+++ b/packages/plugin-eslint/src/lib/runner.integration.test.ts
@@ -17,9 +17,7 @@ import {
 } from './runner';
 import { setupESLint } from './setup';
 
-// FIXME: tests fail when run in same thread as other integration tests
-// eslint-disable-next-line vitest/no-disabled-tests
-describe.skip('executeRunner', () => {
+describe('executeRunner', () => {
   let cwdSpy: MockInstance<[], string>;
   let platformSpy: MockInstance<[], NodeJS.Platform>;
 


### PR DESCRIPTION
In this PR, I include ESLint integration tests in our pipelines again.
Apparently, something that happened after the nx update fixed the encountered issues.