### PR TITLE
feat(plugin-js-packages): set up and implement configuration for audit plugin

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,5 +12,6 @@ mocks/ @Tlacenka
 # Plugins
 /packages/plugin-eslint/ @matejchalk
 /packages/plugin-coverage/ @Tlacenka
+/packages/plugin-js-packages/ @Tlacenka
 /packages/plugin-lighthouse/ @BioPhoton
 /examples/plugins/ @BioPhoton

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -26,6 +26,10 @@
   - changed-files:
       - any-glob-to-any-file: 'packages/plugin-coverage/src/**'
 
+🧩 js-packages-plugin:
+  - changed-files:
+      - any-glob-to-any-file: 'packages/plugin-js-packages/src/**'
+
 🧩 utils:
   - changed-files:
       - any-glob-to-any-file: 'packages/utils/src/**'

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -12,7 +12,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        lib: [cli, core, models, utils, plugin-eslint, plugin-coverage]
+        lib:
+          [
+            cli,
+            core,
+            models,
+            utils,
+            plugin-eslint,
+            plugin-coverage,
+            plugin-js-packages,
+          ]
         scope: [unit, integration]
     name: Update code coverage
     runs-on: ubuntu-latest

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -13,15 +13,13 @@ jobs:
       fail-fast: false
       matrix:
         lib:
-          [
-            cli,
-            core,
-            models,
-            utils,
-            plugin-eslint,
-            plugin-coverage,
-            plugin-js-packages,
-          ]
+          - cli
+          - core
+          - models
+          - utils
+          - plugin-eslint
+          - plugin-coverage
+          - plugin-js-packages
         scope: [unit, integration]
     name: Update code coverage
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -30,5 +30,6 @@ This monorepo contains code for open-source Code PushUp NPM packages:
 - plugins:
   - [📦 @code-pushup/eslint-plugin](./packages/plugin-eslint#readme) - static analysis using **ESLint** rules
   - [📦 @code-pushup/coverage-plugin](./packages/plugin-coverage#readme) - code coverage analysis
+  - [📦 @code-pushup/js-packages-plugin](./packages/plugin-js-packages#readme) - package audit and outdated dependencies
 
 If you want to contribute, please refer to [CONTRIBUTING.md](./CONTRIBUTING.md).

--- a/e2e/cli-e2e/project.json
+++ b/e2e/cli-e2e/project.json
@@ -23,6 +23,7 @@
     "plugin-eslint",
     "plugin-lighthouse",
     "plugin-coverage",
+    "plugin-js-packages",
     "react-todos-app"
   ],
   "tags": ["scope:core", "scope:plugin", "type:e2e"]

--- a/packages/plugin-js-packages/.eslintrc.json
+++ b/packages/plugin-js-packages/.eslintrc.json
@@ -1,0 +1,19 @@
+{
+  "extends": ["../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx"],
+      "parserOptions": {
+        "project": ["packages/plugin-js-packages/tsconfig.*?.json"]
+      }
+    },
+    {
+      "files": ["*.json"],
+      "parser": "jsonc-eslint-parser",
+      "rules": {
+        "@nx/dependency-checks": ["error"]
+      }
+    }
+  ]
+}

--- a/packages/plugin-js-packages/README.md
+++ b/packages/plugin-js-packages/README.md
@@ -7,13 +7,17 @@
 📦 **Code PushUp plugin for JavaScript packages.** 🛡️
 
 This plugin allows you to list outdated dependencies and run audit for known vulnerabilities.
-It supports the following package managers: npm, yarn, yarn berry, pnpm.
+It supports the following package managers:
+
+- [NPM](https://docs.npmjs.com/)
+- [Yarn v1](https://classic.yarnpkg.com/docs/) & [Yarn v2+](https://yarnpkg.com/getting-started)
+- [PNPM](https://pnpm.io/pnpm-cli)
 
 ## Getting started
 
 1. If you haven't already, install [@code-pushup/cli](../cli/README.md) and create a configuration file.
 
-2. Insert plugin configuration. By default, npm audit and npm outdated commands will be run.
+2. Insert plugin configuration. By default, `audit` and `outdated` commands will be run.
 
    Default configuration will look as follows:
 
@@ -40,7 +44,7 @@ It supports the following package managers: npm, yarn, yarn berry, pnpm.
      // ...
      plugins: [
        // ...
-       await jsPackagesPlugin({ packageManager: ['yarn'], features: ['audit'] }),
+       await jsPackagesPlugin({ packageManager: ['yarn'], checks: ['audit'] }),
      ],
    };
    ```
@@ -78,8 +82,8 @@ It supports the following package managers: npm, yarn, yarn berry, pnpm.
 
 The plugin accepts the following parameters:
 
-- (optional) `packageManager`: The package manager you are using. Supported values: `npm`, `yarn` (v1), `yarn-berry` (v2+), `pnpm`. Default is `npm`.
-- (optional) `features`: Array of commands to be run. Supported commands: `audit`, `outdated`. Both are configured by default.
+- (optional) `packageManager`: The package manager you are using. Supported values: `npm`, `yarn-classic` (v1), `yarn-modern` (v2+), `pnpm`. Default is `npm`.
+- (optional) `checks`: Array of checks to be run. Supported commands: `audit`, `outdated`. Both are configured by default.
 - (optional) `auditLevelMapping`: If you wish to set a custom level of issue severity based on audit vulnerability level, you may do so here. Any omitted values will be filled in by defaults. Audit levels are: `critical`, `high`, `moderate`, `low` and `info`. Issue severities are: `error`, `warn` and `info`. By default the mapping is as follows: `critical` and `high` → `error`; `moderate` and `low` → `warning`; `info` → `info`.
 
 > [!NOTE]

--- a/packages/plugin-js-packages/README.md
+++ b/packages/plugin-js-packages/README.md
@@ -1,0 +1,9 @@
+# @code-pushup/js-packages-plugin
+
+[![npm](https://img.shields.io/npm/v/%40code-pushup%2Fjs-packages-plugin.svg)](https://www.npmjs.com/package/@code-pushup/js-packages-plugin)
+[![downloads](https://img.shields.io/npm/dm/%40code-pushup%2Fjs-packages-plugin)](https://npmtrends.com/@code-pushup/js-packages-plugin)
+[![dependencies](https://img.shields.io/librariesio/release/npm/%40code-pushup/js-packages-plugin)](https://www.npmjs.com/package/@code-pushup/js-packages-plugin?activeTab=dependencies)
+
+🧪 **Code PushUp plugin for JavaScript packages.** ☂️
+
+This plugin allows you to list outdated dependencies and run audit for known vulnerabilities.

--- a/packages/plugin-js-packages/README.md
+++ b/packages/plugin-js-packages/README.md
@@ -4,6 +4,135 @@
 [![downloads](https://img.shields.io/npm/dm/%40code-pushup%2Fjs-packages-plugin)](https://npmtrends.com/@code-pushup/js-packages-plugin)
 [![dependencies](https://img.shields.io/librariesio/release/npm/%40code-pushup/js-packages-plugin)](https://www.npmjs.com/package/@code-pushup/js-packages-plugin?activeTab=dependencies)
 
-🧪 **Code PushUp plugin for JavaScript packages.** ☂️
+📦 **Code PushUp plugin for JavaScript packages.** 🛡️
 
 This plugin allows you to list outdated dependencies and run audit for known vulnerabilities.
+It supports the following package managers: npm, yarn, yarn berry, pnpm.
+
+## Getting started
+
+1. If you haven't already, install [@code-pushup/cli](../cli/README.md) and create a configuration file.
+
+2. Insert plugin configuration. By default, npm audit and npm outdated commands will be run.
+
+   Default configuration will look as follows:
+
+   ```js
+   import jsPackagesPlugin from '@code-pushup/js-packages-plugin';
+
+   export default {
+     // ...
+     plugins: [
+       // ...
+       await jsPackagesPlugin(),
+     ],
+   };
+   ```
+
+   You may run this plugin with a custom configuration for any supported package manager or command.
+
+   A custom configuration will look similarly to the following:
+
+   ```js
+   import jsPackagesPlugin from '@code-pushup/js-packages-plugin';
+
+   export default {
+     // ...
+     plugins: [
+       // ...
+       await jsPackagesPlugin({ packageManager: ['yarn'], features: ['audit'] }),
+     ],
+   };
+   ```
+
+3. (Optional) Reference individual audits or the provided plugin group which you wish to include in custom categories (use `npx code-pushup print-config` to list audits and groups).
+
+   💡 Assign weights based on what influence each command should have on the overall category score (assign weight 0 to only include as extra info, without influencing category score).
+
+   ```js
+   export default {
+     // ...
+     categories: [
+       {
+         slug: 'dependencies',
+         title: 'Package dependencies',
+         refs: [
+           {
+             type: 'group',
+             plugin: 'npm-package-manager', // replace prefix with your package manager
+             slug: 'js-packages',
+             weight: 1,
+           },
+         ],
+       },
+       // ...
+     ],
+   };
+   ```
+
+4. Run the CLI with `npx code-pushup collect` and view or upload report (refer to [CLI docs](../cli/README.md)).
+
+## Plugin architecture
+
+### Plugin configuration specification
+
+The plugin accepts the following parameters:
+
+- (optional) `packageManager`: The package manager you are using. Supported values: `npm`, `yarn` (v1), `yarn-berry` (v2+), `pnpm`. Default is `npm`.
+- (optional) `features`: Array of commands to be run. Supported commands: `audit`, `outdated`. Both are configured by default.
+- (optional) `auditLevelMapping`: If you wish to set a custom level of issue severity based on audit vulnerability level, you may do so here. Any omitted values will be filled in by defaults. Audit levels are: `critical`, `high`, `moderate`, `low` and `info`. Issue severities are: `error`, `warn` and `info`. By default the mapping is as follows: `critical` and `high` → `error`; `moderate` and `low` → `warning`; `info` → `info`.
+
+> [!NOTE]
+> All parameters are optional so the plugin can be called with no arguments in the default setting.
+
+### Audits and group
+
+This plugin provides a group for convenient declaration in your config. When defined this way, all measured coverage type audits have the same weight.
+
+```ts
+     // ...
+     categories: [
+       {
+         slug: 'dependencies',
+         title: 'Package dependencies',
+         refs: [
+           {
+             type: 'group',
+             plugin: 'js-packages',
+             slug: 'npm-package-manager', // replace prefix with your package manager
+             weight: 1,
+           },
+           // ...
+         ],
+       },
+       // ...
+     ],
+```
+
+Each package manager command still has its own audit. So when you want to include a subset of commands or assign different weights to them, you can do so in the following way:
+
+```ts
+     // ...
+     categories: [
+       {
+         slug: 'dependencies',
+         title: 'Package dependencies',
+         refs: [
+           {
+             type: 'audit',
+             plugin: 'js-packages',
+             slug: 'npm-audit', // replace prefix with your package manager
+             weight: 2,
+           },
+           {
+             type: 'audit',
+             plugin: 'js-packages',
+             slug: 'npm-outdated', // replace prefix with your package manager
+             weight: 1,
+           },
+           // ...
+         ],
+       },
+       // ...
+     ],
+```

--- a/packages/plugin-js-packages/README.md
+++ b/packages/plugin-js-packages/README.md
@@ -6,7 +6,7 @@
 
 📦 **Code PushUp plugin for JavaScript packages.** 🛡️
 
-This plugin allows you to list outdated dependencies and run audit for known vulnerabilities.
+This plugin checks for known vulnerabilities and outdated dependencies.
 It supports the following package managers:
 
 - [NPM](https://docs.npmjs.com/)
@@ -17,9 +17,7 @@ It supports the following package managers:
 
 1. If you haven't already, install [@code-pushup/cli](../cli/README.md) and create a configuration file.
 
-2. Insert plugin configuration. By default, `audit` and `outdated` commands will be run.
-
-   Default configuration will look as follows:
+2. Insert plugin configuration with your package manager. By default, both `audit` and `outdated` checks will be run. The result should look as follows:
 
    ```js
    import jsPackagesPlugin from '@code-pushup/js-packages-plugin';
@@ -28,14 +26,12 @@ It supports the following package managers:
      // ...
      plugins: [
        // ...
-       await jsPackagesPlugin(),
+       await jsPackagesPlugin({ packageManager: 'npm' }), // replace with your package manager
      ],
    };
    ```
 
-   You may run this plugin with a custom configuration for any supported package manager or command.
-
-   A custom configuration will look similarly to the following:
+   You may run this plugin with a custom configuration for any supported package manager or command. A custom configuration will look similarly to the following:
 
    ```js
    import jsPackagesPlugin from '@code-pushup/js-packages-plugin';
@@ -49,7 +45,7 @@ It supports the following package managers:
    };
    ```
 
-3. (Optional) Reference individual audits or the provided plugin group which you wish to include in custom categories (use `npx code-pushup print-config` to list audits and groups).
+3. (Optional) Reference individual audits or the provided plugin groups which you wish to include in custom categories (use `npx code-pushup print-config` to list audits and groups).
 
    💡 Assign weights based on what influence each command should have on the overall category score (assign weight 0 to only include as extra info, without influencing category score).
 
@@ -58,15 +54,28 @@ It supports the following package managers:
      // ...
      categories: [
        {
-         slug: 'dependencies',
-         title: 'Package dependencies',
+         slug: 'security',
+         title: 'Security',
          refs: [
            {
              type: 'group',
-             plugin: 'npm-package-manager', // replace prefix with your package manager
+             plugin: 'npm-audit', // replace prefix with your package manager
              slug: 'js-packages',
              weight: 1,
            },
+         ],
+       },
+       {
+         slug: 'up-to-date',
+         title: 'Up-to-date tools',
+         refs: [
+           {
+             type: 'group',
+             plugin: 'npm-outdated', // replace prefix with your package manager
+             slug: 'js-packages',
+             weight: 1,
+           },
+           // ...
          ],
        },
        // ...
@@ -82,16 +91,13 @@ It supports the following package managers:
 
 The plugin accepts the following parameters:
 
-- (optional) `packageManager`: The package manager you are using. Supported values: `npm`, `yarn-classic` (v1), `yarn-modern` (v2+), `pnpm`. Default is `npm`.
+- `packageManager`: The package manager you are using. Supported values: `npm`, `yarn-classic` (v1), `yarn-modern` (v2+), `pnpm`.
 - (optional) `checks`: Array of checks to be run. Supported commands: `audit`, `outdated`. Both are configured by default.
 - (optional) `auditLevelMapping`: If you wish to set a custom level of issue severity based on audit vulnerability level, you may do so here. Any omitted values will be filled in by defaults. Audit levels are: `critical`, `high`, `moderate`, `low` and `info`. Issue severities are: `error`, `warn` and `info`. By default the mapping is as follows: `critical` and `high` → `error`; `moderate` and `low` → `warning`; `info` → `info`.
 
-> [!NOTE]
-> All parameters are optional so the plugin can be called with no arguments in the default setting.
-
 ### Audits and group
 
-This plugin provides a group for convenient declaration in your config. When defined this way, all measured coverage type audits have the same weight.
+This plugin provides a group per check for a convenient declaration in your config.
 
 ```ts
      // ...
@@ -103,7 +109,13 @@ This plugin provides a group for convenient declaration in your config. When def
            {
              type: 'group',
              plugin: 'js-packages',
-             slug: 'npm-package-manager', // replace prefix with your package manager
+             slug: 'npm-audit', // replace prefix with your package manager
+             weight: 1,
+           },
+           {
+             type: 'group',
+             plugin: 'js-packages',
+             slug: 'npm-outdated', // replace prefix with your package manager
              weight: 1,
            },
            // ...
@@ -113,7 +125,7 @@ This plugin provides a group for convenient declaration in your config. When def
      ],
 ```
 
-Each package manager command still has its own audit. So when you want to include a subset of commands or assign different weights to them, you can do so in the following way:
+Each dependency group has its own audit. If you want to check only a subset of dependencies (e.g. run audit and outdated for production dependencies) or assign different weights to them, you can do so in the following way:
 
 ```ts
      // ...
@@ -125,14 +137,20 @@ Each package manager command still has its own audit. So when you want to includ
            {
              type: 'audit',
              plugin: 'js-packages',
-             slug: 'npm-audit', // replace prefix with your package manager
+             slug: 'npm-audit-prod', // replace prefix with your package manager
              weight: 2,
+           },
+                      {
+             type: 'audit',
+             plugin: 'js-packages',
+             slug: 'npm-audit-dev', // replace prefix with your package manager
+             weight: 1,
            },
            {
              type: 'audit',
              plugin: 'js-packages',
-             slug: 'npm-outdated', // replace prefix with your package manager
-             weight: 1,
+             slug: 'npm-outdated-prod', // replace prefix with your package manager
+             weight: 2,
            },
            // ...
          ],

--- a/packages/plugin-js-packages/package.json
+++ b/packages/plugin-js-packages/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@code-pushup/js-packages-plugin",
+  "version": "0.26.1",
+  "dependencies": {
+    "@code-pushup/models": "*",
+    "zod": "^3.22.4"
+  }
+}

--- a/packages/plugin-js-packages/package.json
+++ b/packages/plugin-js-packages/package.json
@@ -3,6 +3,7 @@
   "version": "0.26.1",
   "dependencies": {
     "@code-pushup/models": "*",
+    "@code-pushup/utils": "*",
     "zod": "^3.22.4"
   }
 }

--- a/packages/plugin-js-packages/project.json
+++ b/packages/plugin-js-packages/project.json
@@ -1,0 +1,56 @@
+{
+  "name": "plugin-js-packages",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/plugin-js-packages/src",
+  "projectType": "library",
+  "targets": {
+    "build": {
+      "executor": "@nx/esbuild:esbuild",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "outputPath": "dist/packages/plugin-js-packages",
+        "main": "packages/plugin-js-packages/src/index.ts",
+        "tsConfig": "packages/plugin-js-packages/tsconfig.lib.json",
+        "additionalEntryPoints": ["packages/plugin-js-packages/src/bin.ts"],
+        "assets": ["packages/plugin-js-packages/*.md"],
+        "esbuildConfig": "esbuild.config.js"
+      }
+    },
+    "lint": {
+      "executor": "@nx/linter:eslint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": [
+          "packages/plugin-js-packages/**/*.ts",
+          "packages/plugin-js-packages/package.json"
+        ]
+      }
+    },
+    "unit-test": {
+      "executor": "@nx/vite:test",
+      "outputs": ["{options.reportsDirectory}"],
+      "options": {
+        "config": "packages/plugin-js-packages/vite.config.unit.ts",
+        "reportsDirectory": "../../coverage/plugin-js-packages/unit-tests"
+      }
+    },
+    "integration-test": {
+      "executor": "@nx/vite:test",
+      "outputs": ["{options.reportsDirectory}"],
+      "options": {
+        "config": "packages/plugin-js-packages/vite.config.integration.ts",
+        "reportsDirectory": "../../coverage/plugin-js-packages/integration-tests"
+      }
+    },
+    "deploy": {
+      "options": {
+        "distFolderPath": "dist/packages/plugin-js-packages"
+      }
+    },
+    "publish": {
+      "command": "node tools/scripts/publish.mjs plugin-js-packages {args.ver} {args.tag}",
+      "dependsOn": ["build"]
+    }
+  },
+  "tags": ["scope:plugin", "type:feature"]
+}

--- a/packages/plugin-js-packages/src/bin.ts
+++ b/packages/plugin-js-packages/src/bin.ts
@@ -1,0 +1,3 @@
+import { executeRunner } from './lib/runner';
+
+executeRunner();

--- a/packages/plugin-js-packages/src/index.ts
+++ b/packages/plugin-js-packages/src/index.ts
@@ -1,0 +1,4 @@
+import { jsPackagesPlugin } from './lib/js-packages-plugin';
+
+export default jsPackagesPlugin;
+export type { JSPackagesPluginConfig } from './lib/config';

--- a/packages/plugin-js-packages/src/lib/config.ts
+++ b/packages/plugin-js-packages/src/lib/config.ts
@@ -1,0 +1,83 @@
+import { z } from 'zod';
+import { IssueSeverity, issueSeveritySchema } from '@code-pushup/models';
+
+const packageCommandSchema = z.enum(['audit', 'outdated']);
+export type PackageCommand = z.infer<typeof packageCommandSchema>;
+
+const packageManagerSchema = z.enum(['npm', 'yarn', 'yarn-berry', 'pnpm']);
+export type PackageManager = z.infer<typeof packageManagerSchema>;
+
+const packageAuditLevelSchema = z.enum([
+  'info',
+  'low',
+  'moderate',
+  'high',
+  'critical',
+]);
+export type PackageAuditLevel = z.infer<typeof packageAuditLevelSchema>;
+
+const defaultAuditLevelMapping: Record<PackageAuditLevel, IssueSeverity> = {
+  critical: 'error',
+  high: 'error',
+  moderate: 'warning',
+  low: 'warning',
+  info: 'info',
+};
+
+export function fillAuditLevelMapping(
+  mapping: Partial<Record<PackageAuditLevel, IssueSeverity>>,
+): Record<PackageAuditLevel, IssueSeverity> {
+  return {
+    critical: mapping.critical ?? defaultAuditLevelMapping.critical,
+    high: mapping.high ?? defaultAuditLevelMapping.high,
+    moderate: mapping.moderate ?? defaultAuditLevelMapping.moderate,
+    low: mapping.low ?? defaultAuditLevelMapping.low,
+    info: mapping.info ?? defaultAuditLevelMapping.info,
+  };
+}
+
+// TODO how?
+// export function objectKeys<T extends object>(obj: T): (keyof T)[] {
+//   return Object.keys(obj) as (keyof T)[];
+// }
+
+// function newFillAuditLevelMapping(
+//   mapping: Partial<Record<PackageAuditLevel, IssueSeverity>>,
+// ): Record<PackageAuditLevel, IssueSeverity> {
+//   return Object.fromEntries(
+//     objectKeys(defaultAuditLevelMapping).map<
+//       [PackageAuditLevel, IssueSeverity]
+//     >(auditLevel => [
+//       auditLevel,
+//       mapping[auditLevel] ?? defaultAuditLevelMapping[auditLevel],
+//     ]),
+//   );
+// }
+
+export const jsPackagesPluginConfigSchema = z.object({
+  features: z
+    .array(packageCommandSchema, {
+      description:
+        'Package manager commands to be run. Defaults to both audit and outdated.',
+    })
+    .min(1)
+    .default(['audit', 'outdated']),
+  packageManager: packageManagerSchema
+    .describe('Package manager to be used. Defaults to npm')
+    .default('npm'),
+  auditLevelMapping: z
+    .record(packageAuditLevelSchema, issueSeveritySchema, {
+      description:
+        'Mapping of audit levels to issue severity. Custom mapping or overrides may be entered manually, otherwise has a default preset.',
+    })
+    .default(defaultAuditLevelMapping)
+    .transform(fillAuditLevelMapping),
+});
+
+export type JSPackagesPluginConfig = z.input<
+  typeof jsPackagesPluginConfigSchema
+>;
+
+export type FinalJSPackagesPluginConfig = z.infer<
+  typeof jsPackagesPluginConfigSchema
+>;

--- a/packages/plugin-js-packages/src/lib/config.ts
+++ b/packages/plugin-js-packages/src/lib/config.ts
@@ -49,9 +49,7 @@ export const jsPackagesPluginConfigSchema = z.object({
     })
     .min(1)
     .default(['audit', 'outdated']),
-  packageManager: packageManagerSchema
-    .describe('Package manager to be used. Defaults to npm')
-    .default('npm'),
+  packageManager: packageManagerSchema.describe('Package manager to be used.'),
   auditLevelMapping: z
     .record(packageAuditLevelSchema, issueSeveritySchema, {
       description:
@@ -68,3 +66,5 @@ export type JSPackagesPluginConfig = z.input<
 export type FinalJSPackagesPluginConfig = z.infer<
   typeof jsPackagesPluginConfigSchema
 >;
+
+export type PackageDependencyType = 'prod' | 'dev' | 'optional';

--- a/packages/plugin-js-packages/src/lib/config.ts
+++ b/packages/plugin-js-packages/src/lib/config.ts
@@ -4,7 +4,12 @@ import { IssueSeverity, issueSeveritySchema } from '@code-pushup/models';
 const packageCommandSchema = z.enum(['audit', 'outdated']);
 export type PackageCommand = z.infer<typeof packageCommandSchema>;
 
-const packageManagerSchema = z.enum(['npm', 'yarn', 'yarn-berry', 'pnpm']);
+const packageManagerSchema = z.enum([
+  'npm',
+  'yarn-classic',
+  'yarn-modern',
+  'pnpm',
+]);
 export type PackageManager = z.infer<typeof packageManagerSchema>;
 
 const packageAuditLevelSchema = z.enum([
@@ -36,26 +41,8 @@ export function fillAuditLevelMapping(
   };
 }
 
-// TODO how?
-// export function objectKeys<T extends object>(obj: T): (keyof T)[] {
-//   return Object.keys(obj) as (keyof T)[];
-// }
-
-// function newFillAuditLevelMapping(
-//   mapping: Partial<Record<PackageAuditLevel, IssueSeverity>>,
-// ): Record<PackageAuditLevel, IssueSeverity> {
-//   return Object.fromEntries(
-//     objectKeys(defaultAuditLevelMapping).map<
-//       [PackageAuditLevel, IssueSeverity]
-//     >(auditLevel => [
-//       auditLevel,
-//       mapping[auditLevel] ?? defaultAuditLevelMapping[auditLevel],
-//     ]),
-//   );
-// }
-
 export const jsPackagesPluginConfigSchema = z.object({
-  features: z
+  checks: z
     .array(packageCommandSchema, {
       description:
         'Package manager commands to be run. Defaults to both audit and outdated.',

--- a/packages/plugin-js-packages/src/lib/config.unit.test.ts
+++ b/packages/plugin-js-packages/src/lib/config.unit.test.ts
@@ -20,11 +20,17 @@ describe('jsPackagesPluginConfigSchema', () => {
   });
 
   it('should accept a minimal JS package configuration', () => {
-    expect(() => jsPackagesPluginConfigSchema.parse({})).not.toThrow();
+    expect(() =>
+      jsPackagesPluginConfigSchema.parse({
+        packageManager: 'pnpm',
+      } satisfies JSPackagesPluginConfig),
+    ).not.toThrow();
   });
 
   it('should fill in default values', () => {
-    const config = jsPackagesPluginConfigSchema.parse({});
+    const config = jsPackagesPluginConfigSchema.parse({
+      packageManager: 'npm',
+    });
     expect(config).toEqual<FinalJSPackagesPluginConfig>({
       checks: ['audit', 'outdated'],
       packageManager: 'npm',
@@ -39,9 +45,12 @@ describe('jsPackagesPluginConfigSchema', () => {
   });
 
   it('should throw for no passed commands', () => {
-    expect(() => jsPackagesPluginConfigSchema.parse({ checks: [] })).toThrow(
-      'too_small',
-    );
+    expect(() =>
+      jsPackagesPluginConfigSchema.parse({
+        packageManager: 'yarn-classic',
+        checks: [],
+      }),
+    ).toThrow('too_small');
   });
 });
 

--- a/packages/plugin-js-packages/src/lib/config.unit.test.ts
+++ b/packages/plugin-js-packages/src/lib/config.unit.test.ts
@@ -13,8 +13,8 @@ describe('jsPackagesPluginConfigSchema', () => {
     expect(() =>
       jsPackagesPluginConfigSchema.parse({
         auditLevelMapping: { moderate: 'error' },
-        features: ['audit'],
-        packageManager: 'yarn',
+        checks: ['audit'],
+        packageManager: 'yarn-classic',
       } satisfies JSPackagesPluginConfig),
     ).not.toThrow();
   });
@@ -26,7 +26,7 @@ describe('jsPackagesPluginConfigSchema', () => {
   it('should fill in default values', () => {
     const config = jsPackagesPluginConfigSchema.parse({});
     expect(config).toEqual<FinalJSPackagesPluginConfig>({
-      features: ['audit', 'outdated'],
+      checks: ['audit', 'outdated'],
       packageManager: 'npm',
       auditLevelMapping: {
         critical: 'error',
@@ -38,8 +38,8 @@ describe('jsPackagesPluginConfigSchema', () => {
     });
   });
 
-  it('should throw for no features', () => {
-    expect(() => jsPackagesPluginConfigSchema.parse({ features: [] })).toThrow(
+  it('should throw for no passed commands', () => {
+    expect(() => jsPackagesPluginConfigSchema.parse({ checks: [] })).toThrow(
       'too_small',
     );
   });

--- a/packages/plugin-js-packages/src/lib/config.unit.test.ts
+++ b/packages/plugin-js-packages/src/lib/config.unit.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { IssueSeverity } from '@code-pushup/models';
+import {
+  FinalJSPackagesPluginConfig,
+  JSPackagesPluginConfig,
+  PackageAuditLevel,
+  fillAuditLevelMapping,
+  jsPackagesPluginConfigSchema,
+} from './config';
+
+describe('jsPackagesPluginConfigSchema', () => {
+  it('should accept a JS package configuration with all entities', () => {
+    expect(() =>
+      jsPackagesPluginConfigSchema.parse({
+        auditLevelMapping: { moderate: 'error' },
+        features: ['audit'],
+        packageManager: 'yarn',
+      } satisfies JSPackagesPluginConfig),
+    ).not.toThrow();
+  });
+
+  it('should accept a minimal JS package configuration', () => {
+    expect(() => jsPackagesPluginConfigSchema.parse({})).not.toThrow();
+  });
+
+  it('should fill in default values', () => {
+    const config = jsPackagesPluginConfigSchema.parse({});
+    expect(config).toEqual<FinalJSPackagesPluginConfig>({
+      features: ['audit', 'outdated'],
+      packageManager: 'npm',
+      auditLevelMapping: {
+        critical: 'error',
+        high: 'error',
+        moderate: 'warning',
+        low: 'warning',
+        info: 'info',
+      },
+    });
+  });
+
+  it('should throw for no features', () => {
+    expect(() => jsPackagesPluginConfigSchema.parse({ features: [] })).toThrow(
+      'too_small',
+    );
+  });
+});
+
+describe('fillAuditLevelMapping', () => {
+  it('should fill in defaults', () => {
+    expect(fillAuditLevelMapping({})).toEqual<
+      Record<PackageAuditLevel, IssueSeverity>
+    >({
+      critical: 'error',
+      high: 'error',
+      moderate: 'warning',
+      low: 'warning',
+      info: 'info',
+    });
+  });
+
+  it('should override mapping for given values', () => {
+    expect(fillAuditLevelMapping({ high: 'warning', low: 'info' })).toEqual<
+      Record<PackageAuditLevel, IssueSeverity>
+    >({
+      critical: 'error',
+      high: 'warning',
+      moderate: 'warning',
+      low: 'info',
+      info: 'info',
+    });
+  });
+});

--- a/packages/plugin-js-packages/src/lib/constants.ts
+++ b/packages/plugin-js-packages/src/lib/constants.ts
@@ -1,5 +1,5 @@
 import { MaterialIcon } from '@code-pushup/models';
-import { PackageManager } from './config';
+import { PackageDependencyType, PackageManager } from './config';
 
 export const pkgManagerNames: Record<PackageManager, string> = {
   npm: 'NPM',
@@ -25,7 +25,7 @@ export const auditDocs: Record<PackageManager, string> = {
   npm: 'https://docs.npmjs.com/cli/commands/npm-audit',
   'yarn-classic': 'https://classic.yarnpkg.com/docs/cli/audit',
   'yarn-modern': 'https://yarnpkg.com/cli/npm/audit',
-  pnpm: 'https://pnpm.io/',
+  pnpm: 'https://pnpm.io/cli/audit/',
 };
 
 export const outdatedDocs: Record<PackageManager, string> = {
@@ -33,4 +33,11 @@ export const outdatedDocs: Record<PackageManager, string> = {
   'yarn-classic': 'https://classic.yarnpkg.com/docs/cli/outdated/',
   'yarn-modern': 'https://github.com/mskelton/yarn-plugin-outdated',
   pnpm: 'https://pnpm.io/cli/outdated',
+};
+
+export const dependencyDocs: Record<PackageDependencyType, string> = {
+  prod: 'https://classic.yarnpkg.com/docs/dependency-types#toc-dependencies',
+  dev: 'https://classic.yarnpkg.com/docs/dependency-types#toc-devdependencies',
+  optional:
+    'https://classic.yarnpkg.com/docs/dependency-types#toc-optionaldependencies',
 };

--- a/packages/plugin-js-packages/src/lib/js-packages-plugin.ts
+++ b/packages/plugin-js-packages/src/lib/js-packages-plugin.ts
@@ -1,0 +1,81 @@
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Audit, Group, PluginConfig } from '@code-pushup/models';
+import { name, version } from '../../package.json';
+import {
+  JSPackagesPluginConfig,
+  PackageCommand,
+  jsPackagesPluginConfigSchema,
+} from './config';
+import { createRunnerConfig } from './runner';
+import { auditDocs, outdatedDocs, pkgManagerDocs } from './utils';
+
+/**
+ * Instantiates Code PushUp JS packages plugin for core config.
+ *
+ * @example
+ * import coveragePlugin from '@code-pushup/js-packages-plugin'
+ *
+ * export default {
+ *   // ... core config ...
+ *   plugins: [
+ *     // ... other plugins ...
+ *     await jsPackagesPlugin()
+ *   ]
+ * }
+ *
+ * @returns Plugin configuration.
+ */
+export async function jsPackagesPlugin(
+  config: JSPackagesPluginConfig = {},
+): Promise<PluginConfig> {
+  const jsPackagesPluginConfig = jsPackagesPluginConfigSchema.parse(config);
+  const pkgManager = jsPackagesPluginConfig.packageManager;
+  const features = [...new Set(jsPackagesPluginConfig.features)];
+
+  const runnerScriptPath = join(
+    fileURLToPath(dirname(import.meta.url)),
+    'bin.js',
+  );
+
+  const audits: Record<PackageCommand, Audit> = {
+    audit: {
+      slug: `${pkgManager}-audit`,
+      title: `${pkgManager} audit`,
+      description: `Lists ${pkgManager} audit vulnerabilities.`,
+      docsUrl: auditDocs[pkgManager],
+    },
+    outdated: {
+      slug: `${pkgManager}-outdated`,
+      title: `${pkgManager} outdated dependencies`,
+      description: `Lists ${pkgManager} outdated dependencies.`,
+      docsUrl: outdatedDocs[pkgManager],
+    },
+  };
+
+  const group: Group = {
+    slug: `${pkgManager}-package-manager`,
+    title: `${pkgManager} package manager`,
+    description: `Group containing both audit and dependencies command audits for the ${pkgManager} package manager.`,
+    docsUrl: pkgManagerDocs[pkgManager],
+    refs: features.map(feature => ({
+      slug: `${pkgManager}-${feature}`,
+      weight: 1,
+    })),
+  };
+
+  return {
+    slug: 'js-packages',
+    title: 'Plugin for JS packages',
+    icon:
+      pkgManager === 'npm' ? 'npm' : pkgManager === 'pnpm' ? 'pnpm' : 'yarn',
+    description:
+      'This plugin runs audit to uncover vulnerabilities and lists outdated dependencies. It supports npm, yarn classic and berry, pnpm package managers.',
+    docsUrl: pkgManagerDocs[pkgManager],
+    packageName: name,
+    version,
+    audits: features.map(feature => audits[feature]),
+    groups: [group],
+    runner: await createRunnerConfig(runnerScriptPath, jsPackagesPluginConfig),
+  };
+}

--- a/packages/plugin-js-packages/src/lib/js-packages-plugin.ts
+++ b/packages/plugin-js-packages/src/lib/js-packages-plugin.ts
@@ -8,7 +8,13 @@ import {
   jsPackagesPluginConfigSchema,
 } from './config';
 import { createRunnerConfig } from './runner';
-import { auditDocs, outdatedDocs, pkgManagerDocs } from './utils';
+import {
+  auditDocs,
+  outdatedDocs,
+  pkgManagerDocs,
+  pkgManagerIcons,
+  pkgManagerNames,
+} from './utils';
 
 /**
  * Instantiates Code PushUp JS packages plugin for core config.
@@ -31,7 +37,7 @@ export async function jsPackagesPlugin(
 ): Promise<PluginConfig> {
   const jsPackagesPluginConfig = jsPackagesPluginConfigSchema.parse(config);
   const pkgManager = jsPackagesPluginConfig.packageManager;
-  const features = [...new Set(jsPackagesPluginConfig.features)];
+  const checks = [...new Set(jsPackagesPluginConfig.checks)];
 
   const runnerScriptPath = join(
     fileURLToPath(dirname(import.meta.url)),
@@ -41,25 +47,25 @@ export async function jsPackagesPlugin(
   const audits: Record<PackageCommand, Audit> = {
     audit: {
       slug: `${pkgManager}-audit`,
-      title: `${pkgManager} audit`,
-      description: `Lists ${pkgManager} audit vulnerabilities.`,
+      title: `${pkgManagerNames[pkgManager]} audit`,
+      description: `Lists ${pkgManagerNames[pkgManager]} audit vulnerabilities.`,
       docsUrl: auditDocs[pkgManager],
     },
     outdated: {
       slug: `${pkgManager}-outdated`,
-      title: `${pkgManager} outdated dependencies`,
-      description: `Lists ${pkgManager} outdated dependencies.`,
+      title: `${pkgManagerNames[pkgManager]} outdated dependencies`,
+      description: `Lists ${pkgManagerNames[pkgManager]} outdated dependencies.`,
       docsUrl: outdatedDocs[pkgManager],
     },
   };
 
   const group: Group = {
     slug: `${pkgManager}-package-manager`,
-    title: `${pkgManager} package manager`,
-    description: `Group containing both audit and dependencies command audits for the ${pkgManager} package manager.`,
+    title: `${pkgManagerNames[pkgManager]} package manager`,
+    description: `Group containing both audit and dependencies command audits for the ${pkgManagerNames[pkgManager]} package manager.`,
     docsUrl: pkgManagerDocs[pkgManager],
-    refs: features.map(feature => ({
-      slug: `${pkgManager}-${feature}`,
+    refs: checks.map(check => ({
+      slug: `${pkgManager}-${check}`,
       weight: 1,
     })),
   };
@@ -67,14 +73,13 @@ export async function jsPackagesPlugin(
   return {
     slug: 'js-packages',
     title: 'Plugin for JS packages',
-    icon:
-      pkgManager === 'npm' ? 'npm' : pkgManager === 'pnpm' ? 'pnpm' : 'yarn',
+    icon: pkgManagerIcons[pkgManager],
     description:
       'This plugin runs audit to uncover vulnerabilities and lists outdated dependencies. It supports npm, yarn classic and berry, pnpm package managers.',
     docsUrl: pkgManagerDocs[pkgManager],
     packageName: name,
     version,
-    audits: features.map(feature => audits[feature]),
+    audits: checks.map(check => audits[check]),
     groups: [group],
     runner: await createRunnerConfig(runnerScriptPath, jsPackagesPluginConfig),
   };

--- a/packages/plugin-js-packages/src/lib/js-packages-plugin.unit.test.ts
+++ b/packages/plugin-js-packages/src/lib/js-packages-plugin.unit.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { Group, PluginConfig, RunnerConfig } from '@code-pushup/models';
+import { jsPackagesPlugin } from './js-packages-plugin';
+
+vi.mock('./runner/index.ts', () => ({
+  createRunnerConfig: vi.fn().mockReturnValue({
+    command: 'node',
+    outputFile: 'runner-output.json',
+  } satisfies RunnerConfig),
+}));
+
+describe('jsPackagesPlugin', () => {
+  it('should initialise a JS packages plugin', async () => {
+    await expect(
+      jsPackagesPlugin({ packageManager: 'npm', features: ['outdated'] }),
+    ).resolves.toStrictEqual(
+      expect.objectContaining({
+        slug: 'js-packages',
+        title: 'Plugin for JS packages',
+        audits: expect.any(Array),
+        groups: expect.any(Array),
+        runner: expect.any(Object),
+      }),
+    );
+  });
+
+  it('should set package manager and commands based on configuration', async () => {
+    await expect(
+      jsPackagesPlugin({ packageManager: 'yarn', features: ['audit'] }),
+    ).resolves.toStrictEqual(
+      expect.objectContaining({
+        audits: [expect.objectContaining({ slug: 'yarn-audit' })],
+        groups: [
+          expect.objectContaining<Partial<Group>>({
+            slug: 'yarn-package-manager',
+            refs: [{ slug: 'yarn-audit', weight: 1 }],
+          }),
+        ],
+      }),
+    );
+  });
+
+  it('should use npm with both audit and outdated commands when no configuration is provided', async () => {
+    await expect(jsPackagesPlugin()).resolves.toStrictEqual(
+      expect.objectContaining<Partial<PluginConfig>>({
+        audits: [
+          expect.objectContaining({ slug: 'npm-audit' }),
+          expect.objectContaining({ slug: 'npm-outdated' }),
+        ],
+        groups: [
+          expect.objectContaining<Partial<Group>>({
+            slug: 'npm-package-manager',
+            refs: [
+              { slug: 'npm-audit', weight: 1 },
+              { slug: 'npm-outdated', weight: 1 },
+            ],
+          }),
+        ],
+      }),
+    );
+  });
+
+  it('should use an icon that matches the chosen package manager', async () => {
+    await expect(
+      jsPackagesPlugin({ packageManager: 'pnpm' }),
+    ).resolves.toStrictEqual(
+      expect.objectContaining<Partial<PluginConfig>>({
+        icon: 'pnpm',
+      }),
+    );
+  });
+});

--- a/packages/plugin-js-packages/src/lib/js-packages-plugin.unit.test.ts
+++ b/packages/plugin-js-packages/src/lib/js-packages-plugin.unit.test.ts
@@ -24,35 +24,54 @@ describe('jsPackagesPlugin', () => {
     );
   });
 
-  it('should set package manager and commands based on configuration', async () => {
+  it('should create a group for both audit and outdated when no check configuration is provided', async () => {
     await expect(
-      jsPackagesPlugin({ packageManager: 'yarn-classic', checks: ['audit'] }),
+      jsPackagesPlugin({ packageManager: 'npm' }),
     ).resolves.toStrictEqual(
-      expect.objectContaining({
-        audits: [expect.objectContaining({ slug: 'yarn-classic-audit' })],
+      expect.objectContaining<Partial<PluginConfig>>({
         groups: [
           expect.objectContaining<Partial<Group>>({
-            slug: 'yarn-classic-package-manager',
-            refs: [{ slug: 'yarn-classic-audit', weight: 1 }],
+            slug: 'npm-audit',
+          }),
+          expect.objectContaining<Partial<Group>>({
+            slug: 'npm-outdated',
           }),
         ],
       }),
     );
   });
 
-  it('should use npm with both audit and outdated commands when no configuration is provided', async () => {
-    await expect(jsPackagesPlugin()).resolves.toStrictEqual(
-      expect.objectContaining<Partial<PluginConfig>>({
+  it('should configure a group based on package manager and chosen check', async () => {
+    await expect(
+      jsPackagesPlugin({ packageManager: 'yarn-modern', checks: ['outdated'] }),
+    ).resolves.toStrictEqual(
+      expect.objectContaining({
+        groups: [
+          expect.objectContaining<Partial<Group>>({
+            slug: 'yarn-modern-outdated',
+          }),
+        ],
+      }),
+    );
+  });
+
+  it('should create an audit for each dependency group', async () => {
+    await expect(
+      jsPackagesPlugin({ packageManager: 'yarn-classic', checks: ['audit'] }),
+    ).resolves.toStrictEqual(
+      expect.objectContaining({
         audits: [
-          expect.objectContaining({ slug: 'npm-audit' }),
-          expect.objectContaining({ slug: 'npm-outdated' }),
+          expect.objectContaining({ slug: 'yarn-classic-audit-prod' }),
+          expect.objectContaining({ slug: 'yarn-classic-audit-dev' }),
+          expect.objectContaining({ slug: 'yarn-classic-audit-optional' }),
         ],
         groups: [
           expect.objectContaining<Partial<Group>>({
-            slug: 'npm-package-manager',
+            slug: 'yarn-classic-audit',
             refs: [
-              { slug: 'npm-audit', weight: 1 },
-              { slug: 'npm-outdated', weight: 1 },
+              { slug: 'yarn-classic-audit-prod', weight: 8 },
+              { slug: 'yarn-classic-audit-dev', weight: 1 },
+              { slug: 'yarn-classic-audit-optional', weight: 1 },
             ],
           }),
         ],

--- a/packages/plugin-js-packages/src/lib/js-packages-plugin.unit.test.ts
+++ b/packages/plugin-js-packages/src/lib/js-packages-plugin.unit.test.ts
@@ -12,7 +12,7 @@ vi.mock('./runner/index.ts', () => ({
 describe('jsPackagesPlugin', () => {
   it('should initialise a JS packages plugin', async () => {
     await expect(
-      jsPackagesPlugin({ packageManager: 'npm', features: ['outdated'] }),
+      jsPackagesPlugin({ packageManager: 'npm', checks: ['outdated'] }),
     ).resolves.toStrictEqual(
       expect.objectContaining({
         slug: 'js-packages',
@@ -26,14 +26,14 @@ describe('jsPackagesPlugin', () => {
 
   it('should set package manager and commands based on configuration', async () => {
     await expect(
-      jsPackagesPlugin({ packageManager: 'yarn', features: ['audit'] }),
+      jsPackagesPlugin({ packageManager: 'yarn-classic', checks: ['audit'] }),
     ).resolves.toStrictEqual(
       expect.objectContaining({
-        audits: [expect.objectContaining({ slug: 'yarn-audit' })],
+        audits: [expect.objectContaining({ slug: 'yarn-classic-audit' })],
         groups: [
           expect.objectContaining<Partial<Group>>({
-            slug: 'yarn-package-manager',
-            refs: [{ slug: 'yarn-audit', weight: 1 }],
+            slug: 'yarn-classic-package-manager',
+            refs: [{ slug: 'yarn-classic-audit', weight: 1 }],
           }),
         ],
       }),

--- a/packages/plugin-js-packages/src/lib/runner/constants.ts
+++ b/packages/plugin-js-packages/src/lib/runner/constants.ts
@@ -1,0 +1,10 @@
+import { join } from 'node:path';
+import { pluginWorkDir } from '@code-pushup/utils';
+
+export const WORKDIR = pluginWorkDir('js-packages');
+export const RUNNER_OUTPUT_PATH = join(WORKDIR, 'runner-output.json');
+export const PLUGIN_CONFIG_PATH = join(
+  process.cwd(),
+  WORKDIR,
+  'plugin-config.json',
+);

--- a/packages/plugin-js-packages/src/lib/runner/index.ts
+++ b/packages/plugin-js-packages/src/lib/runner/index.ts
@@ -1,3 +1,24 @@
+import { writeFile } from 'node:fs/promises';
+import { dirname } from 'node:path';
+import { RunnerConfig } from '@code-pushup/models';
+import { ensureDirectoryExists } from '@code-pushup/utils';
+import { FinalJSPackagesPluginConfig } from '../config';
+import { PLUGIN_CONFIG_PATH, RUNNER_OUTPUT_PATH } from './constants';
+
 export function executeRunner(): void {
   return;
+}
+
+export async function createRunnerConfig(
+  scriptPath: string,
+  config: FinalJSPackagesPluginConfig,
+): Promise<RunnerConfig> {
+  await ensureDirectoryExists(dirname(PLUGIN_CONFIG_PATH));
+  await writeFile(PLUGIN_CONFIG_PATH, JSON.stringify(config));
+
+  return {
+    command: 'node',
+    args: [scriptPath],
+    outputFile: RUNNER_OUTPUT_PATH,
+  };
 }

--- a/packages/plugin-js-packages/src/lib/runner/index.ts
+++ b/packages/plugin-js-packages/src/lib/runner/index.ts
@@ -1,0 +1,3 @@
+export function executeRunner(): void {
+  return;
+}

--- a/packages/plugin-js-packages/src/lib/utils.ts
+++ b/packages/plugin-js-packages/src/lib/utils.ts
@@ -1,21 +1,36 @@
+import { MaterialIcon } from '@code-pushup/models';
 import { PackageManager } from './config';
+
+export const pkgManagerNames: Record<PackageManager, string> = {
+  npm: 'NPM',
+  'yarn-classic': 'Yarn v1',
+  'yarn-modern': 'Yarn v2+',
+  pnpm: 'PNPM',
+};
+
+export const pkgManagerIcons: Record<PackageManager, MaterialIcon> = {
+  npm: 'npm',
+  'yarn-classic': 'yarn',
+  'yarn-modern': 'yarn',
+  pnpm: 'pnpm',
+};
 
 export const pkgManagerDocs: Record<PackageManager, string> = {
   npm: 'https://docs.npmjs.com/',
-  yarn: 'https://classic.yarnpkg.com/lang/en/docs/',
-  'yarn-berry': 'https://yarnpkg.com/getting-started',
+  'yarn-classic': 'https://classic.yarnpkg.com/docs/',
+  'yarn-modern': 'https://yarnpkg.com/getting-started',
   pnpm: 'https://pnpm.io/pnpm-cli',
 };
 export const auditDocs: Record<PackageManager, string> = {
-  npm: 'https://docs.npmjs.com/cli/v10/commands/npm-audit',
-  yarn: 'https://classic.yarnpkg.com/en/docs/cli/audit',
-  'yarn-berry': 'https://yarnpkg.com/cli/npm/audit',
+  npm: 'https://docs.npmjs.com/cli/commands/npm-audit',
+  'yarn-classic': 'https://classic.yarnpkg.com/docs/cli/audit',
+  'yarn-modern': 'https://yarnpkg.com/cli/npm/audit',
   pnpm: 'https://pnpm.io/',
 };
 
 export const outdatedDocs: Record<PackageManager, string> = {
-  npm: 'https://docs.npmjs.com/cli/v10/commands/npm-outdated',
-  yarn: 'https://classic.yarnpkg.com/lang/en/docs/cli/outdated/',
-  'yarn-berry': 'https://github.com/mskelton/yarn-plugin-outdated',
+  npm: 'https://docs.npmjs.com/cli/commands/npm-outdated',
+  'yarn-classic': 'https://classic.yarnpkg.com/docs/cli/outdated/',
+  'yarn-modern': 'https://github.com/mskelton/yarn-plugin-outdated',
   pnpm: 'https://pnpm.io/cli/outdated',
 };

--- a/packages/plugin-js-packages/src/lib/utils.ts
+++ b/packages/plugin-js-packages/src/lib/utils.ts
@@ -1,0 +1,21 @@
+import { PackageManager } from './config';
+
+export const pkgManagerDocs: Record<PackageManager, string> = {
+  npm: 'https://docs.npmjs.com/',
+  yarn: 'https://classic.yarnpkg.com/lang/en/docs/',
+  'yarn-berry': 'https://yarnpkg.com/getting-started',
+  pnpm: 'https://pnpm.io/pnpm-cli',
+};
+export const auditDocs: Record<PackageManager, string> = {
+  npm: 'https://docs.npmjs.com/cli/v10/commands/npm-audit',
+  yarn: 'https://classic.yarnpkg.com/en/docs/cli/audit',
+  'yarn-berry': 'https://yarnpkg.com/cli/npm/audit',
+  pnpm: 'https://pnpm.io/',
+};
+
+export const outdatedDocs: Record<PackageManager, string> = {
+  npm: 'https://docs.npmjs.com/cli/v10/commands/npm-outdated',
+  yarn: 'https://classic.yarnpkg.com/lang/en/docs/cli/outdated/',
+  'yarn-berry': 'https://github.com/mskelton/yarn-plugin-outdated',
+  pnpm: 'https://pnpm.io/cli/outdated',
+};

--- a/packages/plugin-js-packages/tsconfig.json
+++ b/packages/plugin-js-packages/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "types": ["vitest"]
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.test.json"
+    }
+  ]
+}

--- a/packages/plugin-js-packages/tsconfig.lib.json
+++ b/packages/plugin-js-packages/tsconfig.lib.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": [
+    "vite.config.unit.ts",
+    "vite.config.integration.ts",
+    "src/**/*.test.ts",
+    "src/**/*.mock.ts",
+    "mocks/**/*.ts"
+  ]
+}

--- a/packages/plugin-js-packages/tsconfig.test.json
+++ b/packages/plugin-js-packages/tsconfig.test.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "types": ["vitest/globals", "vitest/importMeta", "vite/client", "node"]
+  },
+  "include": [
+    "vite.config.unit.ts",
+    "vite.config.integration.ts",
+    "mocks/**/*.ts",
+    "src/**/*.test.ts"
+  ]
+}

--- a/packages/plugin-js-packages/vite.config.integration.ts
+++ b/packages/plugin-js-packages/vite.config.integration.ts
@@ -1,0 +1,28 @@
+/// <reference types="vitest" />
+import { defineConfig } from 'vite';
+import { tsconfigPathAliases } from '../../tools/vitest-tsconfig-path-aliases';
+
+export default defineConfig({
+  cacheDir: '../../node_modules/.vite/plugin-js-packages',
+  test: {
+    reporters: ['basic'],
+    globals: true,
+    cache: {
+      dir: '../../node_modules/.vitest',
+    },
+    alias: tsconfigPathAliases(),
+    pool: 'threads',
+    poolOptions: { threads: { singleThread: true } },
+    coverage: {
+      reporter: ['text', 'lcov'],
+      reportsDirectory: '../../coverage/plugin-js-packages/integration-tests',
+    },
+    environment: 'node',
+    include: ['src/**/*.integration.test.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    globalSetup: ['../../global-setup.ts'],
+    setupFiles: [
+      '../../testing/test-setup/src/lib/console.mock.ts',
+      '../../testing/test-setup/src/lib/reset.mocks.ts',
+    ],
+  },
+});

--- a/packages/plugin-js-packages/vite.config.unit.ts
+++ b/packages/plugin-js-packages/vite.config.unit.ts
@@ -1,0 +1,29 @@
+/// <reference types="vitest" />
+import { defineConfig } from 'vite';
+import { tsconfigPathAliases } from '../../tools/vitest-tsconfig-path-aliases';
+
+export default defineConfig({
+  cacheDir: '../../node_modules/.vite/plugin-js-packages',
+  test: {
+    reporters: ['basic'],
+    globals: true,
+    cache: {
+      dir: '../../node_modules/.vitest',
+    },
+    alias: tsconfigPathAliases(),
+    pool: 'threads',
+    poolOptions: { threads: { singleThread: true } },
+    coverage: {
+      reporter: ['text', 'lcov'],
+      reportsDirectory: '../../coverage/plugin-js-packages/unit-tests',
+    },
+    environment: 'node',
+    include: ['src/**/*.unit.test.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    globalSetup: ['../../global-setup.ts'],
+    setupFiles: [
+      '../../testing/test-setup/src/lib/fs.mock.ts',
+      '../../testing/test-setup/src/lib/console.mock.ts',
+      '../../testing/test-setup/src/lib/reset.mocks.ts',
+    ],
+  },
+});

--- a/project.json
+++ b/project.json
@@ -36,6 +36,7 @@
             "cli",
             "plugin-eslint",
             "plugin-coverage",
+            "plugin-js-packages",
             "examples-plugins",
             "react-todos-app"
           ],
@@ -51,6 +52,7 @@
             "cli",
             "plugin-eslint",
             "plugin-coverage",
+            "plugin-js-packages",
             "examples-plugins",
             "react-todos-app"
           ],
@@ -66,6 +68,7 @@
             "cli",
             "plugin-eslint",
             "plugin-coverage",
+            "plugin-js-packages",
             "examples-plugins",
             "react-todos-app"
           ],

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -23,6 +23,9 @@
       "@code-pushup/core": ["packages/core/src/index.ts"],
       "@code-pushup/coverage-plugin": ["packages/plugin-coverage/src/index.ts"],
       "@code-pushup/eslint-plugin": ["packages/plugin-eslint/src/index.ts"],
+      "@code-pushup/js-packages-plugin": [
+        "packages/plugin-js-packages/src/index.ts"
+      ],
       "@code-pushup/lighthouse-plugin": [
         "packages/plugin-lighthouse/src/index.ts"
       ],


### PR DESCRIPTION
Related to #542 

In this PR I do the following:
- Set up the plugin, its ESLint, dependencies, etc.
- Define plugin configuration schema.
- Create documentation.

Notes:
- Runner will follow in another PR.
- For now, all dependency groups are checked. Configurable dependency groups will be in post-MVP.
- Naming improvements are welcome!