### PR TITLE
feat(plugin-js-packages): implement npm audit and outdated runner

### DIFF
--- a/code-pushup.config.ts
+++ b/code-pushup.config.ts
@@ -17,6 +17,7 @@ import coveragePlugin, {
 import eslintPlugin, {
   eslintConfigFromNxProjects,
 } from './dist/packages/plugin-eslint';
+import jsPackagesPlugin from './dist/packages/plugin-js-packages';
 import type { CoreConfig } from './packages/models/src';
 
 // load upload configuration from environment
@@ -51,6 +52,7 @@ const config: CoreConfig = {
 
   plugins: [
     await eslintPlugin(await eslintConfigFromNxProjects()),
+
     await coveragePlugin({
       coverageToolCommand: {
         command: 'npx',
@@ -66,6 +68,9 @@ const config: CoreConfig = {
       },
       reports: await getNxCoveragePaths(['unit-test', 'integration-test']),
     }),
+
+    await jsPackagesPlugin({ packageManager: 'npm' }),
+
     fileSizePlugin({
       directory: './dist/examples/react-todos-app',
       pattern: /\.js$/,
@@ -106,6 +111,30 @@ const config: CoreConfig = {
           type: 'group',
           plugin: 'coverage',
           slug: 'coverage',
+          weight: 1,
+        },
+      ],
+    },
+    {
+      slug: 'security',
+      title: 'Security',
+      refs: [
+        {
+          type: 'group',
+          plugin: 'js-packages',
+          slug: 'npm-audit',
+          weight: 1,
+        },
+      ],
+    },
+    {
+      slug: 'dependencies',
+      title: 'Dependencies',
+      refs: [
+        {
+          type: 'group',
+          plugin: 'js-packages',
+          slug: 'npm-outdated',
           weight: 1,
         },
       ],

--- a/code-pushup.config.ts
+++ b/code-pushup.config.ts
@@ -128,8 +128,8 @@ const config: CoreConfig = {
       ],
     },
     {
-      slug: 'dependencies',
-      title: 'Dependencies',
+      slug: 'updates',
+      title: 'Updates',
       refs: [
         {
           type: 'group',

--- a/packages/plugin-js-packages/README.md
+++ b/packages/plugin-js-packages/README.md
@@ -158,3 +158,33 @@ Each dependency group has its own audit. If you want to check only a subset of d
        // ...
      ],
 ```
+
+## Score calculation
+
+Audit output score is a numeric value in the range 0-1.
+
+### Security audit
+
+The score for security audit is decreased for each vulnerability found based on its **severity**.
+
+The mapping is as follows:
+
+- Critical vulnerabilities set score to 0.
+- High-severity vulnerabilities reduce score by 0.1.
+- Moderate vulnerabilities reduce score by 0.05.
+- Low-severity vulnerabilities reduce score by 0.02.
+- Information-level vulnerabilities reduce score by 0.01.
+
+Examples:
+
+- 1+ **critical** vulnerabilities → score will be 0
+- 1 high and 2 low vulnerabilities → score will be 1 - 0.1 - 2\*0.02 = 0.86
+
+### Outdated dependencies
+
+In order for this audit not to drastically lower the score, the current logic is such that only dependencies with **major** outdated version lower the score by a proportional amount to the total amount of dependencies on your project.
+
+Examples:
+
+- 5 dependencies out of which 1 has an outdated **major** version → score will be (5 - 1) / 5 = 0.8
+- 2 dependencies out of which 1 has an outdated minor version and one is up-to-date → score stay 1

--- a/packages/plugin-js-packages/src/bin.ts
+++ b/packages/plugin-js-packages/src/bin.ts
@@ -1,3 +1,3 @@
 import { executeRunner } from './lib/runner';
 
-executeRunner();
+await executeRunner();

--- a/packages/plugin-js-packages/src/lib/config.ts
+++ b/packages/plugin-js-packages/src/lib/config.ts
@@ -1,5 +1,9 @@
 import { z } from 'zod';
 import { IssueSeverity, issueSeveritySchema } from '@code-pushup/models';
+import { defaultAuditLevelMapping } from './constants';
+
+export const packageDependencies = ['prod', 'dev', 'optional'] as const;
+export type PackageDependency = (typeof packageDependencies)[number];
 
 const packageCommandSchema = z.enum(['audit', 'outdated']);
 export type PackageCommand = z.infer<typeof packageCommandSchema>;
@@ -12,22 +16,15 @@ const packageManagerSchema = z.enum([
 ]);
 export type PackageManager = z.infer<typeof packageManagerSchema>;
 
-const packageAuditLevelSchema = z.enum([
-  'info',
-  'low',
-  'moderate',
-  'high',
+export const packageAuditLevels = [
   'critical',
-]);
+  'high',
+  'moderate',
+  'low',
+  'info',
+] as const;
+const packageAuditLevelSchema = z.enum(packageAuditLevels);
 export type PackageAuditLevel = z.infer<typeof packageAuditLevelSchema>;
-
-const defaultAuditLevelMapping: Record<PackageAuditLevel, IssueSeverity> = {
-  critical: 'error',
-  high: 'error',
-  moderate: 'warning',
-  low: 'warning',
-  info: 'info',
-};
 
 export function fillAuditLevelMapping(
   mapping: Partial<Record<PackageAuditLevel, IssueSeverity>>,
@@ -66,5 +63,3 @@ export type JSPackagesPluginConfig = z.input<
 export type FinalJSPackagesPluginConfig = z.infer<
   typeof jsPackagesPluginConfigSchema
 >;
-
-export type PackageDependencyType = 'prod' | 'dev' | 'optional';

--- a/packages/plugin-js-packages/src/lib/config.ts
+++ b/packages/plugin-js-packages/src/lib/config.ts
@@ -2,8 +2,8 @@ import { z } from 'zod';
 import { IssueSeverity, issueSeveritySchema } from '@code-pushup/models';
 import { defaultAuditLevelMapping } from './constants';
 
-export const packageDependencies = ['prod', 'dev', 'optional'] as const;
-export type PackageDependency = (typeof packageDependencies)[number];
+export const dependencyGroups = ['prod', 'dev', 'optional'] as const;
+export type DependencyGroup = (typeof dependencyGroups)[number];
 
 const packageCommandSchema = z.enum(['audit', 'outdated']);
 export type PackageCommand = z.infer<typeof packageCommandSchema>;

--- a/packages/plugin-js-packages/src/lib/constants.ts
+++ b/packages/plugin-js-packages/src/lib/constants.ts
@@ -1,7 +1,7 @@
 import { IssueSeverity, MaterialIcon } from '@code-pushup/models';
 import type {
+  DependencyGroup,
   PackageAuditLevel,
-  PackageDependency,
   PackageManager,
 } from './config';
 
@@ -50,7 +50,7 @@ export const outdatedDocs: Record<PackageManager, string> = {
   pnpm: 'https://pnpm.io/cli/outdated',
 };
 
-export const dependencyDocs: Record<PackageDependency, string> = {
+export const dependencyDocs: Record<DependencyGroup, string> = {
   prod: 'https://classic.yarnpkg.com/docs/dependency-types#toc-dependencies',
   dev: 'https://classic.yarnpkg.com/docs/dependency-types#toc-devdependencies',
   optional:

--- a/packages/plugin-js-packages/src/lib/constants.ts
+++ b/packages/plugin-js-packages/src/lib/constants.ts
@@ -1,5 +1,20 @@
-import { MaterialIcon } from '@code-pushup/models';
-import { PackageDependencyType, PackageManager } from './config';
+import { IssueSeverity, MaterialIcon } from '@code-pushup/models';
+import type {
+  PackageAuditLevel,
+  PackageDependency,
+  PackageManager,
+} from './config';
+
+export const defaultAuditLevelMapping: Record<
+  PackageAuditLevel,
+  IssueSeverity
+> = {
+  critical: 'error',
+  high: 'error',
+  moderate: 'warning',
+  low: 'warning',
+  info: 'info',
+};
 
 export const pkgManagerNames: Record<PackageManager, string> = {
   npm: 'NPM',
@@ -35,7 +50,7 @@ export const outdatedDocs: Record<PackageManager, string> = {
   pnpm: 'https://pnpm.io/cli/outdated',
 };
 
-export const dependencyDocs: Record<PackageDependencyType, string> = {
+export const dependencyDocs: Record<PackageDependency, string> = {
   prod: 'https://classic.yarnpkg.com/docs/dependency-types#toc-dependencies',
   dev: 'https://classic.yarnpkg.com/docs/dependency-types#toc-devdependencies',
   optional:

--- a/packages/plugin-js-packages/src/lib/js-packages-plugin.ts
+++ b/packages/plugin-js-packages/src/lib/js-packages-plugin.ts
@@ -3,9 +3,9 @@ import { fileURLToPath } from 'node:url';
 import type { Audit, Group, PluginConfig } from '@code-pushup/models';
 import { name, version } from '../../package.json';
 import {
+  DependencyGroup,
   JSPackagesPluginConfig,
   PackageCommand,
-  PackageDependency,
   PackageManager,
   jsPackagesPluginConfigSchema,
 } from './config';
@@ -126,7 +126,7 @@ function createAudits(
 function getAuditTitle(
   pkgManager: PackageManager,
   check: PackageCommand,
-  dependencyType: PackageDependency,
+  dependencyType: DependencyGroup,
 ) {
   return check === 'audit'
     ? `Vulnerabilities for ${pkgManagerNames[pkgManager]} ${dependencyType} dependencies.`
@@ -135,7 +135,7 @@ function getAuditTitle(
 
 function getAuditDescription(
   check: PackageCommand,
-  dependencyType: PackageDependency,
+  dependencyType: DependencyGroup,
 ) {
   return check === 'audit'
     ? `Runs security audit on ${dependencyType} dependencies.`

--- a/packages/plugin-js-packages/src/lib/js-packages-plugin.ts
+++ b/packages/plugin-js-packages/src/lib/js-packages-plugin.ts
@@ -1,11 +1,11 @@
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { Audit, Group, PluginConfig } from '@code-pushup/models';
+import type { Audit, Group, PluginConfig } from '@code-pushup/models';
 import { name, version } from '../../package.json';
 import {
   JSPackagesPluginConfig,
   PackageCommand,
-  PackageDependencyType,
+  PackageDependency,
   PackageManager,
   jsPackagesPluginConfigSchema,
 } from './config';
@@ -126,7 +126,7 @@ function createAudits(
 function getAuditTitle(
   pkgManager: PackageManager,
   check: PackageCommand,
-  dependencyType: PackageDependencyType,
+  dependencyType: PackageDependency,
 ) {
   return check === 'audit'
     ? `Vulnerabilities for ${pkgManagerNames[pkgManager]} ${dependencyType} dependencies.`
@@ -135,7 +135,7 @@ function getAuditTitle(
 
 function getAuditDescription(
   check: PackageCommand,
-  dependencyType: PackageDependencyType,
+  dependencyType: PackageDependency,
 ) {
   return check === 'audit'
     ? `Runs security audit on ${dependencyType} dependencies.`

--- a/packages/plugin-js-packages/src/lib/runner/audit/constants.ts
+++ b/packages/plugin-js-packages/src/lib/runner/audit/constants.ts
@@ -1,0 +1,11 @@
+import { PackageAuditLevel } from '../../config';
+
+/* eslint-disable no-magic-numbers */
+export const auditScoreModifiers: Record<PackageAuditLevel, number> = {
+  critical: 1,
+  high: 0.1,
+  moderate: 0.05,
+  low: 0.02,
+  info: 0.01,
+};
+/* eslint-enable no-magic-numbers */

--- a/packages/plugin-js-packages/src/lib/runner/audit/transform.ts
+++ b/packages/plugin-js-packages/src/lib/runner/audit/transform.ts
@@ -1,0 +1,81 @@
+import type { AuditOutput, Issue, IssueSeverity } from '@code-pushup/models';
+import { objectToEntries } from '@code-pushup/utils';
+import {
+  PackageAuditLevel,
+  PackageDependency,
+  packageAuditLevels,
+} from '../../config';
+import { NpmAuditResultJson, Vulnerabilities } from './types';
+
+export function auditResultToAuditOutput(
+  result: NpmAuditResultJson,
+  dependenciesType: PackageDependency,
+  auditLevelMapping: Record<PackageAuditLevel, IssueSeverity>,
+): AuditOutput {
+  const issues = vulnerabilitiesToIssues(
+    result.vulnerabilities,
+    auditLevelMapping,
+  );
+  return {
+    slug: `npm-audit-${dependenciesType}`,
+    score: result.metadata.vulnerabilities.total === 0 ? 1 : 0,
+    value: result.metadata.vulnerabilities.total,
+    displayValue: vulnerabilitiesToDisplayValue(
+      result.metadata.vulnerabilities,
+    ),
+    ...(issues.length > 0 && { details: { issues } }),
+  };
+}
+
+export function vulnerabilitiesToDisplayValue(
+  vulnerabilities: Record<PackageAuditLevel | 'total', number>,
+): string {
+  if (vulnerabilities.total === 0) {
+    return 'passed';
+  }
+
+  const displayValue = packageAuditLevels
+    .map(level =>
+      vulnerabilities[level] > 0 ? `${vulnerabilities[level]} ${level}` : '',
+    )
+    .filter(text => text !== '')
+    .join(', ');
+  return `${displayValue} ${
+    vulnerabilities.total === 1 ? 'vulnerability' : 'vulnerabilities'
+  }`;
+}
+
+export function vulnerabilitiesToIssues(
+  vulnerabilities: Vulnerabilities,
+  auditLevelMapping: Record<PackageAuditLevel, IssueSeverity>,
+): Issue[] {
+  if (Object.keys(vulnerabilities).length === 0) {
+    return [];
+  }
+
+  return objectToEntries(vulnerabilities).map<Issue>(([, detail]) => {
+    // Advisory details via can refer to another vulnerability
+    // For now, only direct context is supported
+    if (
+      Array.isArray(detail.via) &&
+      detail.via.length > 0 &&
+      typeof detail.via[0] === 'object'
+    ) {
+      return {
+        message: `${detail.name} dependency has a vulnerability "${
+          detail.via[0].title
+        }" for versions ${detail.range}. Fix is ${
+          detail.fixAvailable ? '' : 'not '
+        }available. More information [here](${detail.via[0].url})`,
+        severity: auditLevelMapping[detail.severity],
+      };
+    }
+
+    return {
+      message: `${detail.name} dependency has a vulnerability for versions ${
+        detail.range
+      }. Fix is ${detail.fixAvailable ? '' : 'not '}available.`,
+      severity: auditLevelMapping[detail.severity],
+    };
+  });
+}

--- a/packages/plugin-js-packages/src/lib/runner/audit/transform.unit.test.ts
+++ b/packages/plugin-js-packages/src/lib/runner/audit/transform.unit.test.ts
@@ -1,0 +1,259 @@
+import { describe, expect, it } from 'vitest';
+import type { AuditOutput, Issue } from '@code-pushup/models';
+import { defaultAuditLevelMapping } from '../../constants';
+import {
+  auditResultToAuditOutput,
+  vulnerabilitiesToDisplayValue,
+  vulnerabilitiesToIssues,
+} from './transform';
+import { Vulnerability } from './types';
+
+describe('auditResultToAuditOutput', () => {
+  it('should return audit output with no vulnerabilities', () => {
+    expect(
+      auditResultToAuditOutput(
+        {
+          vulnerabilities: {},
+          metadata: {
+            vulnerabilities: {
+              critical: 0,
+              high: 0,
+              moderate: 0,
+              low: 0,
+              info: 0,
+              total: 0,
+            },
+          },
+        },
+        'prod',
+        defaultAuditLevelMapping,
+      ),
+    ).toEqual<AuditOutput>({
+      slug: 'npm-audit-prod',
+      score: 1,
+      value: 0,
+      displayValue: 'passed',
+    });
+  });
+
+  it('should return audit output with a vulnerability', () => {
+    expect(
+      auditResultToAuditOutput(
+        {
+          vulnerabilities: {
+            request: {
+              name: 'request',
+              severity: 'critical',
+              range: '2.0.0 - 3.0.0',
+              via: [
+                { title: 'SSR forgery', url: 'https://github.com/advisories/' },
+              ],
+              fixAvailable: false,
+            },
+          },
+          metadata: {
+            vulnerabilities: {
+              critical: 1,
+              high: 0,
+              moderate: 0,
+              low: 0,
+              info: 0,
+              total: 1,
+            },
+          },
+        },
+        'prod',
+        defaultAuditLevelMapping,
+      ),
+    ).toEqual<AuditOutput>({
+      slug: 'npm-audit-prod',
+      score: 0,
+      value: 1,
+      displayValue: '1 critical vulnerability',
+      details: {
+        issues: [
+          {
+            message: expect.stringContaining(
+              'request dependency has a vulnerability "SSR forgery"',
+            ),
+            severity: 'error',
+          },
+        ],
+      },
+    });
+  });
+
+  it('should return audit output with multiple vulnerabilities', () => {
+    expect(
+      auditResultToAuditOutput(
+        {
+          vulnerabilities: {
+            request: {
+              name: 'request',
+              severity: 'critical',
+              range: '2.0.0 - 3.0.0',
+              via: [
+                { title: 'SSR forgery', url: 'https://github.com/advisories/' },
+              ],
+              fixAvailable: false,
+            },
+            '@babel/traverse': {
+              name: '@babel/traverse',
+              severity: 'high',
+              range: '<7.23.2',
+              via: [
+                {
+                  title: 'Malicious code execution',
+                  url: 'https://github.com/advisories/',
+                },
+              ],
+              fixAvailable: true,
+            },
+            verdaccio: {
+              name: 'verdaccio',
+              severity: 'critical',
+              range: '*',
+              via: ['request'],
+              fixAvailable: true,
+            },
+          },
+          metadata: {
+            vulnerabilities: {
+              critical: 2,
+              high: 1,
+              moderate: 0,
+              low: 0,
+              info: 0,
+              total: 3,
+            },
+          },
+        },
+        'dev',
+        defaultAuditLevelMapping,
+      ),
+    ).toEqual<AuditOutput>({
+      slug: 'npm-audit-dev',
+      score: 0,
+      value: 3,
+      displayValue: '2 critical, 1 high vulnerabilities',
+      details: {
+        issues: [
+          expect.objectContaining({
+            message: expect.stringContaining('request'),
+          }),
+          expect.objectContaining({
+            message: expect.stringContaining('@babel/traverse'),
+          }),
+          expect.objectContaining({
+            message: expect.stringContaining('verdaccio'),
+          }),
+        ],
+      },
+    });
+  });
+});
+
+describe('vulnerabilitiesToDisplayValue', () => {
+  it('should return passed for no vulnerabilities', () => {
+    expect(
+      vulnerabilitiesToDisplayValue({
+        critical: 0,
+        high: 0,
+        moderate: 0,
+        low: 0,
+        info: 0,
+        total: 0,
+      }),
+    ).toBe('passed');
+  });
+
+  it('should return a summary of vulnerabilities', () => {
+    expect(
+      vulnerabilitiesToDisplayValue({
+        critical: 1,
+        high: 0,
+        moderate: 2,
+        low: 0,
+        info: 3,
+        total: 6,
+      }),
+    ).toBe('1 critical, 2 moderate, 3 info vulnerabilities');
+  });
+});
+
+describe('vulnerabilitiesToIssues', () => {
+  it('should create an issue with a vulnerability URL based on provided vulnerability', () => {
+    expect(
+      vulnerabilitiesToIssues(
+        {
+          'tough-cookie': {
+            name: 'tough-cookie',
+            severity: 'moderate',
+            fixAvailable: true,
+            range: '<4.1.3',
+            via: [
+              {
+                title: 'tough-cookie Prototype Pollution vulnerability',
+                url: 'https://github.com/advisories/GHSA-72xf-g2v4-qvf3',
+              },
+            ],
+          },
+        },
+        defaultAuditLevelMapping,
+      ),
+    ).toEqual<Issue[]>([
+      {
+        message: expect.stringMatching(
+          /tough-cookie dependency has a vulnerability "tough-cookie Prototype Pollution vulnerability" for versions <4.1.3.* More information.*https:\/\/github\.com\/advisories/,
+        ),
+        severity: 'warning',
+      },
+    ]);
+  });
+
+  it('should provide shorter message when context is in a different vulnerability', () => {
+    expect(
+      vulnerabilitiesToIssues(
+        {
+          verdaccio: {
+            name: 'verdaccio',
+            severity: 'high',
+            fixAvailable: true,
+            range: '<=5.28.0',
+            via: ['request'],
+          },
+        },
+        defaultAuditLevelMapping,
+      ),
+    ).toEqual<Issue[]>([
+      {
+        message: expect.stringMatching(
+          /verdaccio dependency has a vulnerability for versions <=5.28.0. Fix is available./,
+        ),
+        severity: 'error',
+      },
+    ]);
+  });
+
+  it('should correctly map vulnerability level to issue severity', () => {
+    expect(
+      vulnerabilitiesToIssues(
+        {
+          verdaccio: {
+            severity: 'high',
+          } as Vulnerability,
+        },
+        { ...defaultAuditLevelMapping, high: 'info' },
+      ),
+    ).toEqual<Issue[]>([
+      {
+        message: expect.any(String),
+        severity: 'info',
+      },
+    ]);
+  });
+
+  it('should return empty array for no vulnerabilities', () => {
+    expect(vulnerabilitiesToIssues({}, defaultAuditLevelMapping)).toEqual([]);
+  });
+});

--- a/packages/plugin-js-packages/src/lib/runner/audit/types.ts
+++ b/packages/plugin-js-packages/src/lib/runner/audit/types.ts
@@ -1,9 +1,15 @@
 import type { PackageAuditLevel } from '../../config';
 
-// NPM audit JSON types
+// Subset of NPM audit JSON type
 type Advisory = {
   title: string;
   url: string;
+};
+
+type FixInformation = {
+  name: string;
+  version: string;
+  isSemVerMajor: boolean;
 };
 
 export type Vulnerability = {
@@ -11,7 +17,7 @@ export type Vulnerability = {
   severity: PackageAuditLevel;
   via: Advisory[] | string[];
   range: string;
-  fixAvailable: boolean;
+  fixAvailable: boolean | FixInformation;
 };
 
 export type Vulnerabilities = {

--- a/packages/plugin-js-packages/src/lib/runner/audit/types.ts
+++ b/packages/plugin-js-packages/src/lib/runner/audit/types.ts
@@ -1,0 +1,26 @@
+import type { PackageAuditLevel } from '../../config';
+
+// NPM audit JSON types
+type Advisory = {
+  title: string;
+  url: string;
+};
+
+export type Vulnerability = {
+  name: string;
+  severity: PackageAuditLevel;
+  via: Advisory[] | string[];
+  range: string;
+  fixAvailable: boolean;
+};
+
+export type Vulnerabilities = {
+  [key: string]: Vulnerability;
+};
+
+export type NpmAuditResultJson = {
+  vulnerabilities: Vulnerabilities;
+  metadata: {
+    vulnerabilities: Record<PackageAuditLevel | 'total', number>;
+  };
+};

--- a/packages/plugin-js-packages/src/lib/runner/index.ts
+++ b/packages/plugin-js-packages/src/lib/runner/index.ts
@@ -1,12 +1,61 @@
 import { writeFile } from 'node:fs/promises';
-import { dirname } from 'node:path';
-import { RunnerConfig } from '@code-pushup/models';
-import { ensureDirectoryExists } from '@code-pushup/utils';
-import { FinalJSPackagesPluginConfig } from '../config';
+import { dirname, join } from 'node:path';
+import type { AuditOutput, RunnerConfig } from '@code-pushup/models';
+import {
+  ensureDirectoryExists,
+  executeProcess,
+  readJsonFile,
+} from '@code-pushup/utils';
+import {
+  FinalJSPackagesPluginConfig,
+  PackageDependency,
+  packageDependencies,
+} from '../config';
+import { auditResultToAuditOutput } from './audit/transform';
+import { NpmAuditResultJson } from './audit/types';
 import { PLUGIN_CONFIG_PATH, RUNNER_OUTPUT_PATH } from './constants';
 
-export function executeRunner(): void {
-  return;
+export async function executeRunner(): Promise<void> {
+  const outputPath = join(
+    process.cwd(),
+    'node_modules',
+    '.code-pushup',
+    'js-packages',
+  );
+
+  const { packageManager, checks, auditLevelMapping } =
+    await readJsonFile<FinalJSPackagesPluginConfig>(PLUGIN_CONFIG_PATH);
+
+  const results = await Promise.allSettled(
+    checks.flatMap(check =>
+      packageDependencies.map<Promise<AuditOutput>>(async dep => {
+        await executeProcess({
+          command: 'npm',
+          args: [
+            check,
+            ...createAuditFlags(dep),
+            '--json',
+            '--audit-level=none',
+            '>',
+            join(outputPath, `${packageManager}-${check}-${dep}.json`),
+          ],
+        });
+
+        const auditResult = await readJsonFile<NpmAuditResultJson>(
+          join(outputPath, `${packageManager}-${check}-${dep}.json`),
+        );
+        return auditResultToAuditOutput(auditResult, dep, auditLevelMapping);
+      }),
+    ),
+  );
+  const auditOutputs = results
+    .filter(
+      (x): x is PromiseFulfilledResult<AuditOutput> => x.status === 'fulfilled',
+    )
+    .map(x => x.value);
+
+  await ensureDirectoryExists(dirname(RUNNER_OUTPUT_PATH));
+  await writeFile(RUNNER_OUTPUT_PATH, JSON.stringify(auditOutputs));
 }
 
 export async function createRunnerConfig(
@@ -21,4 +70,17 @@ export async function createRunnerConfig(
     args: [scriptPath],
     outputFile: RUNNER_OUTPUT_PATH,
   };
+}
+
+function createAuditFlags(currentDep: PackageDependency) {
+  if (currentDep === 'optional') {
+    return packageDependencies.map(dep => `--include=${dep}`);
+  }
+
+  return [
+    `--include${currentDep}`,
+    ...packageDependencies
+      .filter(dep => dep !== currentDep)
+      .map(dep => `--omit=${dep}`),
+  ];
 }

--- a/packages/plugin-js-packages/src/lib/runner/outdated/constants.ts
+++ b/packages/plugin-js-packages/src/lib/runner/outdated/constants.ts
@@ -1,0 +1,8 @@
+import { IssueSeverity } from '@code-pushup/models';
+import { VersionType } from './types';
+
+export const outdatedSeverity: Record<VersionType, IssueSeverity> = {
+  major: 'error',
+  minor: 'warning',
+  patch: 'info',
+};

--- a/packages/plugin-js-packages/src/lib/runner/outdated/transform.ts
+++ b/packages/plugin-js-packages/src/lib/runner/outdated/transform.ts
@@ -1,0 +1,102 @@
+import { Issue } from '@code-pushup/models';
+import { objectToEntries, pluralize } from '@code-pushup/utils';
+import { PackageDependency } from '../../config';
+import { outdatedSeverity } from './constants';
+import {
+  NormalizedOutdatedEntries,
+  NormalizedVersionOverview,
+  NpmOutdatedResultJson,
+  PackageVersion,
+  VersionType,
+} from './types';
+
+export function outdatedResultToAuditOutput(
+  result: NpmOutdatedResultJson,
+  dependenciesType: PackageDependency,
+) {
+  // current might be missing in some cases
+  // https://stackoverflow.com/questions/42267101/npm-outdated-command-shows-missing-in-current-version
+  const validDependencies: NormalizedOutdatedEntries = objectToEntries(result)
+    .filter(
+      (entry): entry is [string, NormalizedVersionOverview] =>
+        entry[1].current != null,
+    )
+    .filter(([, detail]) =>
+      dependenciesType === 'prod'
+        ? detail.type === 'dependencies'
+        : detail.type.startsWith(dependenciesType),
+    );
+  const outdatedDependencies = validDependencies.filter(
+    ([, versions]) => versions.current !== versions.wanted,
+  );
+
+  const issues =
+    outdatedDependencies.length === 0
+      ? []
+      : outdatedToIssues(outdatedDependencies);
+
+  return {
+    slug: `npm-outdated-${dependenciesType}`,
+    score: outdatedDependencies.length === 0 ? 1 : 0,
+    value: outdatedDependencies.length,
+    displayValue: outdatedToDisplayValue(outdatedDependencies.length),
+    ...(issues.length > 0 && { details: { issues } }),
+  };
+}
+
+function outdatedToDisplayValue(outdatedDeps: number) {
+  return outdatedDeps === 0
+    ? 'passed'
+    : `${outdatedDeps} outdated ${
+        outdatedDeps === 1 ? 'dependency' : pluralize('dependency')
+      }`;
+}
+
+export function outdatedToIssues(
+  dependencies: NormalizedOutdatedEntries,
+): Issue[] {
+  return dependencies.map<Issue>(([name, versions]) => {
+    const outdatedLevel = getOutdatedLevel(versions.current, versions.wanted);
+    const packageDocumentation =
+      versions.homepage == null
+        ? ''
+        : ` Package documentation [here](${versions.homepage})`;
+
+    return {
+      message: `Package ${name} requires a ${outdatedLevel} update from **${versions.current}** to **${versions.wanted}**.${packageDocumentation}`,
+      severity: outdatedSeverity[outdatedLevel],
+    };
+  });
+}
+
+export function getOutdatedLevel(
+  currentFullVersion: string,
+  wantedFullVersion: string,
+): VersionType {
+  const current = splitPackageVersion(currentFullVersion);
+  const wanted = splitPackageVersion(wantedFullVersion);
+
+  if (current.major < wanted.major) {
+    return 'major';
+  }
+
+  if (current.minor < wanted.minor) {
+    return 'minor';
+  }
+
+  if (current.patch < wanted.patch) {
+    return 'patch';
+  }
+
+  throw new Error('Package is not outdated.');
+}
+
+export function splitPackageVersion(fullVersion: string): PackageVersion {
+  const [major, minor, patch] = fullVersion.split('.').map(Number);
+
+  if (major == null || minor == null || patch == null) {
+    throw new Error(`Invalid version description ${fullVersion}`);
+  }
+
+  return { major, minor, patch };
+}

--- a/packages/plugin-js-packages/src/lib/runner/outdated/transform.unit.test.ts
+++ b/packages/plugin-js-packages/src/lib/runner/outdated/transform.unit.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, it } from 'vitest';
+import { AuditOutput, Issue } from '@code-pushup/models';
+import {
+  getOutdatedLevel,
+  outdatedResultToAuditOutput,
+  outdatedToIssues,
+  splitPackageVersion,
+} from './transform';
+import { PackageVersion } from './types';
+
+describe('outdatedResultToAuditOutput', () => {
+  it('should create an audit output', () => {
+    expect(
+      outdatedResultToAuditOutput(
+        {
+          moment: { current: '4.5.0', wanted: '4.5.2', type: 'dependencies' },
+        },
+        'prod',
+      ),
+    ).toEqual<AuditOutput>({
+      slug: 'npm-outdated-prod',
+      score: 0,
+      value: 1,
+      displayValue: '1 outdated dependency',
+      details: {
+        issues: [
+          {
+            message: expect.stringMatching(
+              /Package moment requires a patch update/,
+            ),
+            severity: 'info',
+          },
+        ],
+      },
+    });
+  });
+
+  it('should distinguish up-to-date from outdated dependencies', () => {
+    expect(
+      outdatedResultToAuditOutput(
+        {
+          nx: { current: '17.0.0', wanted: '17.0.0', type: 'dependencies' },
+          prettier: { current: '2.8.8', wanted: '3.2.0', type: 'dependencies' },
+        },
+        'prod',
+      ),
+    ).toEqual<AuditOutput>({
+      slug: 'npm-outdated-prod',
+      score: 0,
+      value: 1,
+      displayValue: '1 outdated dependency',
+      details: {
+        issues: [
+          expect.objectContaining({
+            message: expect.stringContaining(
+              'Package prettier requires a major update',
+            ),
+          }),
+        ],
+      },
+    });
+  });
+
+  it('should combine multiple outdated dependencies', () => {
+    expect(
+      outdatedResultToAuditOutput(
+        {
+          nx: { current: '15.8.1', wanted: '17.0.0', type: 'dependencies' },
+          jsdom: { current: '22.1.0', wanted: '22.1.2', type: 'dependencies' },
+          prettier: {
+            current: '3.0.0',
+            wanted: '3.2.0',
+            type: 'dependencies',
+          },
+        },
+        'prod',
+      ),
+    ).toEqual<AuditOutput>({
+      slug: 'npm-outdated-prod',
+      score: 0,
+      value: 3,
+      displayValue: '3 outdated dependencies',
+      details: {
+        issues: [
+          {
+            message: expect.stringContaining(
+              'Package nx requires a major update',
+            ),
+            severity: 'error',
+          },
+          {
+            message: expect.stringContaining(
+              'Package jsdom requires a patch update',
+            ),
+            severity: 'info',
+          },
+          {
+            message: expect.stringContaining(
+              'Package prettier requires a minor update',
+            ),
+            severity: 'warning',
+          },
+        ],
+      },
+    });
+  });
+
+  it('should omit irrelevant dependency types', () => {
+    expect(
+      outdatedResultToAuditOutput(
+        {
+          memfs: {
+            current: '5.2.1',
+            wanted: '5.3.0',
+            type: 'devDependencies',
+          },
+        },
+        'optional',
+      ),
+    ).toEqual<AuditOutput>({
+      slug: 'npm-outdated-optional',
+      score: 1,
+      value: 0,
+      displayValue: 'passed',
+    });
+  });
+
+  it('should filter out invalid dependencies (missing current)', () => {
+    expect(
+      outdatedResultToAuditOutput(
+        {
+          nx: { wanted: '17.0.0', type: 'dependencies' },
+        },
+        'prod',
+      ),
+    ).toEqual<AuditOutput>({
+      slug: 'npm-outdated-prod',
+      score: 1,
+      value: 0,
+      displayValue: 'passed',
+    });
+  });
+});
+
+describe('outdatedToIssues', () => {
+  it('should create an issue for an outdated dependency', () => {
+    expect(
+      outdatedToIssues([
+        [
+          'moment',
+          { current: '2.29.0', wanted: '2.30.0', type: 'dependencies' },
+        ],
+      ]),
+    ).toEqual<Issue[]>([
+      {
+        message: expect.stringMatching(
+          /Package moment requires a minor update from.*2.29.0.*to.*2.30.0/,
+        ),
+        severity: 'warning',
+      },
+    ]);
+  });
+
+  it('should include package URL when provided', () => {
+    expect(
+      outdatedToIssues([
+        [
+          'nx',
+          {
+            current: '16.8.2',
+            wanted: '17.0.0',
+            type: 'dependencies',
+            homepage: 'https://nx.dev',
+          },
+        ],
+      ]),
+    ).toEqual<Issue[]>([
+      expect.objectContaining({
+        message: expect.stringMatching(
+          /Package nx requires a major update .* Package documentation.*https:\/\/nx\.dev/,
+        ),
+      }),
+    ]);
+  });
+
+  it('should include outdated patch version as info', () => {
+    expect(
+      outdatedToIssues([
+        [
+          'memfs',
+          {
+            current: '4.5.0',
+            wanted: '4.5.1',
+            type: 'devDependencies',
+          },
+        ],
+      ]),
+    ).toEqual<Issue[]>([
+      expect.objectContaining({
+        severity: 'info',
+      }),
+    ]);
+  });
+
+  it('should return empty issues for no outdated dependencies', () => {
+    expect(outdatedToIssues([])).toEqual([]);
+  });
+});
+
+describe('getOutdatedLevel', () => {
+  it('should return outdated major version', () => {
+    expect(getOutdatedLevel('4.2.1', '5.2.0')).toBe('major');
+  });
+
+  it('should prioritise higher outdated version level', () => {
+    expect(getOutdatedLevel('6.2.1', '6.3.2')).toBe('minor');
+  });
+});
+
+describe('splitPackageVersion', () => {
+  it('should split version into major, minor and patch', () => {
+    expect(splitPackageVersion('0.32.4')).toEqual<PackageVersion>({
+      major: 0,
+      minor: 32,
+      patch: 4,
+    });
+  });
+
+  it('should throw for an incomplete version', () => {
+    expect(() => splitPackageVersion('5.0')).toThrow(
+      'Invalid version description 5.0',
+    );
+  });
+});

--- a/packages/plugin-js-packages/src/lib/runner/outdated/types.ts
+++ b/packages/plugin-js-packages/src/lib/runner/outdated/types.ts
@@ -1,4 +1,4 @@
-// NPM outdated JSON types
+// Subset of NPM outdated JSON type
 
 export type VersionType = 'major' | 'minor' | 'patch';
 export type PackageVersion = Record<VersionType, number>;

--- a/packages/plugin-js-packages/src/lib/runner/outdated/types.ts
+++ b/packages/plugin-js-packages/src/lib/runner/outdated/types.ts
@@ -1,0 +1,20 @@
+// NPM outdated JSON types
+
+export type VersionType = 'major' | 'minor' | 'patch';
+export type PackageVersion = Record<VersionType, number>;
+
+export type VersionOverview = {
+  current?: string;
+  wanted: string;
+  type: 'dependencies' | 'devDependencies' | 'optionalDependencies';
+  homepage?: string;
+};
+
+export type NormalizedVersionOverview = Omit<VersionOverview, 'current'> & {
+  current: string;
+};
+export type NormalizedOutdatedEntries = [string, NormalizedVersionOverview][];
+
+export type NpmOutdatedResultJson = {
+  [key: string]: VersionOverview;
+};

--- a/packages/plugin-js-packages/src/lib/runner/runner.integration.test.ts
+++ b/packages/plugin-js-packages/src/lib/runner/runner.integration.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { RunnerConfig } from '@code-pushup/models';
+import { readJsonFile, removeDirectoryIfExists } from '@code-pushup/utils';
+import { createRunnerConfig } from '.';
+import { FinalJSPackagesPluginConfig } from '../config';
+import { defaultAuditLevelMapping } from '../constants';
+import { PLUGIN_CONFIG_PATH, WORKDIR } from './constants';
+
+describe('createRunnerConfig', () => {
+  it('should create a valid runner config', async () => {
+    const runnerConfig = await createRunnerConfig('executeRunner.ts', {
+      packageManager: 'npm',
+      checks: ['audit'],
+      auditLevelMapping: defaultAuditLevelMapping,
+    });
+    expect(runnerConfig).toStrictEqual<RunnerConfig>({
+      command: 'node',
+      args: ['executeRunner.ts'],
+      outputFile: expect.stringContaining('runner-output.json'),
+    });
+  });
+
+  it('should provide plugin config to runner in JSON file', async () => {
+    await removeDirectoryIfExists(WORKDIR);
+    const pluginConfig: FinalJSPackagesPluginConfig = {
+      packageManager: 'yarn-classic',
+      checks: ['outdated'],
+      auditLevelMapping: { ...defaultAuditLevelMapping, moderate: 'error' },
+    };
+    await createRunnerConfig('executeRunner.ts', pluginConfig);
+    const config = await readJsonFile<FinalJSPackagesPluginConfig>(
+      PLUGIN_CONFIG_PATH,
+    );
+    expect(config).toStrictEqual(pluginConfig);
+  });
+});

--- a/packages/utils/src/lib/execute-process.ts
+++ b/packages/utils/src/lib/execute-process.ts
@@ -82,6 +82,7 @@ export type ProcessConfig = {
   args?: string[];
   cwd?: string;
   observer?: ProcessObserver;
+  alwaysResolve?: boolean;
 };
 
 /**
@@ -132,7 +133,7 @@ export type ProcessObserver = {
  * @param cfg - see {@link ProcessConfig}
  */
 export function executeProcess(cfg: ProcessConfig): Promise<ProcessResult> {
-  const { observer, cwd, command, args } = cfg;
+  const { observer, cwd, command, args, alwaysResolve = false } = cfg;
   const { onStdout, onError, onComplete } = observer ?? {};
   const date = new Date().toISOString();
   const start = performance.now();
@@ -160,7 +161,7 @@ export function executeProcess(cfg: ProcessConfig): Promise<ProcessResult> {
 
     process.on('close', code => {
       const timings = { date, duration: calcDuration(start) };
-      if (code === 0) {
+      if (code === 0 || alwaysResolve) {
         onComplete?.();
         resolve({ code, stdout, stderr, ...timings });
       } else {

--- a/packages/utils/src/lib/execute-process.unit.test.ts
+++ b/packages/utils/src/lib/execute-process.unit.test.ts
@@ -23,8 +23,8 @@ describe('executeProcess', () => {
 
     // Note: called once or twice depending on environment (2nd time for a new line)
     expect(spyObserver.onStdout).toHaveBeenCalled();
-    expect(spyObserver.onComplete).toHaveBeenCalledTimes(1);
-    expect(spyObserver.onError).toHaveBeenCalledTimes(0);
+    expect(spyObserver.onComplete).toHaveBeenCalledOnce();
+    expect(spyObserver.onError).not.toHaveBeenCalled();
     expect(processResult.stdout).toMatch(/v\d{1,2}(\.\d{1,2}){0,2}/);
   });
 
@@ -34,9 +34,9 @@ describe('executeProcess', () => {
       args: ['--help'],
       observer: spyObserver,
     });
-    expect(spyObserver.onStdout).toHaveBeenCalledTimes(1);
-    expect(spyObserver.onComplete).toHaveBeenCalledTimes(1);
-    expect(spyObserver.onError).toHaveBeenCalledTimes(0);
+    expect(spyObserver.onStdout).toHaveBeenCalledOnce();
+    expect(spyObserver.onComplete).toHaveBeenCalledOnce();
+    expect(spyObserver.onError).not.toHaveBeenCalled();
     expect(processResult.stdout).toContain('npm exec');
   });
 
@@ -46,11 +46,11 @@ describe('executeProcess', () => {
       observer: spyObserver,
     }).catch(errorSpy);
 
-    expect(errorSpy).toHaveBeenCalledTimes(0);
+    expect(errorSpy).not.toHaveBeenCalled();
     expect(processResult.stdout).toContain('process:complete');
     expect(spyObserver.onStdout).toHaveBeenCalledTimes(6); // intro + 4 runs + complete
-    expect(spyObserver.onError).toHaveBeenCalledTimes(0);
-    expect(spyObserver.onComplete).toHaveBeenCalledTimes(1);
+    expect(spyObserver.onError).not.toHaveBeenCalled();
+    expect(spyObserver.onComplete).toHaveBeenCalledOnce();
   });
 
   it('should work with async script `node custom-script.js` that throws an error', async () => {
@@ -63,10 +63,30 @@ describe('executeProcess', () => {
       observer: spyObserver,
     }).catch(errorSpy);
 
-    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalledOnce();
     expect(processResult).toBeUndefined();
     expect(spyObserver.onStdout).toHaveBeenCalledTimes(2); // intro + 1 run before error
-    expect(spyObserver.onError).toHaveBeenCalledTimes(1);
-    expect(spyObserver.onComplete).toHaveBeenCalledTimes(0);
+    expect(spyObserver.onError).toHaveBeenCalledOnce();
+    expect(spyObserver.onComplete).not.toHaveBeenCalled();
+  });
+
+  it('should successfully exit process after an error is thrown when alwaysResolves is set', async () => {
+    const processResult = await executeProcess({
+      ...getAsyncProcessRunnerConfig({
+        interval: 10,
+        runs: 1,
+        throwError: true,
+      }),
+      observer: spyObserver,
+      alwaysResolve: true,
+    }).catch(errorSpy);
+
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(processResult.code).toBe(1);
+    expect(processResult.stdout).toContain('process:update');
+    expect(processResult.stderr).toContain('dummy-error');
+    expect(spyObserver.onStdout).toHaveBeenCalledTimes(2); // intro + 1 run before error
+    expect(spyObserver.onError).not.toHaveBeenCalled();
+    expect(spyObserver.onComplete).toHaveBeenCalledOnce();
   });
 });


### PR DESCRIPTION
Related to #542

In this PR, I implement the plugin runner for the packages plugin. Currently, it only supports `npm` package manager.

### Notable changes
- I added `alwaysResolve` option to our `executeProcess` to suppress non-zero code from `npm outdated`.
- I added this plugin to our Code PushUp config, so that we can see `npm audit` and `npm outdated` results in portal.
- I added score calculation logic to the plugin documentation.

### OOS
- Linking to dependency line in `package.json`.
- Configurable dependency groups.
- Attempting to get more vulnerability context via indirect reference to another dependency in `via` or `effects`.
- Mention all outdated versions in `outdated` display value.

### Preview
<details>
  <summary> Dashboard </summary>

  ![image](https://github.com/code-pushup/cli/assets/6306671/3365f1e8-0751-4d82-826b-35cb222357d3)
</details>

<details>
  <summary> Security detail</summary>

  ![image](https://github.com/code-pushup/cli/assets/6306671/d89ce0db-cbc4-4217-a91c-202f657ef5bb)
</details>

<details>
  <summary> Dependencies detail</summary>

  ![image](https://github.com/code-pushup/cli/assets/6306671/da4b4078-2811-404f-9f7e-bcc173f191d8)
</details>

<details>
  <summary> Issues </summary>

  ![image](https://github.com/code-pushup/cli/assets/6306671/1b60af3e-ff51-4183-b837-54b09bd5d685)
</details>