### PR TITLE
ci: improve pipeline naming

### DIFF
--- a/.github/workflows/pr-commitlint.yml
+++ b/.github/workflows/pr-commitlint.yml
@@ -1,4 +1,4 @@
-name: PR Title Commitlint Check
+name: PR Commitlint
 
 on:
   pull_request:
@@ -6,6 +6,7 @@ on:
 
 jobs:
   check:
+    name: Check PR title
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   label:
+    name: Add PR labels
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write


### PR DESCRIPTION
In order to match required checks better, I added names to labeler and commitlint jobs.