### PR TITLE
feat(cli): include commit info in report.json

### DIFF
--- a/e2e/cli-e2e/tests/collect.e2e.test.ts
+++ b/e2e/cli-e2e/tests/collect.e2e.test.ts
@@ -14,14 +14,13 @@ describe('CLI collect', () => {
     duration,
     version,
     ...report
-  }: Report | PluginReport) => report;
-  /* eslint-enable @typescript-eslint/no-unused-vars */
-
-  const omitVariableReportData = (report: Report) =>
+  }: Omit<Report, 'commit'> | PluginReport) => report;
+  const omitVariableReportData = ({ commit, ...report }: Report) =>
     omitVariableData({
       ...report,
       plugins: report.plugins.map(omitVariableData) as PluginReport[],
     });
+  /* eslint-enable @typescript-eslint/no-unused-vars */
 
   beforeEach(async () => {
     await cleanTestFolder('tmp/e2e');

--- a/packages/cli/src/lib/autorun/autorun-command.ts
+++ b/packages/cli/src/lib/autorun/autorun-command.ts
@@ -6,7 +6,6 @@ import {
   collectAndPersistReports,
   upload,
 } from '@code-pushup/core';
-import { getLatestCommit, validateCommitData } from '@code-pushup/utils';
 import { CLI_NAME } from '../constants';
 import {
   collectSuccessfulLog,
@@ -50,10 +49,7 @@ export function yargsAutorunCommandObject() {
 
       if (options.upload) {
         const { url } = await upload(options);
-        const commitData = await getLatestCommit();
-        if (validateCommitData(commitData, { throwError: true })) {
-          uploadSuccessfulLog(url);
-        }
+        uploadSuccessfulLog(url);
       } else {
         ui().logger.warning('Upload skipped because configuration is not set.');
         renderIntegratePortalHint();

--- a/packages/cli/src/lib/upload/upload-command.ts
+++ b/packages/cli/src/lib/upload/upload-command.ts
@@ -1,7 +1,6 @@
 import chalk from 'chalk';
 import { ArgumentsCamelCase, CommandModule } from 'yargs';
 import { UploadOptions, upload } from '@code-pushup/core';
-import { getLatestCommit, validateCommitData } from '@code-pushup/utils';
 import { CLI_NAME } from '../constants';
 import {
   renderIntegratePortalHint,
@@ -24,11 +23,7 @@ export function yargsUploadCommandObject() {
         throw new Error('Upload configuration not set');
       }
       const { url } = await upload(options);
-
-      const commitData = await getLatestCommit();
-      if (validateCommitData(commitData, { throwError: true })) {
-        uploadSuccessfulLog(url);
-      }
+      uploadSuccessfulLog(url);
     },
   } satisfies CommandModule;
 }

--- a/packages/core/src/lib/collect-and-persist.unit.test.ts
+++ b/packages/core/src/lib/collect-and-persist.unit.test.ts
@@ -4,7 +4,10 @@ import {
   MINIMAL_CONFIG_MOCK,
   MINIMAL_REPORT_MOCK,
 } from '@code-pushup/test-utils';
-import { collectAndPersistReports } from './collect-and-persist';
+import {
+  CollectAndPersistReportsOptions,
+  collectAndPersistReports,
+} from './collect-and-persist';
 import { collect } from './implementation/collect';
 import { logPersistedResults, persistReport } from './implementation/persist';
 
@@ -19,7 +22,8 @@ vi.mock('./implementation/persist', () => ({
 
 describe('collectAndPersistReports', () => {
   it('should call collect and persistReport with correct parameters in non-verbose mode', async () => {
-    const nonVerboseConfig = {
+    const nonVerboseConfig: CollectAndPersistReportsOptions = {
+      categories: [],
       ...MINIMAL_CONFIG_MOCK,
       persist: {
         outputDir: 'output',
@@ -33,12 +37,15 @@ describe('collectAndPersistReports', () => {
 
     expect(collect).toHaveBeenCalledWith(nonVerboseConfig);
 
-    expect(persistReport).toHaveBeenCalledWith(
+    expect(persistReport).toHaveBeenCalledWith<
+      Parameters<typeof persistReport>
+    >(
       {
         packageName: '@code-pushup/core',
         version: '0.0.1',
         date: expect.stringMatching(ISO_STRING_REGEXP),
         duration: 666,
+        commit: expect.any(Object),
         categories: expect.any(Array),
         plugins: expect.any(Array),
       },
@@ -53,7 +60,8 @@ describe('collectAndPersistReports', () => {
   });
 
   it('should call collect and persistReport with correct parameters in verbose mode', async () => {
-    const verboseConfig = {
+    const verboseConfig: CollectAndPersistReportsOptions = {
+      categories: [],
       ...MINIMAL_CONFIG_MOCK,
       persist: {
         outputDir: 'output',

--- a/packages/core/src/lib/implementation/collect.integration.test.ts
+++ b/packages/core/src/lib/implementation/collect.integration.test.ts
@@ -1,5 +1,6 @@
 import { vol } from 'memfs';
 import { describe, expect, it } from 'vitest';
+import { commitSchema } from '@code-pushup/models';
 import { MEMFS_VOLUME, MINIMAL_CONFIG_MOCK } from '@code-pushup/test-utils';
 import { collect } from './collect';
 
@@ -7,6 +8,7 @@ describe('collect', () => {
   it('should execute with valid options', async () => {
     vol.fromJSON({}, MEMFS_VOLUME);
     const report = await collect({
+      categories: [],
       ...MINIMAL_CONFIG_MOCK,
       verbose: true,
       progress: false,
@@ -27,5 +29,7 @@ describe('collect', () => {
         },
       }),
     );
+
+    expect(() => commitSchema.parse(report.commit)).not.toThrow();
   });
 });

--- a/packages/core/src/lib/implementation/collect.ts
+++ b/packages/core/src/lib/implementation/collect.ts
@@ -1,5 +1,5 @@
 import { CoreConfig, Report } from '@code-pushup/models';
-import { calcDuration } from '@code-pushup/utils';
+import { calcDuration, getLatestCommit } from '@code-pushup/utils';
 import { name, version } from '../../../package.json';
 import { GlobalOptions } from '../types';
 import { executePlugins } from './execute-plugin';
@@ -17,8 +17,10 @@ export async function collect(options: CollectOptions): Promise<Report> {
   const { plugins, categories } = options;
   const date = new Date().toISOString();
   const start = performance.now();
+  const commit = await getLatestCommit();
   const pluginOutputs = await executePlugins(plugins, options);
   return {
+    commit,
     packageName: name,
     version,
     date,

--- a/packages/core/src/lib/implementation/persist.ts
+++ b/packages/core/src/lib/implementation/persist.ts
@@ -6,11 +6,9 @@ import {
   directoryExists,
   generateMdReport,
   generateStdoutSummary,
-  getLatestCommit,
   logMultipleFileResults,
   scoreReport,
   sortReport,
-  validateCommitData,
 } from '@code-pushup/utils';
 
 export class PersistDirError extends Error {
@@ -35,24 +33,20 @@ export async function persistReport(
   console.info(generateStdoutSummary(sortedScoredReport));
 
   // collect physical format outputs
-  const results = await Promise.all(
-    format.map(async reportType => {
-      switch (reportType) {
-        case 'json':
-          return {
-            format: 'json',
-            content: JSON.stringify(report, null, 2),
-          };
-        case 'md':
-          const commitData = await getLatestCommit();
-          validateCommitData(commitData);
-          return {
-            format: 'md',
-            content: generateMdReport(sortedScoredReport, commitData),
-          };
-      }
-    }),
-  );
+  const results = format.map(reportType => {
+    switch (reportType) {
+      case 'json':
+        return {
+          format: 'json',
+          content: JSON.stringify(report, null, 2),
+        };
+      case 'md':
+        return {
+          format: 'md',
+          content: generateMdReport(sortedScoredReport),
+        };
+    }
+  });
 
   if (!(await directoryExists(outputDir))) {
     try {

--- a/packages/core/src/lib/upload.ts
+++ b/packages/core/src/lib/upload.ts
@@ -3,7 +3,7 @@ import {
   uploadToPortal,
 } from '@code-pushup/portal-client';
 import { PersistConfig, Report, UploadConfig } from '@code-pushup/models';
-import { getLatestCommit, loadReport } from '@code-pushup/utils';
+import { loadReport } from '@code-pushup/utils';
 import { reportToGQL } from './implementation/report-to-gql';
 import { GlobalOptions } from './types';
 
@@ -27,15 +27,14 @@ export async function upload(
     ...options.persist,
     format: 'json',
   });
-  const commitData = await getLatestCommit();
-  if (!commitData) {
-    throw new Error('no commit data available');
+  if (!report.commit) {
+    throw new Error('Commit must be linked in order to upload report');
   }
 
   const data: SaveReportMutationVariables = {
     organization,
     project,
-    commit: commitData.hash,
+    commit: report.commit.hash,
     ...reportToGQL(report),
   };
 

--- a/packages/models/docs/models-reference.md
+++ b/packages/models/docs/models-reference.md
@@ -90,6 +90,21 @@ _Object containing the following properties:_
 
 _(\*) Required._
 
+## Commit
+
+Git commit
+
+_Object containing the following properties:_
+
+| Property           | Description                            | Type                                  |
+| :----------------- | :------------------------------------- | :------------------------------------ |
+| **`hash`** (\*)    | Commit SHA (full)                      | `string` (_regex: `/^[\da-f]{40}$/`_) |
+| **`message`** (\*) | Commit message                         | `string`                              |
+| **`date`** (\*)    | Date and time when commit was authored | `Date` (_nullable_)                   |
+| **`author`** (\*)  | Commit author name                     | `string`                              |
+
+_(\*) Required._
+
 ## CoreConfig
 
 _Object containing the following properties:_
@@ -1095,14 +1110,15 @@ _(\*) Required._
 
 _Object containing the following properties:_
 
-| Property               | Description                            | Type                                                      |
-| :--------------------- | :------------------------------------- | :-------------------------------------------------------- |
-| **`packageName`** (\*) | NPM package name                       | `string`                                                  |
-| **`version`** (\*)     | NPM version of the CLI                 | `string`                                                  |
-| **`date`** (\*)        | Start date and time of the collect run | `string`                                                  |
-| **`duration`** (\*)    | Duration of the collect run in ms      | `number`                                                  |
-| **`categories`** (\*)  |                                        | _Array of [CategoryConfig](#categoryconfig) items_        |
-| **`plugins`** (\*)     |                                        | _Array of at least 1 [PluginReport](#pluginreport) items_ |
+| Property               | Description                               | Type                                                                                                                                                                                                                                                                                                |
+| :--------------------- | :---------------------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`packageName`** (\*) | NPM package name                          | `string`                                                                                                                                                                                                                                                                                            |
+| **`version`** (\*)     | NPM version of the CLI                    | `string`                                                                                                                                                                                                                                                                                            |
+| **`date`** (\*)        | Start date and time of the collect run    | `string`                                                                                                                                                                                                                                                                                            |
+| **`duration`** (\*)    | Duration of the collect run in ms         | `number`                                                                                                                                                                                                                                                                                            |
+| **`categories`** (\*)  |                                           | _Array of [CategoryConfig](#categoryconfig) items_                                                                                                                                                                                                                                                  |
+| **`plugins`** (\*)     |                                           | _Array of at least 1 [PluginReport](#pluginreport) items_                                                                                                                                                                                                                                           |
+| **`commit`** (\*)      | Git commit for which report was collected | _Object with properties:_<ul><li>`hash`: `string` (_regex: `/^[\da-f]{40}$/`_) - Commit SHA (full)</li><li>`message`: `string` - Commit message</li><li>`date`: `Date` (_nullable_) - Date and time when commit was authored</li><li>`author`: `string` - Commit author name</li></ul> (_nullable_) |
 
 _(\*) Required._
 

--- a/packages/models/src/index.ts
+++ b/packages/models/src/index.ts
@@ -13,6 +13,7 @@ export {
   categoryConfigSchema,
   categoryRefSchema,
 } from './lib/category-config';
+export { Commit, commitSchema } from './lib/commit';
 export { CoreConfig, coreConfigSchema } from './lib/core-config';
 export { Group, GroupRef, groupRefSchema, groupSchema } from './lib/group';
 export {

--- a/packages/models/src/lib/commit.ts
+++ b/packages/models/src/lib/commit.ts
@@ -1,0 +1,24 @@
+import { z } from 'zod';
+
+export const commitSchema = z.object(
+  {
+    hash: z
+      .string({ description: 'Commit SHA (full)' })
+      .regex(
+        /^[\da-f]{40}$/,
+        'Commit SHA should be a 40-character hexadecimal string',
+      ),
+    message: z.string({ description: 'Commit message' }),
+    date: z.coerce.date({
+      description: 'Date and time when commit was authored',
+    }),
+    author: z
+      .string({
+        description: 'Commit author name',
+      })
+      .trim(),
+  },
+  { description: 'Git commit' },
+);
+
+export type Commit = z.infer<typeof commitSchema>;

--- a/packages/models/src/lib/commit.unit.test.ts
+++ b/packages/models/src/lib/commit.unit.test.ts
@@ -1,0 +1,41 @@
+import { type Commit, commitSchema } from './commit';
+
+describe('commitSchema', () => {
+  it('should accept valid git commit data', () => {
+    expect(() =>
+      commitSchema.parse({
+        hash: 'abcdef0123456789abcdef0123456789abcdef01',
+        message: 'Minor fixes',
+        author: 'John Doe',
+        date: new Date(),
+      } satisfies Commit),
+    ).not.toThrow();
+  });
+
+  it('should coerce date string into Date object', () => {
+    expect(
+      commitSchema.parse({
+        hash: 'abcdef0123456789abcdef0123456789abcdef01',
+        message: 'Minor fixes',
+        author: 'John Doe',
+        date: '2024-03-06T17:30:12+01:00',
+      }),
+    ).toEqual<Commit>({
+      hash: 'abcdef0123456789abcdef0123456789abcdef01',
+      message: 'Minor fixes',
+      author: 'John Doe',
+      date: new Date('2024-03-06T17:30:12+01:00'),
+    });
+  });
+
+  it('should throw for invalid hash', () => {
+    expect(() =>
+      commitSchema.parse({
+        hash: '12345678', // too short
+        message: 'Minor fixes',
+        author: 'John Doe',
+        date: new Date(),
+      } satisfies Commit),
+    ).toThrow('Commit SHA should be a 40-character hexadecimal string');
+  });
+});

--- a/packages/models/src/lib/report.ts
+++ b/packages/models/src/lib/report.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import { auditSchema } from './audit';
 import { auditOutputSchema } from './audit-output';
 import { categoryConfigSchema } from './category-config';
+import { commitSchema } from './commit';
 import { Group, groupSchema } from './group';
 import {
   executionMetaSchema,
@@ -76,6 +77,9 @@ export const reportSchema = packageVersionSchema({
       {
         categories: z.array(categoryConfigSchema),
         plugins: z.array(pluginReportSchema).min(1),
+        commit: commitSchema
+          .describe('Git commit for which report was collected')
+          .nullable(),
       },
       { description: 'Collect output data' },
     ),

--- a/packages/models/src/lib/report.unit.test.ts
+++ b/packages/models/src/lib/report.unit.test.ts
@@ -183,6 +183,12 @@ describe('reportSchema', () => {
             title: 'Bug prevention',
           },
         ],
+        commit: {
+          hash: 'abcdef0123456789abcdef0123456789abcdef01',
+          message: 'Minor fixes',
+          author: 'John Doe',
+          date: new Date('2024-01-07T09:15:00.000Z'),
+        },
         date: '2024-01-07T09:30:00.000Z',
         duration: 600,
         plugins: [
@@ -235,6 +241,7 @@ describe('reportSchema', () => {
             title: 'Bug prevention',
           },
         ],
+        commit: null,
         date: '2024-01-07T09:30:00.000Z',
         duration: 600,
         plugins: [

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -39,7 +39,6 @@ export {
   getGitRoot,
   getLatestCommit,
   toGitPath,
-  validateCommitData,
 } from './lib/git';
 export { groupByStatus } from './lib/group-by-status';
 export {

--- a/packages/utils/src/lib/git.integration.test.ts
+++ b/packages/utils/src/lib/git.integration.test.ts
@@ -54,14 +54,11 @@ describe('git utils in a git repo', () => {
     });
 
     it('should log latest commit', async () => {
-      const gitCommitDateRegex =
-        /^(Mon|Tue|Wed|Thu|Fri|Sat|Sun) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d{1,2} \d{2}:\d{2}:\d{2} \d{4} [+|-]\d{4}$/;
-
       await expect(getLatestCommit(emptyGit)).resolves.toEqual({
         hash: expect.stringMatching(/^[\da-f]{40}$/),
         message: 'Create README',
         author: 'John Doe',
-        date: expect.stringMatching(gitCommitDateRegex),
+        date: expect.any(Date),
       });
     });
 

--- a/packages/utils/src/lib/reports/__snapshots__/generate-md-report.integration.test.ts.snap
+++ b/packages/utils/src/lib/reports/__snapshots__/generate-md-report.integration.test.ts.snap
@@ -429,7 +429,7 @@ Report was created by [Code PushUp](https://github.com/flowup/quality-metrics-cl
 
 |Commit|Version|Duration|Plugins|Categories|Audits|
 |:--|:--:|:--:|:--:|:--:|:--:|
-|refactor(cli): fix exec target (41682a2)|\`0.0.1\`|1.65 s|2|3|52|
+|Minor fixes (abcdef0)|\`0.0.1\`|1.65 s|2|3|52|
 
 The following plugins were run:
 
@@ -806,7 +806,7 @@ Report was created by [Code PushUp](https://github.com/flowup/quality-metrics-cl
 
 |Commit|Version|Duration|Plugins|Categories|Audits|
 |:--|:--:|:--:|:--:|:--:|:--:|
-|refactor(cli): fix exec target (41682a2)|\`0.0.1\`|1.65 s|2|0|52|
+|Minor fixes (abcdef0)|\`0.0.1\`|1.65 s|2|0|52|
 
 The following plugins were run:
 

--- a/packages/utils/src/lib/reports/__snapshots__/sorting.integration.test.ts.snap
+++ b/packages/utils/src/lib/reports/__snapshots__/sorting.integration.test.ts.snap
@@ -60,6 +60,12 @@ exports[`sortReport > should sort the audits and audit groups in categories, plu
       "title": "Bug prevention",
     },
   ],
+  "commit": {
+    "author": "John Doe",
+    "date": 2023-08-16T08:30:00.000Z,
+    "hash": "abcdef0123456789abcdef0123456789abcdef01",
+    "message": "Minor fixes",
+  },
   "date": "2023-08-16T09:00:00.000Z",
   "duration": 666,
   "packageName": "@code-pushup/core",

--- a/packages/utils/src/lib/reports/generate-md-report.integration.test.ts
+++ b/packages/utils/src/lib/reports/generate-md-report.integration.test.ts
@@ -15,19 +15,7 @@ describe('generateMdReport', () => {
   });
 
   it('should contain all sections when using the fixture report', () => {
-    const commit = {
-      hash: '41682a2fec1d4ece81c696a26c08984baeb4bcf3',
-      message: 'refactor(cli): fix exec target',
-      author: 'BioPhoton',
-      date: 'Sat Sep 10 12:00:00 2021 +0200',
-    };
-    const mdReport = generateMdReport(
-      sortReport(scoreReport(reportMock())),
-      commit,
-    );
-    expect(mdReport).toContain(
-      `${commit.message} (${commit.hash.slice(0, 7)})`,
-    );
+    const mdReport = generateMdReport(sortReport(scoreReport(reportMock())));
     expect(mdReport).toContain('🏷 Category');
     expect(mdReport).toMatchSnapshot();
   });
@@ -35,12 +23,6 @@ describe('generateMdReport', () => {
   it('should not contain category sections when categories are empty', () => {
     const mdReport = generateMdReport(
       sortReport(scoreReport({ ...reportMock(), categories: [] })),
-      {
-        hash: '41682a2fec1d4ece81c696a26c08984baeb4bcf3',
-        message: 'refactor(cli): fix exec target',
-        author: 'BioPhoton',
-        date: 'Sat Sep 10 12:00:00 2021 +0200',
-      },
     );
     expect(mdReport).not.toContain('🏷 Category');
     expect(mdReport).toMatchSnapshot();

--- a/packages/utils/src/lib/reports/generate-md-report.ts
+++ b/packages/utils/src/lib/reports/generate-md-report.ts
@@ -1,6 +1,5 @@
 import { AuditReport, CategoryConfig, Issue } from '@code-pushup/models';
 import { formatDate, formatDuration, slugify } from '../formatting';
-import { CommitData } from '../git';
 import {
   FOOTER_PREFIX,
   NEW_LINE,
@@ -34,10 +33,7 @@ import {
   getSquaredScoreMarker,
 } from './utils';
 
-export function generateMdReport(
-  report: ScoredReport,
-  commitData: CommitData | null,
-): string {
+export function generateMdReport(report: ScoredReport): string {
   const printCategories = report.categories.length > 0;
 
   return (
@@ -58,7 +54,7 @@ export function generateMdReport(
     NEW_LINE +
     NEW_LINE +
     // about section
-    reportToAboutSection(report, commitData) +
+    reportToAboutSection(report) +
     NEW_LINE +
     NEW_LINE +
     // footer section
@@ -235,15 +231,12 @@ function reportToDetailsSection(audit: AuditReport) {
   return details(detailsTitle, detailsTable);
 }
 
-function reportToAboutSection(
-  report: ScoredReport,
-  commitData: CommitData | null,
-): string {
+function reportToAboutSection(report: ScoredReport): string {
   const date = formatDate(new Date());
 
-  const { duration, version, plugins, categories } = report;
-  const commitInfo = commitData
-    ? `${commitData.message} (${commitData.hash.slice(0, 7)})`
+  const { duration, version, commit, plugins, categories } = report;
+  const commitInfo = commit
+    ? `${commit.message} (${commit.hash.slice(0, 7)})`
     : 'N/A';
   const reportMetaTable: string[][] = [
     reportMetaTableHeaders,

--- a/testing/test-utils/src/lib/utils/dynamic-mocks/commit.mock.ts
+++ b/testing/test-utils/src/lib/utils/dynamic-mocks/commit.mock.ts
@@ -1,0 +1,8 @@
+import type { Commit } from '@code-pushup/models';
+
+export const COMMIT_MOCK: Commit = {
+  hash: 'abcdef0123456789abcdef0123456789abcdef01',
+  message: 'Minor fixes',
+  author: 'John Doe',
+  date: new Date('2023-08-16T08:30:00.000Z'),
+};

--- a/testing/test-utils/src/lib/utils/dynamic-mocks/config.mock.ts
+++ b/testing/test-utils/src/lib/utils/dynamic-mocks/config.mock.ts
@@ -1,10 +1,4 @@
-import {
-  CoreConfig,
-  PluginConfig,
-  PluginReport,
-  Report,
-  coreConfigSchema,
-} from '@code-pushup/models';
+import { CoreConfig, coreConfigSchema } from '@code-pushup/models';
 import { categoryConfigsMock } from './categories.mock';
 import { eslintPluginConfigMock } from './eslint-plugin.mock';
 import { lighthousePluginConfigMock } from './lighthouse-plugin.mock';
@@ -67,48 +61,4 @@ export function minimalConfigMock(
   });
 
   return JSON.parse(JSON.stringify(cfg));
-}
-
-export function minimalReportMock(outputDir = 'tmp'): Report {
-  const PLUGIN_1_SLUG = 'plugin-1';
-  const AUDIT_1_SLUG = 'audit-1';
-
-  const plg1: PluginConfig = pluginConfigMock([], {
-    slug: PLUGIN_1_SLUG,
-    outputDir,
-  });
-
-  const { runner: _, ...rest } = plg1;
-  const pluginReport: PluginReport = {
-    ...rest,
-    duration: 0,
-    date: 'dummy-data-string',
-    version: '',
-    packageName: '',
-    audits: [auditReportMock({ slug: AUDIT_1_SLUG })],
-  };
-
-  return JSON.parse(
-    JSON.stringify({
-      packageName: '@code-pushup/core',
-      version: '0.1.0',
-      date: 'today',
-      duration: 42,
-      categories: [
-        {
-          slug: 'category-1',
-          title: 'Category 1',
-          refs: [
-            {
-              type: 'audit',
-              plugin: PLUGIN_1_SLUG,
-              slug: AUDIT_1_SLUG,
-              weight: 1,
-            },
-          ],
-        },
-      ],
-      plugins: [pluginReport],
-    } satisfies Report),
-  );
 }

--- a/testing/test-utils/src/lib/utils/dynamic-mocks/report.mock.ts
+++ b/testing/test-utils/src/lib/utils/dynamic-mocks/report.mock.ts
@@ -1,5 +1,6 @@
 import { Report, reportSchema } from '@code-pushup/models';
 import { categoryConfigsMock } from './categories.mock';
+import { COMMIT_MOCK } from './commit.mock';
 import { eslintPluginReportMock } from './eslint-plugin.mock';
 import { lighthousePluginReportMock } from './lighthouse-plugin.mock';
 
@@ -12,7 +13,8 @@ export function reportMock(): Report {
       eslintPluginReportMock().duration +
       lighthousePluginReportMock().duration +
       50,
+    commit: COMMIT_MOCK,
     categories: categoryConfigsMock(),
     plugins: [eslintPluginReportMock(), lighthousePluginReportMock()],
-  });
+  } satisfies Report);
 }

--- a/testing/test-utils/src/lib/utils/report.mock.ts
+++ b/testing/test-utils/src/lib/utils/report.mock.ts
@@ -1,10 +1,16 @@
-import type { Report } from '@code-pushup/models';
+import type { PluginConfig, PluginReport, Report } from '@code-pushup/models';
+import { COMMIT_MOCK } from './dynamic-mocks/commit.mock';
+import {
+  auditReportMock,
+  pluginConfigMock,
+} from './dynamic-mocks/plugin-config.mock';
 
 export const MINIMAL_REPORT_MOCK: Report = {
   packageName: '@code-pushup/core',
   version: '0.0.1',
   date: '2023-08-16T09:00:00.000Z',
   duration: 666,
+  commit: COMMIT_MOCK,
   categories: [],
   plugins: [
     {
@@ -30,6 +36,7 @@ export const REPORT_MOCK: Report = {
   version: '1.0.0',
   date: '2023-08-16T09:00:00.000Z',
   duration: 666,
+  commit: COMMIT_MOCK,
   categories: [
     {
       slug: 'test-results',
@@ -246,3 +253,48 @@ export const REPORT_MOCK: Report = {
     },
   ],
 };
+
+export function minimalReportMock(outputDir = 'tmp'): Report {
+  const PLUGIN_1_SLUG = 'plugin-1';
+  const AUDIT_1_SLUG = 'audit-1';
+
+  const plg1: PluginConfig = pluginConfigMock([], {
+    slug: PLUGIN_1_SLUG,
+    outputDir,
+  });
+
+  const { runner: _, ...rest } = plg1;
+  const pluginReport: PluginReport = {
+    ...rest,
+    duration: 0,
+    date: 'dummy-data-string',
+    version: '',
+    packageName: '',
+    audits: [auditReportMock({ slug: AUDIT_1_SLUG })],
+  };
+
+  return JSON.parse(
+    JSON.stringify({
+      packageName: '@code-pushup/core',
+      version: '0.1.0',
+      date: 'today',
+      commit: null,
+      duration: 42,
+      categories: [
+        {
+          slug: 'category-1',
+          title: 'Category 1',
+          refs: [
+            {
+              type: 'audit',
+              plugin: PLUGIN_1_SLUG,
+              slug: AUDIT_1_SLUG,
+              weight: 1,
+            },
+          ],
+        },
+      ],
+      plugins: [pluginReport],
+    } satisfies Report),
+  );
+}


### PR DESCRIPTION
Prerequisite for #482 

Instead of fetching the latest commit for `upload` command and `report.md` formatting, the commit is fetched and included in `report.json` by `collect`.

