### PR TITLE
test: create subfolders under tmp for tests

### DIFF
--- a/e2e/cli-e2e/tests/collect.e2e.test.ts
+++ b/e2e/cli-e2e/tests/collect.e2e.test.ts
@@ -36,7 +36,7 @@ describe('CLI collect', () => {
     expect(code).toBe(0);
     expect(stderr).toBe('');
 
-    const report = await readJsonFile('tmp/react-todos-app/report.json');
+    const report = await readJsonFile('tmp/e2e/react-todos-app/report.json');
 
     expect(() => reportSchema.parse(report)).not.toThrow();
     expect(omitVariableReportData(report as Report)).toMatchSnapshot();
@@ -89,7 +89,7 @@ describe('CLI collect', () => {
     expect(code).toBe(0);
     expect(stderr).toBe('');
 
-    const report = await readJsonFile('tmp/react-todos-app/report.json');
+    const report = await readJsonFile('tmp/e2e/react-todos-app/report.json');
 
     expect(() => reportSchema.parse(report)).not.toThrow();
     expect(omitVariableReportData(report as Report)).toMatchSnapshot();
@@ -105,7 +105,7 @@ describe('CLI collect', () => {
     expect(code).toBe(0);
     expect(stderr).toBe('');
 
-    const md = await readTextFile('tmp/react-todos-app/report.md');
+    const md = await readTextFile('tmp/e2e/react-todos-app/report.md');
 
     expect(md).toContain('# Code PushUp Report');
     expect(md).toContain(exampleCategoryTitle);

--- a/examples/react-todos-app/code-pushup.config.js
+++ b/examples/react-todos-app/code-pushup.config.js
@@ -10,7 +10,7 @@ const eslintAuditRef = (slug, weight) => ({
 
 export default {
   persist: {
-    outputDir: '../../tmp/react-todos-app',
+    outputDir: '../../tmp/e2e/react-todos-app',
   },
   plugins: [
     await coveragePlugin({

--- a/global-setup.e2e.ts
+++ b/global-setup.e2e.ts
@@ -1,9 +1,6 @@
 import { execSync } from 'child_process';
-import {
-  setup as globalSetup,
-  teardown as globalTeardown,
-} from './global-setup';
-import { setupTestFolder } from './testing/test-setup/src';
+import { setup as globalSetup } from './global-setup';
+import { setupTestFolder, teardownTestFolder } from './testing/test-setup/src';
 import startLocalRegistry from './tools/scripts/start-local-registry';
 import stopLocalRegistry from './tools/scripts/stop-local-registry';
 
@@ -21,5 +18,6 @@ export async function teardown() {
   execSync('npm uninstall @code-pushup/cli');
   execSync('npm uninstall @code-pushup/eslint-plugin');
   execSync('npm uninstall @code-pushup/coverage-plugin');
-  await globalTeardown();
+  await teardownTestFolder('tmp/e2e');
+  await teardownTestFolder('tmp/local-registry');
 }

--- a/global-setup.ts
+++ b/global-setup.ts
@@ -1,9 +1,3 @@
-import { teardownTestFolder } from './testing/test-setup/src';
-
 export async function setup() {
   process.env.TZ = 'UTC';
-}
-
-export async function teardown() {
-  await teardownTestFolder('tmp');
 }

--- a/packages/utils/src/lib/git.integration.test.ts
+++ b/packages/utils/src/lib/git.integration.test.ts
@@ -12,10 +12,8 @@ import {
 } from './git';
 import { toUnixPath } from './transform';
 
-// we need a separate folder that is not cleaned in `global-setup.ts`, otherwise the tests can't execute in parallel
-const gitTestFolder = 'git-test';
 describe('git utils in a git repo', () => {
-  const baseDir = join(process.cwd(), gitTestFolder);
+  const baseDir = join(process.cwd(), 'tmp', 'git-tests');
   let emptyGit: SimpleGit;
 
   beforeAll(async () => {
@@ -75,12 +73,12 @@ describe('git utils in a git repo', () => {
     it('should convert relative Windows path to relative Git path', async () => {
       await expect(
         toGitPath('Backend\\API\\Startup.cs', emptyGit),
-      ).resolves.toBe('../Backend/API/Startup.cs');
+      ).resolves.toBe('../../Backend/API/Startup.cs');
     });
 
     it('should keep relative Unix path as is (already a Git path)', async () => {
       await expect(toGitPath('Backend/API/Startup.cs', emptyGit)).resolves.toBe(
-        '../Backend/API/Startup.cs',
+        '../../Backend/API/Startup.cs',
       );
     });
 


### PR DESCRIPTION
In this PR, I unify the behaviour of test outputs:
- A test may create a `tmp` subfolder but should not expect `tmp` to be in place.
- A test should clean up after itself - delete a created `tmp` subfolder but not the `tmp` folder itself.

The whole strategy is documented in our [test strategy](https://github.com/code-pushup/cli/wiki/Testing-Strategy#test-outputs).