### PR TITLE
test: add type notation in tests

### DIFF
--- a/examples/plugins/src/lighthouse/src/lighthouse.plugin.ts
+++ b/examples/plugins/src/lighthouse/src/lighthouse.plugin.ts
@@ -102,7 +102,7 @@ export function runnerConfig(options: LighthouseCliOptions): RunnerConfig {
     outputFile: outputPath,
     outputTransform: (lighthouseOutput: unknown) =>
       lhrToAuditOutputs(lighthouseOutput as Result),
-  } satisfies RunnerConfig;
+  };
 }
 
 function lhrToAuditOutputs(lhr: Result): AuditOutputs {

--- a/examples/plugins/src/package-json/src/integration/utils.ts
+++ b/examples/plugins/src/package-json/src/integration/utils.ts
@@ -8,7 +8,7 @@ export function baseAuditOutput(slug: string): AuditOutput {
     score: 1,
     value: 0,
     displayValue: pluralizePackage(),
-  } satisfies AuditOutput;
+  };
 }
 
 export function filterSeverityError(issue: Issue): boolean {

--- a/packages/cli/src/lib/autorun/autorun-command.unit.test.ts
+++ b/packages/cli/src/lib/autorun/autorun-command.unit.test.ts
@@ -1,6 +1,6 @@
 import { vol } from 'memfs';
 import { describe, expect, it, vi } from 'vitest';
-import { PortalUploadArgs, uploadToPortal } from '@code-pushup/portal-client';
+import { uploadToPortal } from '@code-pushup/portal-client';
 import { collectAndPersistReports, readRcByPath } from '@code-pushup/core';
 import { MEMFS_VOLUME, MINIMAL_REPORT_MOCK } from '@code-pushup/test-utils';
 import { DEFAULT_CLI_CONFIGURATION } from '../../../mocks/constants';
@@ -58,7 +58,9 @@ describe('autorun-command', () => {
     );
 
     // values come from CORE_CONFIG_MOCK returned by readRcByPath mock
-    expect(uploadToPortal).toHaveBeenCalledWith({
+    expect(uploadToPortal).toHaveBeenCalledWith<
+      Parameters<typeof uploadToPortal>
+    >({
       apiKey: 'dummy-api-key',
       server: 'https://example.com/api',
       data: {
@@ -72,6 +74,6 @@ describe('autorun-command', () => {
         project: 'cli',
         commit: expect.any(String),
       },
-    } satisfies PortalUploadArgs);
+    });
   });
 });

--- a/packages/cli/src/lib/implementation/core-config.integration.test.ts
+++ b/packages/cli/src/lib/implementation/core-config.integration.test.ts
@@ -4,6 +4,8 @@ import {
   PERSIST_FILENAME,
   PERSIST_FORMAT,
   PERSIST_OUTPUT_DIR,
+  PersistConfig,
+  UploadConfig,
 } from '@code-pushup/models';
 import { CORE_CONFIG_MOCK, MINIMAL_CONFIG_MOCK } from '@code-pushup/test-utils';
 import { yargsCli } from '../yargs-cli';
@@ -58,7 +60,7 @@ describe('parsing values from CLI and middleware', () => {
       },
     ).parseAsync();
 
-    expect(persist).toEqual({
+    expect(persist).toEqual<PersistConfig>({
       filename: PERSIST_FILENAME,
       format: PERSIST_FORMAT,
       outputDir: PERSIST_OUTPUT_DIR,
@@ -79,7 +81,7 @@ describe('parsing values from CLI and middleware', () => {
       },
     ).parseAsync();
 
-    expect(persist).toEqual({
+    expect(persist).toEqual<PersistConfig>({
       filename: 'cli-filename',
       format: ['md'],
       outputDir: 'cli-outputDir',
@@ -95,7 +97,7 @@ describe('parsing values from CLI and middleware', () => {
       },
     ).parseAsync();
 
-    expect(persist).toEqual({
+    expect(persist).toEqual<PersistConfig>({
       filename: 'rc-filename',
       format: ['json', 'md'],
       outputDir: 'rc-outputDir',
@@ -116,7 +118,7 @@ describe('parsing values from CLI and middleware', () => {
       },
     ).parseAsync();
 
-    expect(persist).toEqual({
+    expect(persist).toEqual<PersistConfig>({
       filename: 'cli-filename',
       format: ['md'],
       outputDir: 'cli-outputDir',
@@ -135,7 +137,7 @@ describe('parsing values from CLI and middleware', () => {
       },
     ).parseAsync();
 
-    expect(persist).toEqual({
+    expect(persist).toEqual<PersistConfig>({
       filename: 'rc-filename',
       format: PERSIST_FORMAT,
       outputDir: 'cli-outputdir',
@@ -163,7 +165,7 @@ describe('parsing values from CLI and middleware', () => {
       },
     ).parseAsync();
 
-    expect(upload).toStrictEqual({
+    expect(upload).toStrictEqual<UploadConfig>({
       organization: 'code-pushup',
       project: 'portal',
       apiKey: 'dummy-api-key',

--- a/packages/cli/src/lib/upload/upload-command.unit.test.ts
+++ b/packages/cli/src/lib/upload/upload-command.unit.test.ts
@@ -1,6 +1,6 @@
 import { vol } from 'memfs';
 import { describe, expect, it } from 'vitest';
-import { PortalUploadArgs, uploadToPortal } from '@code-pushup/portal-client';
+import { uploadToPortal } from '@code-pushup/portal-client';
 import { readRcByPath } from '@code-pushup/core';
 import {
   ISO_STRING_REGEXP,
@@ -52,7 +52,9 @@ describe('upload-command-object', () => {
     );
 
     // values come from CORE_CONFIG_MOCK returned by readRcByPath mock
-    expect(uploadToPortal).toHaveBeenCalledWith({
+    expect(uploadToPortal).toHaveBeenCalledWith<
+      Parameters<typeof uploadToPortal>
+    >({
       apiKey: 'dummy-api-key',
       server: 'https://example.com/api',
       data: {
@@ -66,6 +68,6 @@ describe('upload-command-object', () => {
         project: 'cli',
         commit: expect.any(String),
       },
-    } satisfies PortalUploadArgs);
+    });
   });
 });

--- a/packages/cli/src/lib/yargs-cli.integration.test.ts
+++ b/packages/cli/src/lib/yargs-cli.integration.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { CoreConfig } from '@code-pushup/models';
+import { CoreConfig, Format } from '@code-pushup/models';
 import {
   PersistConfigCliOptions,
   UploadConfigCliOptions,
@@ -47,7 +47,7 @@ describe('yargsCli', () => {
       ['--persist.format=md', '--persist.format=json'],
       { options },
     ).parseAsync();
-    expect(parsedArgv.persist?.format).toEqual(['md', 'json']);
+    expect(parsedArgv.persist?.format).toEqual<Format[]>(['md', 'json']);
   });
 
   it('should throw for an invalid persist format', () => {

--- a/packages/core/src/lib/implementation/execute-plugin.ts
+++ b/packages/core/src/lib/implementation/execute-plugin.ts
@@ -92,7 +92,7 @@ export async function executePlugin(
     ...(description && { description }),
     ...(docsUrl && { docsUrl }),
     ...(groups && { groups }),
-  } satisfies PluginReport;
+  };
 }
 
 /**

--- a/packages/core/src/lib/upload.unit.test.ts
+++ b/packages/core/src/lib/upload.unit.test.ts
@@ -1,6 +1,6 @@
 import { vol } from 'memfs';
 import { describe, expect } from 'vitest';
-import { PortalUploadArgs, uploadToPortal } from '@code-pushup/portal-client';
+import { uploadToPortal } from '@code-pushup/portal-client';
 import {
   ISO_STRING_REGEXP,
   MEMFS_VOLUME,
@@ -37,7 +37,9 @@ describe('upload', () => {
 
     expect(result).toEqual({ url: expect.stringContaining('code-pushup/cli') });
 
-    expect(uploadToPortal).toHaveBeenCalledWith({
+    expect(uploadToPortal).toHaveBeenCalledWith<
+      Parameters<typeof uploadToPortal>
+    >({
       apiKey: 'dummy-api-key',
       server: 'https://example.com/api',
       data: {
@@ -51,7 +53,7 @@ describe('upload', () => {
         project: 'cli',
         commit: expect.any(String),
       },
-    } satisfies PortalUploadArgs);
+    });
   });
 
   it('should throw for missing upload configuration', async () => {

--- a/packages/plugin-coverage/src/lib/config.unit.test.ts
+++ b/packages/plugin-coverage/src/lib/config.unit.test.ts
@@ -40,11 +40,11 @@ describe('coveragePluginConfigSchema', () => {
     expect(() => coveragePluginConfigSchema.parse(config)).not.toThrow();
 
     const { coverageTypes } = coveragePluginConfigSchema.parse(config);
-    expect(coverageTypes).toEqual([
+    expect(coverageTypes).toEqual<CoverageType[]>([
       'function',
       'branch',
       'line',
-    ] satisfies CoverageType[]);
+    ]);
   });
 
   it('throws for empty coverage type array', () => {

--- a/packages/plugin-coverage/src/lib/runner/lcov/transform.unit.test.ts
+++ b/packages/plugin-coverage/src/lib/runner/lcov/transform.unit.test.ts
@@ -1,6 +1,6 @@
 import { LCOVRecord } from 'parse-lcov';
 import { describe, it } from 'vitest';
-import { AuditOutput, Issue } from '@code-pushup/models';
+import type { AuditOutput, Issue } from '@code-pushup/models';
 import {
   lcovCoverageToAuditOutput,
   lcovReportToBranchStat,
@@ -28,7 +28,7 @@ describe('lcovReportToFunctionStat', () => {
           details: [{ line: 12, name: 'yargsCli', hit: 6 }],
         },
       }),
-    ).toEqual({ totalHit: 1, totalFound: 1, issues: [] } satisfies LCOVStat);
+    ).toEqual<LCOVStat>({ totalHit: 1, totalFound: 1, issues: [] });
   });
 
   it('should transform an empty LCOV function report to LCOV stat', () => {
@@ -37,7 +37,11 @@ describe('lcovReportToFunctionStat', () => {
         ...lcovRecordMock,
         functions: { hit: 0, found: 0, details: [] },
       }),
-    ).toEqual({ totalHit: 0, totalFound: 0, issues: [] } satisfies LCOVStat);
+    ).toEqual<LCOVStat>({
+      totalHit: 0,
+      totalFound: 0,
+      issues: [],
+    });
   });
 
   it('should transform details from function report to issues', () => {
@@ -101,7 +105,11 @@ describe('lcovReportToLineStat', () => {
           details: [{ line: 1, hit: 6 }],
         },
       }),
-    ).toEqual({ totalHit: 1, totalFound: 1, issues: [] } satisfies LCOVStat);
+    ).toEqual<LCOVStat>({
+      totalHit: 1,
+      totalFound: 1,
+      issues: [],
+    });
   });
 
   it('should transform an empty LCOV line report to LCOV stat', () => {
@@ -110,7 +118,11 @@ describe('lcovReportToLineStat', () => {
         ...lcovRecordMock,
         lines: { hit: 0, found: 0, details: [] },
       }),
-    ).toEqual({ totalHit: 0, totalFound: 0, issues: [] } satisfies LCOVStat);
+    ).toEqual<LCOVStat>({
+      totalHit: 0,
+      totalFound: 0,
+      issues: [],
+    });
   });
 
   it('should transform details from line report to issues', () => {
@@ -210,7 +222,11 @@ describe('lcovReportToBranchStat', () => {
           details: [{ line: 12, taken: 6, branch: 0, block: 0 }],
         },
       }),
-    ).toEqual({ totalHit: 1, totalFound: 1, issues: [] } satisfies LCOVStat);
+    ).toEqual<LCOVStat>({
+      totalHit: 1,
+      totalFound: 1,
+      issues: [],
+    });
   });
 
   it('should transform an empty LCOV branch report to LCOV stat', () => {
@@ -219,7 +235,11 @@ describe('lcovReportToBranchStat', () => {
         ...lcovRecordMock,
         branches: { hit: 0, found: 0, details: [] },
       }),
-    ).toEqual({ totalHit: 0, totalFound: 0, issues: [] } satisfies LCOVStat);
+    ).toEqual<LCOVStat>({
+      totalHit: 0,
+      totalFound: 0,
+      issues: [],
+    });
   });
 
   it('should transform details from branch report to issues', () => {
@@ -279,12 +299,12 @@ describe('lcovCoverageToAudit', () => {
         { totalHit: 56, totalFound: 56, issues: [] },
         'branch',
       ),
-    ).toEqual({
+    ).toEqual<AuditOutput>({
       slug: 'branch-coverage',
       score: 1,
       value: 100,
       displayValue: '100 %',
-    } satisfies AuditOutput);
+    });
   });
 
   it('should transform an empty function coverage to audit output', () => {
@@ -293,12 +313,12 @@ describe('lcovCoverageToAudit', () => {
         { totalHit: 0, totalFound: 0, issues: [] },
         'function',
       ),
-    ).toEqual({
+    ).toEqual<AuditOutput>({
       slug: 'function-coverage',
       score: 1,
       value: 100,
       displayValue: '100 %',
-    } satisfies AuditOutput);
+    });
   });
 
   it('should transform a partial line coverage to audit output', () => {
@@ -317,7 +337,7 @@ describe('lcovCoverageToAudit', () => {
         },
         'line',
       ),
-    ).toEqual({
+    ).toEqual<AuditOutput>({
       slug: 'line-coverage',
       score: 0.9,
       value: 90,
@@ -331,6 +351,6 @@ describe('lcovCoverageToAudit', () => {
           },
         ],
       },
-    } satisfies AuditOutput);
+    });
   });
 });

--- a/packages/plugin-coverage/src/lib/runner/runner.integration.test.ts
+++ b/packages/plugin-coverage/src/lib/runner/runner.integration.test.ts
@@ -15,12 +15,12 @@ describe('createRunnerConfig', () => {
       coverageTypes: ['branch'],
       perfectScoreThreshold: 85,
     });
-    expect(runnerConfig).toStrictEqual({
+    expect(runnerConfig).toStrictEqual<RunnerConfig>({
       command: 'node',
       args: ['executeRunner.ts'],
       outputTransform: expect.any(Function),
       outputFile: expect.stringContaining('runner-output.json'),
-    } satisfies RunnerConfig);
+    });
   });
 
   it('should provide plugin config to runner in JSON file', async () => {

--- a/packages/plugin-coverage/src/lib/utils.unit.test.ts
+++ b/packages/plugin-coverage/src/lib/utils.unit.test.ts
@@ -11,16 +11,16 @@ describe('applyMaxScoreAboveThreshold', () => {
             slug: 'branch-coverage',
             value: 75,
             score: 0.75,
-          } satisfies AuditOutput,
+          },
         ],
         0.7,
       ),
-    ).toEqual([
+    ).toEqual<AuditOutput[]>([
       {
         slug: 'branch-coverage',
         value: 75,
         score: 1,
-      } satisfies AuditOutput,
+      },
     ]);
   });
 
@@ -32,16 +32,16 @@ describe('applyMaxScoreAboveThreshold', () => {
             slug: 'line-coverage',
             value: 60,
             score: 0.6,
-          } satisfies AuditOutput,
+          },
         ],
         0.7,
       ),
-    ).toEqual([
+    ).toEqual<AuditOutput[]>([
       {
         slug: 'line-coverage',
         value: 60,
         score: 0.6,
-      } satisfies AuditOutput,
+      },
     ]);
   });
 });

--- a/packages/plugin-eslint/src/lib/eslint-plugin.integration.test.ts
+++ b/packages/plugin-eslint/src/lib/eslint-plugin.integration.test.ts
@@ -57,17 +57,17 @@ describe('eslintPlugin', () => {
 
     // expect rule from extended base .eslintrc.json
     expect(plugin.audits).toContainEqual(
-      expect.objectContaining({
+      expect.objectContaining<Audit>({
         slug: expect.stringMatching(/^nx-enforce-module-boundaries/),
         title: expect.any(String),
         description: expect.stringContaining('sourceTag'),
-      } satisfies Audit),
+      }),
     );
     // expect rule from utils project's .eslintrc.json
     expect(plugin.audits).toContainEqual(
-      expect.objectContaining({
+      expect.objectContaining<Partial<Audit>>({
         slug: 'nx-dependency-checks',
-      } satisfies Partial<Audit>),
+      }),
     );
   });
 

--- a/packages/plugin-eslint/src/lib/runner.integration.test.ts
+++ b/packages/plugin-eslint/src/lib/runner.integration.test.ts
@@ -72,22 +72,22 @@ describe('executeRunner', () => {
     const json = await readJsonFile<AuditOutput[]>(RUNNER_OUTPUT_PATH);
     // expect warnings from unicorn/filename-case rule from default config
     expect(json).toContainEqual(
-      expect.objectContaining({
+      expect.objectContaining<Partial<AuditOutput>>({
         slug: 'unicorn-filename-case',
         displayValue: '5 warnings',
         details: {
-          issues: expect.arrayContaining([
+          issues: expect.arrayContaining<Issue>([
             {
               severity: 'warning',
               message:
                 'Filename is not in kebab case. Rename it to `use-todos.js`.',
-              source: expect.objectContaining({
+              source: expect.objectContaining<Issue['source']>({
                 file: join(appDir, 'src', 'hooks', 'useTodos.js'),
-              } satisfies Partial<Issue['source']>),
-            } satisfies Issue,
+              }),
+            },
           ]),
         },
-      } satisfies Partial<AuditOutput>),
+      }),
     );
   }, 7000);
 });

--- a/packages/plugin-eslint/src/lib/runner/transform.unit.test.ts
+++ b/packages/plugin-eslint/src/lib/runner/transform.unit.test.ts
@@ -1,5 +1,5 @@
 import type { ESLint } from 'eslint';
-import type { AuditOutput } from '@code-pushup/models';
+import { AuditOutput } from '@code-pushup/models';
 import { lintResultsToAudits } from './transform';
 
 describe('lintResultsToAudits', () => {
@@ -109,7 +109,7 @@ describe('lintResultsToAudits', () => {
           },
         },
       }),
-    ).toEqual([
+    ).toEqual<AuditOutput[]>([
       {
         slug: expect.stringContaining('max-lines'),
         score: 0,
@@ -221,6 +221,6 @@ describe('lintResultsToAudits', () => {
           ],
         },
       },
-    ] satisfies AuditOutput[]);
+    ]);
   });
 });

--- a/packages/plugin-lighthouse/src/lib/utils.unit.test.ts
+++ b/packages/plugin-lighthouse/src/lib/utils.unit.test.ts
@@ -2,6 +2,7 @@ import Details from 'lighthouse/types/lhr/audit-details';
 import { describe, expect, it } from 'vitest';
 import {
   Audit,
+  AuditOutput,
   Group,
   PluginConfig,
   pluginConfigSchema,
@@ -152,10 +153,10 @@ describe('filterAuditsAndGroupsByOnlyOptions to be used in plugin config', () =>
         { onlyAudits: ['speed-index'] },
       );
 
-    expect(filteredAudits).toStrictEqual([
+    expect(filteredAudits).toStrictEqual<Audit[]>([
       { slug: 'speed-index', title: 'Speed Index' },
     ]);
-    expect(filteredGroups).toStrictEqual([
+    expect(filteredGroups).toStrictEqual<Group[]>([
       {
         slug: 'performance',
         title: 'Performance',
@@ -195,10 +196,10 @@ describe('filterAuditsAndGroupsByOnlyOptions to be used in plugin config', () =>
         ],
         { onlyAudits: ['speed-index'] },
       );
-    expect(filteredAudits).toStrictEqual([
+    expect(filteredAudits).toStrictEqual<Audit[]>([
       { slug: 'speed-index', title: 'Speed Index' },
     ]);
-    expect(filteredGroups).toStrictEqual([
+    expect(filteredGroups).toStrictEqual<Group[]>([
       {
         slug: 'performance',
         title: 'Performance',
@@ -245,10 +246,10 @@ describe('filterAuditsAndGroupsByOnlyOptions to be used in plugin config', () =>
         { onlyCategories: ['coverage'] },
       );
 
-    expect(filteredAudits).toStrictEqual([
+    expect(filteredAudits).toStrictEqual<Audit[]>([
       { slug: 'function-coverage', title: 'Function Coverage' },
     ]);
-    expect(filteredGroups).toStrictEqual([
+    expect(filteredGroups).toStrictEqual<Group[]>([
       {
         slug: 'coverage',
         title: 'Code coverage',
@@ -298,10 +299,10 @@ describe('filterAuditsAndGroupsByOnlyOptions to be used in plugin config', () =>
         },
       );
 
-    expect(filteredAudits).toStrictEqual([
+    expect(filteredAudits).toStrictEqual<Audit[]>([
       { slug: 'function-coverage', title: 'Function Coverage' },
     ]);
-    expect(filteredGroups).toStrictEqual([
+    expect(filteredGroups).toStrictEqual<Group[]>([
       {
         slug: 'coverage',
         title: 'Code coverage',
@@ -378,7 +379,7 @@ describe('toAuditOutputs', () => {
           displayValue: '2.8 s',
         },
       ]),
-    ).toStrictEqual([
+    ).toStrictEqual<AuditOutput[]>([
       {
         displayValue: '2.8 s',
         score: 0.55,

--- a/packages/utils/src/lib/reports/utils.unit.test.ts
+++ b/packages/utils/src/lib/reports/utils.unit.test.ts
@@ -79,7 +79,7 @@ describe('getSortableAuditByRef', () => {
           },
         ],
       ),
-    ).toStrictEqual({
+    ).toStrictEqual<SortableAuditReport>({
       slug: 'function-coverage',
       title: 'Function coverage',
       score: 1,
@@ -172,7 +172,7 @@ describe('getSortableGroupByRef', () => {
           },
         ],
       ),
-    ).toStrictEqual({
+    ).toStrictEqual<SortableGroup>({
       slug: 'code-coverage',
       title: 'Code coverage',
       score: 0.66,
@@ -311,11 +311,9 @@ describe('countWeightedRefs', () => {
 describe('compareIssueSeverity', () => {
   it('should order severities in logically ascending order when used as compareFn with .sort()', () => {
     const severityArr = ['error', 'info', 'warning'] satisfies IssueSeverity[];
-    expect([...severityArr].sort(compareIssueSeverity)).toEqual([
-      'info',
-      'warning',
-      'error',
-    ]);
+    expect([...severityArr].sort(compareIssueSeverity)).toEqual<
+      IssueSeverity[]
+    >(['info', 'warning', 'error']);
   });
 });
 

--- a/packages/utils/src/lib/reports/utils.unit.test.ts
+++ b/packages/utils/src/lib/reports/utils.unit.test.ts
@@ -310,7 +310,7 @@ describe('countWeightedRefs', () => {
 
 describe('compareIssueSeverity', () => {
   it('should order severities in logically ascending order when used as compareFn with .sort()', () => {
-    const severityArr = ['error', 'info', 'warning'] satisfies IssueSeverity[];
+    const severityArr: IssueSeverity[] = ['error', 'info', 'warning'];
     expect([...severityArr].sort(compareIssueSeverity)).toEqual<
       IssueSeverity[]
     >(['info', 'warning', 'error']);


### PR DESCRIPTION
Upon discovering one can use a type argument in `toEqual` and `toStrictEqual`, I added these arguments in our tests. They replace the need for `satisfies` in expected test output.

Note: The type argument cannot be used when the output from `expect` is a promise that requires a `resolves` first.