### PR TITLE
fix(utils): use unicode arrows with wider OS support

### DIFF
--- a/e2e/cli-e2e/tests/__snapshots__/compare.report-diff.md
+++ b/e2e/cli-e2e/tests/__snapshots__/compare.report-diff.md
@@ -6,7 +6,7 @@
 
 |🏷️ Category|⭐ Current score|⭐ Previous score|🔄 Score change|
 |:--|:--:|:--:|:--:|
-|Code style|🟡 **77**|🟡 54|![🠉 +23](https://img.shields.io/badge/%F0%9F%A0%89%20%2B23-green)|
+|Code style|🟡 **77**|🟡 54|![↑ +23](https://img.shields.io/badge/%E2%86%91%20%2B23-green)|
 |Bug prevention|🟡 **68**|🟡 68|–|
 
 ## 🎗️ Groups
@@ -16,7 +16,7 @@
 
 |🔌 Plugin|🗃️ Group|⭐ Current score|⭐ Previous score|🔄 Score change|
 |:--|:--|:--:|:--:|:--:|
-|ESLint|Suggestions|🟡 **71**|🟡 50|![🠉 +21](https://img.shields.io/badge/%F0%9F%A0%89%20%2B21-green)|
+|ESLint|Suggestions|🟡 **71**|🟡 50|![↑ +21](https://img.shields.io/badge/%E2%86%91%20%2B21-green)|
 
 3 other groups are unchanged.
 
@@ -30,9 +30,9 @@
 
 |🔌 Plugin|🛡️ Audit|📏 Current value|📏 Previous value|🔄 Value change|
 |:--|:--|:--:|:--:|:--:|
-|ESLint|Require or disallow method and property shorthand syntax for object literals|🟩 **passed**|🟥 3 warnings|![🠋 −100 %](https://img.shields.io/badge/%F0%9F%A0%8B%20%E2%88%92100%E2%80%89%25-green)|
-|ESLint|Require braces around arrow function bodies|🟩 **passed**|🟥 1 warning|![🠋 −100 %](https://img.shields.io/badge/%F0%9F%A0%8B%20%E2%88%92100%E2%80%89%25-green)|
-|ESLint|Require `const` declarations for variables that are never reassigned after declared|🟩 **passed**|🟥 1 warning|![🠋 −100 %](https://img.shields.io/badge/%F0%9F%A0%8B%20%E2%88%92100%E2%80%89%25-green)|
+|ESLint|Require or disallow method and property shorthand syntax for object literals|🟩 **passed**|🟥 3 warnings|![↓ −100 %](https://img.shields.io/badge/%E2%86%93%20%E2%88%92100%E2%80%89%25-green)|
+|ESLint|Require braces around arrow function bodies|🟩 **passed**|🟥 1 warning|![↓ −100 %](https://img.shields.io/badge/%E2%86%93%20%E2%88%92100%E2%80%89%25-green)|
+|ESLint|Require `const` declarations for variables that are never reassigned after declared|🟩 **passed**|🟥 1 warning|![↓ −100 %](https://img.shields.io/badge/%E2%86%93%20%E2%88%92100%E2%80%89%25-green)|
 
 44 other audits are unchanged.
 

--- a/packages/utils/src/lib/reports/__snapshots__/report-diff-added.md
+++ b/packages/utils/src/lib/reports/__snapshots__/report-diff-added.md
@@ -6,7 +6,7 @@
 
 |🏷️ Category|⭐ Current score|⭐ Previous score|🔄 Score change|
 |:--|:--:|:--:|:--:|
-|Bug prevention|🟡 **63**|🟡 68|![🠋 −5](https://img.shields.io/badge/%F0%9F%A0%8B%20%E2%88%925-red)|
+|Bug prevention|🟡 **63**|🟡 68|![↓ −5](https://img.shields.io/badge/%E2%86%93%20%E2%88%925-red)|
 |Performance|🟢 **94**|_n/a (\*)_|_n/a (\*)_|
 |Code style|🟡 **54**|🟡 54|–|
 
@@ -23,7 +23,7 @@ All of 1 group is unchanged.
 
 |🔌 Plugin|🛡️ Audit|📏 Current value|📏 Previous value|🔄 Value change|
 |:--|:--|:--:|:--:|:--:|
-|ESLint|Disallow unused variables|🟥 **1 error**|🟩 passed|![🠉 +∞ %](https://img.shields.io/badge/%F0%9F%A0%89%20%2B%E2%88%9E%E2%80%89%25-red)|
+|ESLint|Disallow unused variables|🟥 **1 error**|🟩 passed|![↑ +∞ %](https://img.shields.io/badge/%E2%86%91%20%2B%E2%88%9E%E2%80%89%25-red)|
 
 48 other audits are unchanged.
 

--- a/packages/utils/src/lib/reports/__snapshots__/report-diff-improved.md
+++ b/packages/utils/src/lib/reports/__snapshots__/report-diff-improved.md
@@ -6,9 +6,9 @@
 
 |🏷️ Category|⭐ Current score|⭐ Previous score|🔄 Score change|
 |:--|:--:|:--:|:--:|
-|Code style|🟢 **100**|🟡 54|![🠉 +46](https://img.shields.io/badge/%F0%9F%A0%89%20%2B46-green)|
-|Bug prevention|🟢 **95**|🟡 68|![🠉 +27](https://img.shields.io/badge/%F0%9F%A0%89%20%2B27-green)|
-|Performance|🟢 **94**|🟢 92|![🠉 +2](https://img.shields.io/badge/%F0%9F%A0%89%20%2B2-green)|
+|Code style|🟢 **100**|🟡 54|![↑ +46](https://img.shields.io/badge/%E2%86%91%20%2B46-green)|
+|Bug prevention|🟢 **95**|🟡 68|![↑ +27](https://img.shields.io/badge/%E2%86%91%20%2B27-green)|
+|Performance|🟢 **94**|🟢 92|![↑ +2](https://img.shields.io/badge/%E2%86%91%20%2B2-green)|
 
 ## 🎗️ Groups
 
@@ -17,8 +17,8 @@
 
 |🔌 Plugin|🗃️ Group|⭐ Current score|⭐ Previous score|🔄 Score change|
 |:--|:--|:--:|:--:|:--:|
-|ESLint|Maximum lines limitation|🟢 **100**|🟡 50|![🠉 +50](https://img.shields.io/badge/%F0%9F%A0%89%20%2B50-green)|
-|Lighthouse|Performance|🟢 **94**|🟢 92|![🠉 +2](https://img.shields.io/badge/%F0%9F%A0%89%20%2B2-green)|
+|ESLint|Maximum lines limitation|🟢 **100**|🟡 50|![↑ +50](https://img.shields.io/badge/%E2%86%91%20%2B50-green)|
+|Lighthouse|Performance|🟢 **94**|🟢 92|![↑ +2](https://img.shields.io/badge/%E2%86%91%20%2B2-green)|
 
 </details>
 
@@ -30,18 +30,18 @@
 
 |🔌 Plugin|🛡️ Audit|📏 Current value|📏 Previous value|🔄 Value change|
 |:--|:--|:--:|:--:|:--:|
-|ESLint|Disallow variable declarations from shadowing variables declared in the outer scope|🟩 **passed**|🟥 3 warnings|![🠋 −100 %](https://img.shields.io/badge/%F0%9F%A0%8B%20%E2%88%92100%E2%80%89%25-green)|
-|ESLint|Require or disallow method and property shorthand syntax for object literals|🟩 **passed**|🟥 3 warnings|![🠋 −100 %](https://img.shields.io/badge/%F0%9F%A0%8B%20%E2%88%92100%E2%80%89%25-green)|
-|ESLint|verifies the list of dependencies for Hooks like useEffect and similar|🟩 **passed**|🟥 2 warnings|![🠋 −100 %](https://img.shields.io/badge/%F0%9F%A0%8B%20%E2%88%92100%E2%80%89%25-green)|
-|ESLint|Disallow unused variables|🟩 **passed**|🟥 1 warning|![🠋 −100 %](https://img.shields.io/badge/%F0%9F%A0%8B%20%E2%88%92100%E2%80%89%25-green)|
-|ESLint|Require braces around arrow function bodies|🟩 **passed**|🟥 1 warning|![🠋 −100 %](https://img.shields.io/badge/%F0%9F%A0%8B%20%E2%88%92100%E2%80%89%25-green)|
-|ESLint|Require the use of `===` and `!==`|🟩 **passed**|🟥 1 warning|![🠋 −100 %](https://img.shields.io/badge/%F0%9F%A0%8B%20%E2%88%92100%E2%80%89%25-green)|
-|ESLint|Enforce a maximum number of lines of code in a function|🟩 **passed**|🟥 1 warning|![🠋 −100 %](https://img.shields.io/badge/%F0%9F%A0%8B%20%E2%88%92100%E2%80%89%25-green)|
-|ESLint|Require `const` declarations for variables that are never reassigned after declared|🟩 **passed**|🟥 1 warning|![🠋 −100 %](https://img.shields.io/badge/%F0%9F%A0%8B%20%E2%88%92100%E2%80%89%25-green)|
-|ESLint|Disallow missing `key` props in iterators/collection literals|🟩 **passed**|🟥 1 warning|![🠋 −100 %](https://img.shields.io/badge/%F0%9F%A0%8B%20%E2%88%92100%E2%80%89%25-green)|
-|Lighthouse|Largest Contentful Paint|🟨 **1.4 s**|🟨 1.5 s|![🠋 −8 %](https://img.shields.io/badge/%F0%9F%A0%8B%20%E2%88%928%E2%80%89%25-green)|
-|Lighthouse|First Contentful Paint|🟨 **1.1 s**|🟨 1.2 s|![🠋 −4 %](https://img.shields.io/badge/%F0%9F%A0%8B%20%E2%88%924%E2%80%89%25-green)|
-|Lighthouse|Speed Index|🟩 **1.1 s**|🟩 1.2 s|![🠋 −4 %](https://img.shields.io/badge/%F0%9F%A0%8B%20%E2%88%924%E2%80%89%25-green)|
+|ESLint|Disallow variable declarations from shadowing variables declared in the outer scope|🟩 **passed**|🟥 3 warnings|![↓ −100 %](https://img.shields.io/badge/%E2%86%93%20%E2%88%92100%E2%80%89%25-green)|
+|ESLint|Require or disallow method and property shorthand syntax for object literals|🟩 **passed**|🟥 3 warnings|![↓ −100 %](https://img.shields.io/badge/%E2%86%93%20%E2%88%92100%E2%80%89%25-green)|
+|ESLint|verifies the list of dependencies for Hooks like useEffect and similar|🟩 **passed**|🟥 2 warnings|![↓ −100 %](https://img.shields.io/badge/%E2%86%93%20%E2%88%92100%E2%80%89%25-green)|
+|ESLint|Disallow unused variables|🟩 **passed**|🟥 1 warning|![↓ −100 %](https://img.shields.io/badge/%E2%86%93%20%E2%88%92100%E2%80%89%25-green)|
+|ESLint|Require braces around arrow function bodies|🟩 **passed**|🟥 1 warning|![↓ −100 %](https://img.shields.io/badge/%E2%86%93%20%E2%88%92100%E2%80%89%25-green)|
+|ESLint|Require the use of `===` and `!==`|🟩 **passed**|🟥 1 warning|![↓ −100 %](https://img.shields.io/badge/%E2%86%93%20%E2%88%92100%E2%80%89%25-green)|
+|ESLint|Enforce a maximum number of lines of code in a function|🟩 **passed**|🟥 1 warning|![↓ −100 %](https://img.shields.io/badge/%E2%86%93%20%E2%88%92100%E2%80%89%25-green)|
+|ESLint|Require `const` declarations for variables that are never reassigned after declared|🟩 **passed**|🟥 1 warning|![↓ −100 %](https://img.shields.io/badge/%E2%86%93%20%E2%88%92100%E2%80%89%25-green)|
+|ESLint|Disallow missing `key` props in iterators/collection literals|🟩 **passed**|🟥 1 warning|![↓ −100 %](https://img.shields.io/badge/%E2%86%93%20%E2%88%92100%E2%80%89%25-green)|
+|Lighthouse|Largest Contentful Paint|🟨 **1.4 s**|🟨 1.5 s|![↓ −8 %](https://img.shields.io/badge/%E2%86%93%20%E2%88%928%E2%80%89%25-green)|
+|Lighthouse|First Contentful Paint|🟨 **1.1 s**|🟨 1.2 s|![↓ −4 %](https://img.shields.io/badge/%E2%86%93%20%E2%88%924%E2%80%89%25-green)|
+|Lighthouse|Speed Index|🟩 **1.1 s**|🟩 1.2 s|![↓ −4 %](https://img.shields.io/badge/%E2%86%93%20%E2%88%924%E2%80%89%25-green)|
 
 40 other audits are unchanged.
 

--- a/packages/utils/src/lib/reports/__snapshots__/report-diff-minimal.md
+++ b/packages/utils/src/lib/reports/__snapshots__/report-diff-minimal.md
@@ -9,6 +9,6 @@
 
 |🔌 Plugin|🛡️ Audit|📏 Current value|📏 Previous value|🔄 Value change|
 |:--|:--|:--:|:--:|:--:|
-|NPM|Check for outdates NPM packages|🟨 **3 packages are out of date**|🟩 1 package is out of date|![🠉 +200 %](https://img.shields.io/badge/%F0%9F%A0%89%20%2B200%E2%80%89%25-red)|
+|NPM|Check for outdates NPM packages|🟨 **3 packages are out of date**|🟩 1 package is out of date|![↑ +200 %](https://img.shields.io/badge/%E2%86%91%20%2B200%E2%80%89%25-red)|
 
 </details>

--- a/packages/utils/src/lib/reports/__snapshots__/report-diff-mixed.md
+++ b/packages/utils/src/lib/reports/__snapshots__/report-diff-mixed.md
@@ -6,8 +6,8 @@
 
 |🏷️ Category|⭐ Current score|⭐ Previous score|🔄 Score change|
 |:--|:--:|:--:|:--:|
-|Bug prevention|🟡 **63**|🟡 68|![🠋 −5](https://img.shields.io/badge/%F0%9F%A0%8B%20%E2%88%925-red)|
-|Performance|🟢 **94**|🟢 92|![🠉 +2](https://img.shields.io/badge/%F0%9F%A0%89%20%2B2-green)|
+|Bug prevention|🟡 **63**|🟡 68|![↓ −5](https://img.shields.io/badge/%E2%86%93%20%E2%88%925-red)|
+|Performance|🟢 **94**|🟢 92|![↑ +2](https://img.shields.io/badge/%E2%86%91%20%2B2-green)|
 |Code style|🟡 **54**|🟡 54|–|
 
 ## 🎗️ Groups
@@ -17,7 +17,7 @@
 
 |🔌 Plugin|🗃️ Group|⭐ Current score|⭐ Previous score|🔄 Score change|
 |:--|:--|:--:|:--:|:--:|
-|Lighthouse|Performance|🟢 **94**|🟢 92|![🠉 +2](https://img.shields.io/badge/%F0%9F%A0%89%20%2B2-green)|
+|Lighthouse|Performance|🟢 **94**|🟢 92|![↑ +2](https://img.shields.io/badge/%E2%86%91%20%2B2-green)|
 
 1 other group is unchanged.
 
@@ -31,10 +31,10 @@
 
 |🔌 Plugin|🛡️ Audit|📏 Current value|📏 Previous value|🔄 Value change|
 |:--|:--|:--:|:--:|:--:|
-|ESLint|Disallow unused variables|🟥 **1 error**|🟩 passed|![🠉 +∞ %](https://img.shields.io/badge/%F0%9F%A0%89%20%2B%E2%88%9E%E2%80%89%25-red)|
-|Lighthouse|Largest Contentful Paint|🟨 **1.4 s**|🟨 1.5 s|![🠋 −8 %](https://img.shields.io/badge/%F0%9F%A0%8B%20%E2%88%928%E2%80%89%25-green)|
-|Lighthouse|First Contentful Paint|🟨 **1.1 s**|🟨 1.2 s|![🠋 −4 %](https://img.shields.io/badge/%F0%9F%A0%8B%20%E2%88%924%E2%80%89%25-green)|
-|Lighthouse|Speed Index|🟩 **1.1 s**|🟩 1.2 s|![🠋 −4 %](https://img.shields.io/badge/%F0%9F%A0%8B%20%E2%88%924%E2%80%89%25-green)|
+|ESLint|Disallow unused variables|🟥 **1 error**|🟩 passed|![↑ +∞ %](https://img.shields.io/badge/%E2%86%91%20%2B%E2%88%9E%E2%80%89%25-red)|
+|Lighthouse|Largest Contentful Paint|🟨 **1.4 s**|🟨 1.5 s|![↓ −8 %](https://img.shields.io/badge/%E2%86%93%20%E2%88%928%E2%80%89%25-green)|
+|Lighthouse|First Contentful Paint|🟨 **1.1 s**|🟨 1.2 s|![↓ −4 %](https://img.shields.io/badge/%E2%86%93%20%E2%88%924%E2%80%89%25-green)|
+|Lighthouse|Speed Index|🟩 **1.1 s**|🟩 1.2 s|![↓ −4 %](https://img.shields.io/badge/%E2%86%93%20%E2%88%924%E2%80%89%25-green)|
 
 48 other audits are unchanged.
 

--- a/packages/utils/src/lib/reports/utils.ts
+++ b/packages/utils/src/lib/reports/utils.ts
@@ -55,10 +55,10 @@ export function getSquaredScoreMarker(score: number): string {
 
 export function getDiffMarker(diff: number): string {
   if (diff > 0) {
-    return '🠉';
+    return '↑';
   }
   if (diff < 0) {
-    return '🠋';
+    return '↓';
   }
   return '';
 }


### PR DESCRIPTION
Turns out the triangle arrowhead unicode symbols (🠅 🠇) aren't supported on Apple devices (thanks to @BioPhoton for reporting), so used more common unicode symbol (↑ ↓) which should have better OS support.

<details>
<summary>iPhone screenshot</summary>

![image](https://github.com/code-pushup/cli/assets/34691111/786158fc-1fad-4875-96c7-427fd8e0e6b7)

</details>

<details>
<summary>

screenshot of supported unicode arrows on Apple devices (http://xahlee.info/comp/unicode_arrows.html)</summary>

![image](https://github.com/code-pushup/cli/assets/34691111/d11e8ec5-df5f-4b4f-99ae-00b3c6ccef48)

</details>

:arrow_down: The comment below isn't updated yet because `compare` runs in `main` branch :sweat_smile:

