### PR TITLE
test: exclude coverage from examples-plugins, update codecov workflow

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -38,6 +38,8 @@ jobs:
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4
         with:
-          files: ./coverage/${{ matrix.lib }}/${{ matrix.scope }}-tests/lcov.info
-          flags: ${{ matrix.lib }}
+          directory: ./coverage/${{ matrix.lib }}/${{ matrix.scope }}-tests/
+          files: ./lcov.info
+          flags: ${{ matrix.lib }}-${{ matrix.scope }}
           token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true

--- a/examples/plugins/vite.config.integration.ts
+++ b/examples/plugins/vite.config.integration.ts
@@ -16,6 +16,7 @@ export default defineConfig({
     coverage: {
       reporter: ['text', 'lcov'],
       reportsDirectory: '../../coverage/examples-plugins/integration-tests',
+      exclude: ['**/mocks/**', '**/mock/**', 'code-pushup.config.ts'],
     },
     environment: 'node',
     include: ['src/**/*.integration.test.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],

--- a/examples/plugins/vite.config.unit.ts
+++ b/examples/plugins/vite.config.unit.ts
@@ -16,6 +16,7 @@ export default defineConfig({
     coverage: {
       reporter: ['text', 'lcov'],
       reportsDirectory: '../../coverage/examples-plugins/unit-tests',
+      exclude: ['**/mocks/**', '**/mock/**', 'code-pushup.config.ts'],
     },
     environment: 'node',
     include: ['src/**/*.unit.test.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],


### PR DESCRIPTION
Closes #540 
## `coverage.exclude`
As a follow-up of #583 , I also exclude non-production code from `examples-plugins`.

## Codecov
Codecov is [silently failing](https://app.codecov.io/gh/code-pushup/cli/commit/2f26c6c241dc1900fbf131cc9ae83618e7f4ffb3) while uploading the reports.
I am trying to follow their [example](https://github.com/codecov/codecov-action/tree/v4/?tab=readme-ov-file#example-workflowyml-with-codecov-action) exactly to rule out wonky file path support or similar.
As per usual, it works in for [this branch](https://app.codecov.io/gh/code-pushup/cli/tree/codecov-debug/packages). We will see though if it is going to work once merged to `main` (last time it did not). 🤞 