### PR TITLE
test: exclude mocks, perf and config from coverage

### DIFF
--- a/packages/cli/vite.config.integration.ts
+++ b/packages/cli/vite.config.integration.ts
@@ -16,6 +16,7 @@ export default defineConfig({
     coverage: {
       reporter: ['text', 'lcov'],
       reportsDirectory: '../../coverage/cli/integration-tests',
+      exclude: ['mocks/**'],
     },
     environment: 'node',
     include: ['src/**/*.integration.test.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],

--- a/packages/cli/vite.config.unit.ts
+++ b/packages/cli/vite.config.unit.ts
@@ -16,6 +16,7 @@ export default defineConfig({
     coverage: {
       reporter: ['text', 'lcov'],
       reportsDirectory: '../../coverage/cli/unit-tests',
+      exclude: ['mocks/**'],
     },
     environment: 'node',
     include: ['src/**/*.unit.test.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],

--- a/packages/core/vite.config.integration.ts
+++ b/packages/core/vite.config.integration.ts
@@ -16,6 +16,7 @@ export default defineConfig({
     coverage: {
       reporter: ['text', 'lcov'],
       reportsDirectory: '../../coverage/core/integration-tests',
+      exclude: ['mocks/**'],
     },
     environment: 'node',
     include: ['src/**/*.integration.test.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],

--- a/packages/core/vite.config.unit.ts
+++ b/packages/core/vite.config.unit.ts
@@ -16,6 +16,7 @@ export default defineConfig({
     coverage: {
       reporter: ['text', 'lcov'],
       reportsDirectory: '../../coverage/core/unit-tests',
+      exclude: ['mocks/**'],
     },
     environment: 'node',
     include: ['src/**/*.unit.test.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],

--- a/packages/models/vite.config.integration.ts
+++ b/packages/models/vite.config.integration.ts
@@ -16,6 +16,7 @@ export default defineConfig({
     coverage: {
       reporter: ['text', 'lcov'],
       reportsDirectory: '../../coverage/models/integration-tests',
+      exclude: ['mocks/**', 'zod2md.config.ts'],
     },
     environment: 'node',
     include: ['src/**/*.integration.test.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],

--- a/packages/models/vite.config.unit.ts
+++ b/packages/models/vite.config.unit.ts
@@ -16,6 +16,7 @@ export default defineConfig({
     coverage: {
       reporter: ['text', 'lcov'],
       reportsDirectory: '../../coverage/models/unit-tests',
+      exclude: ['mocks/**', 'zod2md.config.ts'],
     },
     environment: 'node',
     include: ['src/**/*.unit.test.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],

--- a/packages/nx-plugin/vite.config.integration.ts
+++ b/packages/nx-plugin/vite.config.integration.ts
@@ -16,6 +16,7 @@ export default defineConfig({
     coverage: {
       reporter: ['text', 'lcov'],
       reportsDirectory: '../../coverage/nx-plugin/integration-tests',
+      exclude: ['mocks/**'],
     },
     environment: 'node',
     include: ['src/**/*.integration.test.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],

--- a/packages/nx-plugin/vite.config.unit.ts
+++ b/packages/nx-plugin/vite.config.unit.ts
@@ -16,6 +16,7 @@ export default defineConfig({
     coverage: {
       reporter: ['text', 'lcov'],
       reportsDirectory: '../../coverage/nx-plugin/unit-tests',
+      exclude: ['mocks/**'],
     },
     environment: 'node',
     include: ['src/**/*.unit.test.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],

--- a/packages/plugin-coverage/vite.config.integration.ts
+++ b/packages/plugin-coverage/vite.config.integration.ts
@@ -16,6 +16,7 @@ export default defineConfig({
     coverage: {
       reporter: ['text', 'lcov'],
       reportsDirectory: '../../coverage/plugin-coverage/integration-tests',
+      exclude: ['mocks/**'],
     },
     environment: 'node',
     include: ['src/**/*.integration.test.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],

--- a/packages/plugin-coverage/vite.config.unit.ts
+++ b/packages/plugin-coverage/vite.config.unit.ts
@@ -16,6 +16,7 @@ export default defineConfig({
     coverage: {
       reporter: ['text', 'lcov'],
       reportsDirectory: '../../coverage/plugin-coverage/unit-tests',
+      exclude: ['mocks/**'],
     },
     environment: 'node',
     include: ['src/**/*.unit.test.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],

--- a/packages/plugin-eslint/vite.config.integration.ts
+++ b/packages/plugin-eslint/vite.config.integration.ts
@@ -16,6 +16,7 @@ export default defineConfig({
     coverage: {
       reporter: ['text', 'lcov'],
       reportsDirectory: '../../coverage/plugin-eslint/integration-tests',
+      exclude: ['mocks/**'],
     },
     environment: 'node',
     include: ['src/**/*.integration.test.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],

--- a/packages/plugin-eslint/vite.config.unit.ts
+++ b/packages/plugin-eslint/vite.config.unit.ts
@@ -16,6 +16,7 @@ export default defineConfig({
     coverage: {
       reporter: ['text', 'lcov'],
       reportsDirectory: '../../coverage/plugin-eslint/unit-tests',
+      exclude: ['mocks/**'],
     },
     environment: 'node',
     include: ['src/**/*.unit.test.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],

--- a/packages/plugin-js-packages/vite.config.integration.ts
+++ b/packages/plugin-js-packages/vite.config.integration.ts
@@ -16,6 +16,7 @@ export default defineConfig({
     coverage: {
       reporter: ['text', 'lcov'],
       reportsDirectory: '../../coverage/plugin-js-packages/integration-tests',
+      exclude: ['mocks/**'],
     },
     environment: 'node',
     include: ['src/**/*.integration.test.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],

--- a/packages/plugin-js-packages/vite.config.unit.ts
+++ b/packages/plugin-js-packages/vite.config.unit.ts
@@ -16,6 +16,7 @@ export default defineConfig({
     coverage: {
       reporter: ['text', 'lcov'],
       reportsDirectory: '../../coverage/plugin-js-packages/unit-tests',
+      exclude: ['mocks/**'],
     },
     environment: 'node',
     include: ['src/**/*.unit.test.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],

--- a/packages/plugin-lighthouse/vite.config.integration.ts
+++ b/packages/plugin-lighthouse/vite.config.integration.ts
@@ -16,6 +16,7 @@ export default defineConfig({
     coverage: {
       reporter: ['text', 'lcov'],
       reportsDirectory: '../../coverage/plugin-lighthouse/integration-tests',
+      exclude: ['mocks/**'],
     },
     environment: 'node',
     include: ['src/**/*.integration.test.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],

--- a/packages/plugin-lighthouse/vite.config.unit.ts
+++ b/packages/plugin-lighthouse/vite.config.unit.ts
@@ -16,6 +16,7 @@ export default defineConfig({
     coverage: {
       reporter: ['text', 'lcov'],
       reportsDirectory: '../../coverage/plugin-lighthouse/unit-tests',
+      exclude: ['mocks/**'],
     },
     environment: 'node',
     include: ['src/**/*.unit.test.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],

--- a/packages/utils/vite.config.integration.ts
+++ b/packages/utils/vite.config.integration.ts
@@ -16,6 +16,7 @@ export default defineConfig({
     coverage: {
       reporter: ['text', 'lcov'],
       reportsDirectory: '../../coverage/utils/integration-tests',
+      exclude: ['mocks/**', 'perf/**'],
     },
     environment: 'node',
     include: ['src/**/*.integration.test.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],

--- a/packages/utils/vite.config.unit.ts
+++ b/packages/utils/vite.config.unit.ts
@@ -16,6 +16,7 @@ export default defineConfig({
     coverage: {
       reporter: ['text', 'lcov'],
       reportsDirectory: '../../coverage/utils/unit-tests',
+      exclude: ['mocks/**', 'perf/**'],
     },
     environment: 'node',
     include: ['src/**/*.unit.test.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],


### PR DESCRIPTION
I noticed that our coverage in Codecov is 79%. After looking at the files, I saw that `mocks` and `perf` folder were counted in.
In this PR, I explicitly exclude these folders as well as `zod2md` configuration file using [`coverage.exclude`](https://vitest.dev/config/#coverage-exclude).

[Before](https://app.codecov.io/gh/code-pushup/cli/tree/main/packages) (79%)
![image](https://github.com/code-pushup/cli/assets/6306671/69165724-f147-4dc4-88c8-4034a03f263c)

[After](https://app.codecov.io/gh/code-pushup/cli/tree/coverage-exclude/packages) (91%)
![image](https://github.com/code-pushup/cli/assets/6306671/0f5ab512-a200-41ab-abad-e2235df80ad7)
