### PR TITLE
feat(utils): use auto-link commit format (GitHub/GitLab) in markdown

### DIFF
--- a/e2e/cli-e2e/tests/compare.e2e.test.ts
+++ b/e2e/cli-e2e/tests/compare.e2e.test.ts
@@ -68,10 +68,7 @@ describe('CLI compare', () => {
       'tmp/e2e/react-todos-app/report-diff.md',
     );
     // commits are variable, replace SHAs with placeholders
-    const sanitizedMd = reportsDiffMd.replace(
-      /(?<=commit )`[\da-f]{7}`/g,
-      '`<commit-sha>`',
-    );
+    const sanitizedMd = reportsDiffMd.replace(/[\da-f]{40}/g, '`<commit-sha>`');
     await expect(sanitizedMd).toMatchFileSnapshot(
       '__snapshots__/compare.report-diff.md',
     );

--- a/packages/utils/src/lib/reports/__snapshots__/report-diff-added.md
+++ b/packages/utils/src/lib/reports/__snapshots__/report-diff-added.md
@@ -1,6 +1,6 @@
 # Code PushUp
 
-😟 Code PushUp report has **regressed** – compared target commit `0123456` with source commit `abcdef0`.
+😟 Code PushUp report has **regressed** – compared target commit 0123456789abcdef0123456789abcdef01234567 with source commit abcdef0123456789abcdef0123456789abcdef01.
 
 ## 🏷️ Categories
 

--- a/packages/utils/src/lib/reports/__snapshots__/report-diff-improved.md
+++ b/packages/utils/src/lib/reports/__snapshots__/report-diff-improved.md
@@ -1,6 +1,6 @@
 # Code PushUp
 
-🥳 Code PushUp report has **improved** – compared target commit `0123456` with source commit `abcdef0`.
+🥳 Code PushUp report has **improved** – compared target commit 0123456789abcdef0123456789abcdef01234567 with source commit abcdef0123456789abcdef0123456789abcdef01.
 
 ## 🏷️ Categories
 

--- a/packages/utils/src/lib/reports/__snapshots__/report-diff-minimal.md
+++ b/packages/utils/src/lib/reports/__snapshots__/report-diff-minimal.md
@@ -1,6 +1,6 @@
 # Code PushUp
 
-😟 Code PushUp report has **regressed** – compared target commit `0123456` with source commit `abcdef0`.
+😟 Code PushUp report has **regressed** – compared target commit 0123456789abcdef0123456789abcdef01234567 with source commit abcdef0123456789abcdef0123456789abcdef01.
 
 ## 🛡️ Audits
 

--- a/packages/utils/src/lib/reports/__snapshots__/report-diff-mixed.md
+++ b/packages/utils/src/lib/reports/__snapshots__/report-diff-mixed.md
@@ -1,6 +1,6 @@
 # Code PushUp
 
-🤨 Code PushUp report has both **improvements and regressions** – compared target commit `0123456` with source commit `abcdef0`.
+🤨 Code PushUp report has both **improvements and regressions** – compared target commit 0123456789abcdef0123456789abcdef01234567 with source commit abcdef0123456789abcdef0123456789abcdef01.
 
 ## 🏷️ Categories
 

--- a/packages/utils/src/lib/reports/__snapshots__/report-diff-unchanged.md
+++ b/packages/utils/src/lib/reports/__snapshots__/report-diff-unchanged.md
@@ -1,6 +1,6 @@
 # Code PushUp
 
-😐 Code PushUp report is **unchanged** – compared target commit `0123456` with source commit `abcdef0`.
+😐 Code PushUp report is **unchanged** – compared target commit 0123456789abcdef0123456789abcdef01234567 with source commit abcdef0123456789abcdef0123456789abcdef01.
 
 ## 🏷️ Categories
 

--- a/packages/utils/src/lib/reports/__snapshots__/report-no-categories.md
+++ b/packages/utils/src/lib/reports/__snapshots__/report-no-categories.md
@@ -382,7 +382,7 @@ Report was created by [Code PushUp](https://github.com/flowup/quality-metrics-cl
 
 |Commit|Version|Duration|Plugins|Categories|Audits|
 |:--|:--:|:--:|:--:|:--:|:--:|
-|Minor fixes (abcdef0)|`0.0.1`|1.65 s|2|0|52|
+|Minor fixes (abcdef0123456789abcdef0123456789abcdef01)|`0.0.1`|1.65 s|2|0|52|
 
 The following plugins were run:
 

--- a/packages/utils/src/lib/reports/__snapshots__/report.md
+++ b/packages/utils/src/lib/reports/__snapshots__/report.md
@@ -446,7 +446,7 @@ Report was created by [Code PushUp](https://github.com/flowup/quality-metrics-cl
 
 |Commit|Version|Duration|Plugins|Categories|Audits|
 |:--|:--:|:--:|:--:|:--:|:--:|
-|Minor fixes (abcdef0)|`0.0.1`|1.65 s|2|3|52|
+|Minor fixes (abcdef0123456789abcdef0123456789abcdef01)|`0.0.1`|1.65 s|2|3|52|
 
 The following plugins were run:
 

--- a/packages/utils/src/lib/reports/generate-md-report.ts
+++ b/packages/utils/src/lib/reports/generate-md-report.ts
@@ -235,9 +235,7 @@ function reportToAboutSection(report: ScoredReport): string {
   const date = formatDate(new Date());
 
   const { duration, version, commit, plugins, categories } = report;
-  const commitInfo = commit
-    ? `${commit.message} (${commit.hash.slice(0, 7)})`
-    : 'N/A';
+  const commitInfo = commit ? `${commit.message} (${commit.hash})` : 'N/A';
   const reportMetaTable: string[][] = [
     reportMetaTableHeaders,
     [

--- a/packages/utils/src/lib/reports/generate-md-reports-diff.ts
+++ b/packages/utils/src/lib/reports/generate-md-reports-diff.ts
@@ -1,4 +1,4 @@
-import { AuditDiff, Commit, ReportsDiff } from '@code-pushup/models';
+import { AuditDiff, ReportsDiff } from '@code-pushup/models';
 import { pluralize, pluralizeToken } from '../formatting';
 import { objectToEntries } from '../transform';
 import { Alignment, details, h1, h2, paragraphs, style, tableMd } from './md';
@@ -40,12 +40,8 @@ function formatDiffHeaderSection(diff: ReportsDiff): string {
     ]),
   );
 
-  const styleCommit = (commit: Commit) => style(commit.hash.slice(0, 7), ['c']);
-  const styleCommits = (commits: NonNullable<ReportsDiff['commits']>) => {
-    const src = styleCommit(commits.before);
-    const tgt = styleCommit(commits.after);
-    return `compared target commit ${tgt} with source commit ${src}`;
-  };
+  const styleCommits = (commits: NonNullable<ReportsDiff['commits']>) =>
+    `compared target commit ${commits.after.hash} with source commit ${commits.before.hash}`;
 
   return paragraphs(
     h1('Code PushUp'),


### PR DESCRIPTION
Found out that plain commit hash in full is auto-linked by both GitHub (see [Autolinked references - Commit SHAs](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/autolinked-references-and-urls#commit-shas)) and GitLab (see [GitLab-specific references](https://docs.gitlab.com/ee/user/markdown.html#gitlab-specific-references)).

Solves part of #149.

(The comment in this PR ran from `main`, so it still uses the old formatting.)

### GitHub example

![image](https://github.com/code-pushup/cli/assets/34691111/b89af849-5c80-4f9b-9f54-fc0aac1cdfa9)

### GitLab example

![image](https://github.com/code-pushup/cli/assets/34691111/38a313bd-eb21-422d-a975-84c23d6430cd)
