### PR TITLE
feat(core): create report-diff.md file if specified by persist.format

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,9 +171,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Collect Code PushUp report
-        run: npx nx run-collect
+        run: npx nx code-pushup -- collect
       - name: Upload Code PushUp report to portal
-        run: npx nx run-upload
+        run: npx nx code-pushup -- upload
       - name: Save report files as workflow artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,7 +91,7 @@ jobs:
           echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> .npmrc
           npx nx run-many -t=deploy --exclude=plugin-lighthouse,nx-plugin
       - name: Collect and upload Code PushUp report
-        run: npx nx run-autorun
+        run: npx nx code-pushup -- autorun
         env:
           CP_SERVER: ${{ secrets.CP_SERVER }}
           CP_API_KEY: ${{ secrets.CP_API_KEY }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ npx nx build cli
 npx nx affected:lint
 
 # run Code PushUp command on this repository
-npx nx run-collect
+npx nx code-pushup -- collect
 ```
 
 ## Git

--- a/code-pushup.config.ts
+++ b/code-pushup.config.ts
@@ -31,12 +31,6 @@ const envSchema = z
 const env = await envSchema.parseAsync(process.env);
 
 const config: CoreConfig = {
-  persist: {
-    outputDir: '.code-pushup',
-    filename: 'report',
-    format: ['json', 'md'],
-  },
-
   ...(env.CP_SERVER &&
     env.CP_API_KEY &&
     env.CP_ORGANIZATION &&

--- a/e2e/cli-e2e/tests/__snapshots__/compare.e2e.test.ts.snap
+++ b/e2e/cli-e2e/tests/__snapshots__/compare.e2e.test.ts.snap
@@ -1,32 +1,10 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`CLI compare > should compare report.json files and create report-diff.json 1`] = `
+exports[`CLI compare > should compare report.json files and create report-diff.json and report-diff.md 1`] = `
 {
   "audits": {
     "added": [],
     "changed": [
-      {
-        "displayValues": {
-          "after": "62 %",
-          "before": "62 %",
-        },
-        "plugin": {
-          "slug": "coverage",
-          "title": "Code coverage",
-        },
-        "scores": {
-          "after": 0.617,
-          "before": 0.6211,
-          "diff": -0.0040999999999999925,
-        },
-        "slug": "line-coverage",
-        "title": "Line coverage",
-        "values": {
-          "after": 62,
-          "before": 62,
-          "diff": 0,
-        },
-      },
       {
         "displayValues": {
           "after": "passed",
@@ -96,28 +74,6 @@ exports[`CLI compare > should compare report.json files and create report-diff.j
     ],
     "removed": [],
     "unchanged": [
-      {
-        "displayValue": "50 %",
-        "plugin": {
-          "slug": "coverage",
-          "title": "Code coverage",
-        },
-        "score": 0.5,
-        "slug": "function-coverage",
-        "title": "Function coverage",
-        "value": 50,
-      },
-      {
-        "displayValue": "88 %",
-        "plugin": {
-          "slug": "coverage",
-          "title": "Code coverage",
-        },
-        "score": 0.875,
-        "slug": "branch-coverage",
-        "title": "Branch coverage",
-        "value": 88,
-      },
       {
         "displayValue": "passed",
         "plugin": {
@@ -609,15 +565,6 @@ exports[`CLI compare > should compare report.json files and create report-diff.j
     "changed": [
       {
         "scores": {
-          "after": 0.6242,
-          "before": 0.62461,
-          "diff": -0.00041000000000002146,
-        },
-        "slug": "code-coverage",
-        "title": "Code coverage",
-      },
-      {
-        "scores": {
           "after": 0.7692307692307693,
           "before": 0.5384615384615384,
           "diff": 0.23076923076923084,
@@ -641,19 +588,6 @@ exports[`CLI compare > should compare report.json files and create report-diff.j
   "groups": {
     "added": [],
     "changed": [
-      {
-        "plugin": {
-          "slug": "coverage",
-          "title": "Code coverage",
-        },
-        "scores": {
-          "after": 0.6242,
-          "before": 0.62461,
-          "diff": -0.00041000000000002146,
-        },
-        "slug": "coverage",
-        "title": "Code coverage metrics",
-      },
       {
         "plugin": {
           "slug": "eslint",

--- a/e2e/cli-e2e/tests/__snapshots__/compare.report-diff.md
+++ b/e2e/cli-e2e/tests/__snapshots__/compare.report-diff.md
@@ -1,0 +1,39 @@
+# Code PushUp
+
+🥳 Code PushUp report has **improved** – compared target commit `<commit-sha>` with source commit `<commit-sha>`.
+
+## 🏷️ Categories
+
+|🏷️ Category|⭐ Current score|⭐ Previous score|🔄 Score change|
+|:--|:--:|:--:|:--:|
+|Code style|🟡 **77**|🟡 54|![🠉 +23](https://img.shields.io/badge/%F0%9F%A0%89%20%2B23-green)|
+|Bug prevention|🟡 **68**|🟡 68|–|
+
+## 🎗️ Groups
+
+<details>
+<summary>👍 <strong>1</strong> group improved</summary>
+
+|🔌 Plugin|🎗️ Group|⭐ Current score|⭐ Previous score|🔄 Score change|
+|:--|:--|:--:|:--:|:--:|
+|ESLint|Suggestions|🟡 **71**|🟡 50|![🠉 +21](https://img.shields.io/badge/%F0%9F%A0%89%20%2B21-green)|
+
+3 other groups are unchanged.
+
+</details>
+
+
+## 🛡️ Audits
+
+<details>
+<summary>👍 <strong>3</strong> audits improved</summary>
+
+|🔌 Plugin|🛡️ Audit|📏 Current value|📏 Previous value|🔄 Value change|
+|:--|:--|:--:|:--:|:--:|
+|ESLint|Require or disallow method and property shorthand syntax for object literals|🟩 **passed**|🟥 3 warnings|![🠋 −100 %](https://img.shields.io/badge/%F0%9F%A0%8B%20%E2%88%92100%E2%80%89%25-green)|
+|ESLint|Require braces around arrow function bodies|🟩 **passed**|🟥 1 warning|![🠋 −100 %](https://img.shields.io/badge/%F0%9F%A0%8B%20%E2%88%92100%E2%80%89%25-green)|
+|ESLint|Require `const` declarations for variables that are never reassigned after declared|🟩 **passed**|🟥 1 warning|![🠋 −100 %](https://img.shields.io/badge/%F0%9F%A0%8B%20%E2%88%92100%E2%80%89%25-green)|
+
+44 other audits are unchanged.
+
+</details>

--- a/e2e/cli-e2e/tests/compare.e2e.test.ts
+++ b/e2e/cli-e2e/tests/compare.e2e.test.ts
@@ -1,7 +1,7 @@
 import { simpleGit } from 'simple-git';
 import { ReportsDiff } from '@code-pushup/models';
 import { cleanTestFolder } from '@code-pushup/test-setup';
-import { executeProcess, readJsonFile } from '@code-pushup/utils';
+import { executeProcess, readJsonFile, readTextFile } from '@code-pushup/utils';
 
 describe('CLI compare', () => {
   const git = simpleGit();
@@ -15,7 +15,11 @@ describe('CLI compare', () => {
     await cleanTestFolder('tmp/e2e');
     await executeProcess({
       command: 'code-pushup',
-      args: ['collect', '--persist.filename=source-report'],
+      args: [
+        'collect',
+        '--persist.filename=source-report',
+        '--onlyPlugins=eslint',
+      ],
       cwd: 'examples/react-todos-app',
     });
     await executeProcess({
@@ -25,7 +29,11 @@ describe('CLI compare', () => {
     });
     await executeProcess({
       command: 'code-pushup',
-      args: ['collect', '--persist.filename=target-report'],
+      args: [
+        'collect',
+        '--persist.filename=target-report',
+        '--onlyPlugins=eslint',
+      ],
       cwd: 'examples/react-todos-app',
     });
   }, 20_000);
@@ -35,7 +43,7 @@ describe('CLI compare', () => {
     await cleanTestFolder('tmp/e2e');
   });
 
-  it('should compare report.json files and create report-diff.json', async () => {
+  it('should compare report.json files and create report-diff.json and report-diff.md', async () => {
     await executeProcess({
       command: 'code-pushup',
       args: [
@@ -54,5 +62,17 @@ describe('CLI compare', () => {
       date: expect.any(String),
       duration: expect.any(Number),
     });
+
+    const reportsDiffMd = await readTextFile(
+      'tmp/e2e/react-todos-app/report-diff.md',
+    );
+    // commits are variable, replace SHAs with placeholders
+    const sanitizedMd = reportsDiffMd.replace(
+      /(?<=commit )`[\da-f]{7}`/g,
+      '`<commit-sha>`',
+    );
+    await expect(sanitizedMd).toMatchFileSnapshot(
+      '__snapshots__/compare.report-diff.md',
+    );
   });
 });

--- a/packages/cli/src/lib/collect/collect-command.unit.test.ts
+++ b/packages/cli/src/lib/collect/collect-command.unit.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it, vi } from 'vitest';
 import { collectAndPersistReports, readRcByPath } from '@code-pushup/core';
+import {
+  DEFAULT_PERSIST_FILENAME,
+  DEFAULT_PERSIST_FORMAT,
+  DEFAULT_PERSIST_OUTPUT_DIR,
+  PersistConfig,
+} from '@code-pushup/models';
 import { DEFAULT_CLI_CONFIGURATION } from '../../../mocks/constants';
 import { yargsCli } from '../yargs-cli';
 import { yargsCollectCommandObject } from './collect-command';
@@ -31,10 +37,10 @@ describe('collect-command', () => {
     expect(collectAndPersistReports).toHaveBeenCalledWith(
       expect.objectContaining({
         config: '/test/code-pushup.config.ts',
-        persist: expect.objectContaining({
-          filename: 'report',
-          outputDir: '.code-pushup',
-          format: ['json'],
+        persist: expect.objectContaining<Required<PersistConfig>>({
+          filename: DEFAULT_PERSIST_FILENAME,
+          outputDir: DEFAULT_PERSIST_OUTPUT_DIR,
+          format: DEFAULT_PERSIST_FORMAT,
         }),
       }),
     );

--- a/packages/cli/src/lib/compare/compare-command.ts
+++ b/packages/cli/src/lib/compare/compare-command.ts
@@ -1,5 +1,4 @@
 import chalk from 'chalk';
-import { join } from 'node:path';
 import { CommandModule } from 'yargs';
 import { compareReportFiles } from '@code-pushup/core';
 import { PersistConfig } from '@code-pushup/models';
@@ -23,14 +22,14 @@ export function yargsCompareCommandObject() {
       };
 
       const { before, after, persist } = options;
-      const outputPath = join(
-        persist.outputDir,
-        `${persist.filename}-diff.json`,
+
+      const outputPaths = await compareReportFiles({ before, after }, persist);
+
+      ui().logger.info(
+        `Reports diff written to ${outputPaths
+          .map(path => chalk.bold(path))
+          .join(' and ')}`,
       );
-
-      await compareReportFiles({ before, after }, outputPath);
-
-      ui().logger.info(`Reports diff written to ${chalk.bold(outputPath)}`);
     },
   } satisfies CommandModule;
 }

--- a/packages/cli/src/lib/compare/compare-command.unit.test.ts
+++ b/packages/cli/src/lib/compare/compare-command.unit.test.ts
@@ -1,9 +1,12 @@
-import { join } from 'node:path';
+import chalk from 'chalk';
 import { compareReportFiles } from '@code-pushup/core';
 import {
   DEFAULT_PERSIST_FILENAME,
+  DEFAULT_PERSIST_FORMAT,
   DEFAULT_PERSIST_OUTPUT_DIR,
 } from '@code-pushup/models';
+import { getLogMessages } from '@code-pushup/test-utils';
+import { ui } from '@code-pushup/utils';
 import { DEFAULT_CLI_CONFIGURATION } from '../../../mocks/constants';
 import { yargsCli } from '../yargs-cli';
 import { yargsCompareCommandObject } from './compare-command';
@@ -15,7 +18,12 @@ vi.mock('@code-pushup/core', async () => {
   return {
     ...core,
     autoloadRc: vi.fn().mockResolvedValue(CORE_CONFIG_MOCK),
-    compareReportFiles: vi.fn(),
+    compareReportFiles: vi
+      .fn()
+      .mockResolvedValue([
+        '.code-pushup/report-diff.json',
+        '.code-pushup/report-diff.md',
+      ]),
   };
 });
 
@@ -30,7 +38,24 @@ describe('compare-command', () => {
       Parameters<typeof compareReportFiles>
     >(
       { before: 'source-report.json', after: 'target-report.json' },
-      join(DEFAULT_PERSIST_OUTPUT_DIR, `${DEFAULT_PERSIST_FILENAME}-diff.json`),
+      {
+        outputDir: DEFAULT_PERSIST_OUTPUT_DIR,
+        filename: DEFAULT_PERSIST_FILENAME,
+        format: DEFAULT_PERSIST_FORMAT,
+      },
+    );
+  });
+
+  it('should log output paths to stdout', async () => {
+    await yargsCli(
+      ['compare', '--before=source-report.json', '--after=target-report.json'],
+      { ...DEFAULT_CLI_CONFIGURATION, commands: [yargsCompareCommandObject()] },
+    ).parseAsync();
+
+    expect(getLogMessages(ui().logger).at(-1)).toContain(
+      `Reports diff written to ${chalk.bold(
+        '.code-pushup/report-diff.json',
+      )} and ${chalk.bold('.code-pushup/report-diff.md')}`,
     );
   });
 });

--- a/packages/cli/src/lib/compare/compare-command.unit.test.ts
+++ b/packages/cli/src/lib/compare/compare-command.unit.test.ts
@@ -1,6 +1,9 @@
 import { join } from 'node:path';
 import { compareReportFiles } from '@code-pushup/core';
-import { PERSIST_FILENAME, PERSIST_OUTPUT_DIR } from '@code-pushup/models';
+import {
+  DEFAULT_PERSIST_FILENAME,
+  DEFAULT_PERSIST_OUTPUT_DIR,
+} from '@code-pushup/models';
 import { DEFAULT_CLI_CONFIGURATION } from '../../../mocks/constants';
 import { yargsCli } from '../yargs-cli';
 import { yargsCompareCommandObject } from './compare-command';
@@ -27,7 +30,7 @@ describe('compare-command', () => {
       Parameters<typeof compareReportFiles>
     >(
       { before: 'source-report.json', after: 'target-report.json' },
-      join(PERSIST_OUTPUT_DIR, `${PERSIST_FILENAME}-diff.json`),
+      join(DEFAULT_PERSIST_OUTPUT_DIR, `${DEFAULT_PERSIST_FILENAME}-diff.json`),
     );
   });
 });

--- a/packages/cli/src/lib/implementation/core-config.integration.test.ts
+++ b/packages/cli/src/lib/implementation/core-config.integration.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, vi } from 'vitest';
 import {
   CoreConfig,
-  PERSIST_FILENAME,
-  PERSIST_FORMAT,
-  PERSIST_OUTPUT_DIR,
+  DEFAULT_PERSIST_FILENAME,
+  DEFAULT_PERSIST_FORMAT,
+  DEFAULT_PERSIST_OUTPUT_DIR,
   PersistConfig,
   UploadConfig,
 } from '@code-pushup/models';
@@ -61,9 +61,9 @@ describe('parsing values from CLI and middleware', () => {
     ).parseAsync();
 
     expect(persist).toEqual<PersistConfig>({
-      filename: PERSIST_FILENAME,
-      format: PERSIST_FORMAT,
-      outputDir: PERSIST_OUTPUT_DIR,
+      filename: DEFAULT_PERSIST_FILENAME,
+      format: DEFAULT_PERSIST_FORMAT,
+      outputDir: DEFAULT_PERSIST_OUTPUT_DIR,
     });
   });
 
@@ -139,7 +139,7 @@ describe('parsing values from CLI and middleware', () => {
 
     expect(persist).toEqual<PersistConfig>({
       filename: 'rc-filename',
-      format: PERSIST_FORMAT,
+      format: DEFAULT_PERSIST_FORMAT,
       outputDir: 'cli-outputdir',
     });
   });

--- a/packages/cli/src/lib/implementation/core-config.middleware.ts
+++ b/packages/cli/src/lib/implementation/core-config.middleware.ts
@@ -1,9 +1,9 @@
 import { autoloadRc, readRcByPath } from '@code-pushup/core';
 import {
   CoreConfig,
-  PERSIST_FILENAME,
-  PERSIST_FORMAT,
-  PERSIST_OUTPUT_DIR,
+  DEFAULT_PERSIST_FILENAME,
+  DEFAULT_PERSIST_FORMAT,
+  DEFAULT_PERSIST_OUTPUT_DIR,
   uploadConfigSchema,
 } from '@code-pushup/models';
 import { CoreConfigCliOptions } from './core-config.model';
@@ -46,9 +46,12 @@ export async function coreConfigMiddleware<
     ...(config != null && { config }),
     persist: {
       outputDir:
-        cliPersist?.outputDir ?? rcPersist?.outputDir ?? PERSIST_OUTPUT_DIR,
-      format: cliPersist?.format ?? rcPersist?.format ?? PERSIST_FORMAT,
-      filename: cliPersist?.filename ?? rcPersist?.filename ?? PERSIST_FILENAME,
+        cliPersist?.outputDir ??
+        rcPersist?.outputDir ??
+        DEFAULT_PERSIST_OUTPUT_DIR,
+      filename:
+        cliPersist?.filename ?? rcPersist?.filename ?? DEFAULT_PERSIST_FILENAME,
+      format: cliPersist?.format ?? rcPersist?.format ?? DEFAULT_PERSIST_FORMAT,
     },
     ...(upload != null && { upload }),
     categories: rcCategories ?? [],

--- a/packages/core/src/lib/compare.ts
+++ b/packages/core/src/lib/compare.ts
@@ -1,8 +1,16 @@
 import { writeFile } from 'node:fs/promises';
-import { Report, ReportsDiff, reportSchema } from '@code-pushup/models';
+import { join } from 'node:path';
+import {
+  type Format,
+  type PersistConfig,
+  Report,
+  ReportsDiff,
+  reportSchema,
+} from '@code-pushup/models';
 import {
   Diff,
   calcDuration,
+  generateMdReportsDiff,
   readJsonFile,
   scoreReport,
 } from '@code-pushup/utils';
@@ -16,8 +24,10 @@ import {
 
 export async function compareReportFiles(
   inputPaths: Diff<string>,
-  outputPath: string,
-): Promise<void> {
+  persistConfig: Required<PersistConfig>,
+): Promise<string[]> {
+  const { outputDir, filename, format } = persistConfig;
+
   const [reportBefore, reportAfter] = await Promise.all([
     readJsonFile(inputPaths.before),
     readJsonFile(inputPaths.after),
@@ -29,7 +39,14 @@ export async function compareReportFiles(
 
   const reportsDiff = compareReports(reports);
 
-  await writeFile(outputPath, JSON.stringify(reportsDiff, null, 2));
+  return Promise.all(
+    format.map(async fmt => {
+      const outputPath = join(outputDir, `${filename}-diff.${fmt}`);
+      const content = reportsDiffToFileContent(reportsDiff, fmt);
+      await writeFile(outputPath, content);
+      return outputPath;
+    }),
+  );
 }
 
 export function compareReports(reports: Diff<Report>): ReportsDiff {
@@ -62,4 +79,16 @@ export function compareReports(reports: Diff<Report>): ReportsDiff {
     date,
     duration,
   };
+}
+
+function reportsDiffToFileContent(
+  reportsDiff: ReportsDiff,
+  format: Format,
+): string {
+  switch (format) {
+    case 'json':
+      return JSON.stringify(reportsDiff, null, 2);
+    case 'md':
+      return generateMdReportsDiff(reportsDiff);
+  }
 }

--- a/packages/core/src/lib/compare.unit.test.ts
+++ b/packages/core/src/lib/compare.unit.test.ts
@@ -9,7 +9,7 @@ import {
   REPORT_MOCK,
   reportMock,
 } from '@code-pushup/test-utils';
-import { Diff, readJsonFile } from '@code-pushup/utils';
+import { Diff, fileExists, readJsonFile } from '@code-pushup/utils';
 import { compareReportFiles, compareReports } from './compare';
 
 describe('compareReportFiles', () => {
@@ -23,22 +23,39 @@ describe('compareReportFiles', () => {
     );
   });
 
-  it('should create valid reports-diff.json from report.json files', async () => {
+  it('should create valid report-diff.json from report.json files', async () => {
     await compareReportFiles(
       {
         before: join(MEMFS_VOLUME, 'source-report.json'),
         after: join(MEMFS_VOLUME, 'target-report.json'),
       },
-      join(MEMFS_VOLUME, 'reports-diff.json'),
+      { outputDir: MEMFS_VOLUME, filename: 'report', format: ['json'] },
     );
 
     const reportsDiffPromise = readJsonFile(
-      join(MEMFS_VOLUME, 'reports-diff.json'),
+      join(MEMFS_VOLUME, 'report-diff.json'),
     );
     await expect(reportsDiffPromise).resolves.toBeTruthy();
 
     const reportsDiff = await reportsDiffPromise;
     expect(() => reportsDiffSchema.parse(reportsDiff)).not.toThrow();
+  });
+
+  it('should create all diff files specified by persist.format', async () => {
+    await compareReportFiles(
+      {
+        before: join(MEMFS_VOLUME, 'source-report.json'),
+        after: join(MEMFS_VOLUME, 'target-report.json'),
+      },
+      { outputDir: MEMFS_VOLUME, filename: 'report', format: ['json', 'md'] },
+    );
+
+    await expect(
+      fileExists(join(MEMFS_VOLUME, 'report-diff.json')),
+    ).resolves.toBeTruthy();
+    await expect(
+      fileExists(join(MEMFS_VOLUME, 'report-diff.md')),
+    ).resolves.toBeTruthy();
   });
 });
 

--- a/packages/models/src/index.ts
+++ b/packages/models/src/index.ts
@@ -21,9 +21,9 @@ export {
   SUPPORTED_CONFIG_FILE_FORMATS,
 } from './lib/implementation/configuration';
 export {
-  PERSIST_FILENAME,
-  PERSIST_FORMAT,
-  PERSIST_OUTPUT_DIR,
+  DEFAULT_PERSIST_FILENAME,
+  DEFAULT_PERSIST_FORMAT,
+  DEFAULT_PERSIST_OUTPUT_DIR,
 } from './lib/implementation/constants';
 export {
   MAX_DESCRIPTION_LENGTH,

--- a/packages/models/src/lib/implementation/constants.ts
+++ b/packages/models/src/lib/implementation/constants.ts
@@ -1,5 +1,5 @@
 import { Format } from '../persist-config';
 
-export const PERSIST_OUTPUT_DIR = '.code-pushup';
-export const PERSIST_FORMAT: Format[] = ['json'];
-export const PERSIST_FILENAME = 'report';
+export const DEFAULT_PERSIST_OUTPUT_DIR = '.code-pushup';
+export const DEFAULT_PERSIST_FILENAME = 'report';
+export const DEFAULT_PERSIST_FORMAT: Format[] = ['json', 'md'];

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,5 +1,5 @@
 export { exists } from '@code-pushup/models';
-export { Diff, matchArrayItemsByKey, comparePairs } from './lib/diff';
+export { Diff, comparePairs, matchArrayItemsByKey } from './lib/diff';
 export {
   ProcessConfig,
   ProcessError,
@@ -37,11 +37,11 @@ export {
 } from './lib/formatting';
 export {
   formatGitPath,
+  getCurrentBranchOrTag,
   getGitRoot,
   getLatestCommit,
-  toGitPath,
-  getCurrentBranchOrTag,
   safeCheckout,
+  toGitPath,
 } from './lib/git';
 export { groupByStatus } from './lib/group-by-status';
 export {
@@ -49,8 +49,8 @@ export {
   isPromiseRejectedResult,
 } from './lib/guards';
 export { logMultipleResults } from './lib/log-results';
+export { CliUi, Column, link, ui } from './lib/logging';
 export { ProgressBar, getProgressBar } from './lib/progress';
-export { logStdoutSummary } from './lib/reports/log-stdout-summary';
 export {
   CODE_PUSHUP_DOMAIN,
   FOOTER_PREFIX,
@@ -62,6 +62,8 @@ export {
   listGroupsFromAllPlugins,
 } from './lib/reports/flatten-plugins';
 export { generateMdReport } from './lib/reports/generate-md-report';
+export { generateMdReportsDiff } from './lib/reports/generate-md-reports-diff';
+export { logStdoutSummary } from './lib/reports/log-stdout-summary';
 export { scoreReport } from './lib/reports/scoring';
 export { sortReport } from './lib/reports/sorting';
 export {
@@ -90,4 +92,3 @@ export {
   toUnixPath,
 } from './lib/transform';
 export { verboseUtils } from './lib/verbose-utils';
-export { link, ui, CliUi, Column } from './lib/logging';

--- a/packages/utils/src/lib/reports/utils.ts
+++ b/packages/utils/src/lib/reports/utils.ts
@@ -95,7 +95,7 @@ export function getSeverityIcon(
 }
 
 export function calcDuration(start: number, stop?: number): number {
-  return Math.floor((stop ?? performance.now()) - start);
+  return Math.round((stop ?? performance.now()) - start);
 }
 
 export function countWeightedRefs(refs: CategoryRef[]) {

--- a/project.json
+++ b/project.json
@@ -28,40 +28,8 @@
         "notes": "{notes}"
       }
     },
-    "run-collect": {
-      "command": "npx dist/packages/cli collect",
-      "dependsOn": [
-        {
-          "projects": [
-            "cli",
-            "plugin-eslint",
-            "plugin-coverage",
-            "plugin-js-packages",
-            "examples-plugins",
-            "react-todos-app"
-          ],
-          "target": "build"
-        }
-      ]
-    },
-    "run-upload": {
-      "command": "npx dist/packages/cli upload",
-      "dependsOn": [
-        {
-          "projects": [
-            "cli",
-            "plugin-eslint",
-            "plugin-coverage",
-            "plugin-js-packages",
-            "examples-plugins",
-            "react-todos-app"
-          ],
-          "target": "build"
-        }
-      ]
-    },
-    "run-autorun": {
-      "command": "npx dist/packages/cli autorun",
+    "code-pushup": {
+      "command": "npx dist/packages/cli",
       "dependsOn": [
         {
           "projects": [

--- a/testing/test-utils/src/lib/utils/dynamic-mocks/persist-config.mock.ts
+++ b/testing/test-utils/src/lib/utils/dynamic-mocks/persist-config.mock.ts
@@ -1,7 +1,7 @@
 import {
-  PERSIST_FILENAME,
-  PERSIST_FORMAT,
-  PERSIST_OUTPUT_DIR,
+  DEFAULT_PERSIST_FILENAME,
+  DEFAULT_PERSIST_FORMAT,
+  DEFAULT_PERSIST_OUTPUT_DIR,
   PersistConfig,
   persistConfigSchema,
 } from '@code-pushup/models';
@@ -10,9 +10,9 @@ export function persistConfigMock(
   opt?: Partial<PersistConfig>,
 ): Required<PersistConfig> {
   return persistConfigSchema.parse({
-    outputDir: PERSIST_OUTPUT_DIR,
-    filename: PERSIST_FILENAME,
-    format: PERSIST_FORMAT,
+    outputDir: DEFAULT_PERSIST_OUTPUT_DIR,
+    filename: DEFAULT_PERSIST_FILENAME,
+    format: DEFAULT_PERSIST_FORMAT,
     ...opt,
   }) as Required<PersistConfig>;
 }


### PR DESCRIPTION
Part of #559 

I need to get these changes into `main` before I can implement the GitHub Actions workflow.

Scope:
- `compare` command now creates markdown diff
- changed default `persist.format` from `['json']` to `['json', 'md']`, so that basic `compare` flow works without custom configuration
- added markdown diff to E2E tests
- replaced multi-target `nx run-collect`, `nx run-upload` etc. with single target `nx code-pushup -- <command-and-options-here>`