### PR TITLE
chore: remove verbose logs, unused mock

### DIFF
--- a/packages/plugin-coverage/src/lib/nx/coverage-paths.ts
+++ b/packages/plugin-coverage/src/lib/nx/coverage-paths.ts
@@ -10,10 +10,14 @@ import { CoverageResult } from '../config';
  */
 export async function getNxCoveragePaths(
   targets: string[] = ['test'],
+  verbose?: boolean,
 ): Promise<CoverageResult[]> {
-  ui().logger.info(
-    chalk.bold('💡 Gathering coverage from the following nx projects:'),
-  );
+  if (verbose) {
+    ui().logger.info(
+      chalk.bold('💡 Gathering coverage from the following nx projects:'),
+    );
+  }
+
   const { createProjectGraphAsync } = await import('@nx/devkit');
   const { nodes } = await createProjectGraphAsync({ exitOnError: false });
 
@@ -27,8 +31,9 @@ export async function getNxCoveragePaths(
       const coveragePath = getCoveragePathForTarget(target, targetConfig, name);
       const rootToReportsDir = join(data.root, coveragePath);
 
-      ui().logger.info(`- ${name}: ${target}`);
-
+      if (verbose) {
+        ui().logger.info(`- ${name}: ${target}`);
+      }
       return {
         pathToProject: data.root,
         resultsPath: join(rootToReportsDir, 'lcov.info'),
@@ -36,7 +41,10 @@ export async function getNxCoveragePaths(
     });
   });
 
-  ui().logger.info('\n');
+  if (verbose) {
+    ui().logger.info('\n');
+  }
+
   return coverageResults.flat();
 }
 


### PR DESCRIPTION
In this PR, I do a mini clean-up:
- I remove a mysterious empty mock file from the `cli` package.
- I set logging for coverage plugin helper to `false` by default. This means no more extensive logs before the `collect` command including the [CI](https://github.com/code-pushup/cli/actions/runs/8331116281/job/22797264624?pr=572#step:5:18).