### PR TITLE
feat(plugin-js-packages): add Yarn v2 support

### DIFF
--- a/packages/plugin-js-packages/README.md
+++ b/packages/plugin-js-packages/README.md
@@ -10,11 +10,13 @@ This plugin checks for known vulnerabilities and outdated dependencies.
 It supports the following package managers:
 
 - [NPM](https://docs.npmjs.com/)
-- [Yarn v1](https://classic.yarnpkg.com/docs/)[Yarn v2+](https://yarnpkg.com/getting-started)
+- [Yarn v1](https://classic.yarnpkg.com/docs/)
+- [Yarn v2+](https://yarnpkg.com/getting-started)
+  - In order to check outdated dependencies for Yarn v2+, you need to install [`yarn-plugin-outdated`](https://github.com/mskelton/yarn-plugin-outdated).
 - [PNPM](https://pnpm.io/pnpm-cli)
 
 > ![NOTE]
-> As of now, in order to check outdated dependencies for Yarn v2+, you need to install [`yarn-plugin-outdated`](https://github.com/mskelton/yarn-plugin-outdated).
+> As of now, Yarn v2 does not support security audit of optional dependencies. Only production and dev dependencies audits will be included in the report.
 
 ## Getting started
 
@@ -100,7 +102,7 @@ The plugin accepts the following parameters:
 
 ### Audits and group
 
-This plugin provides a group per check for a convenient declaration in your config.
+This plugin provides a group per check for a convenient declaration in your config. Each group contains audits for all supported groups of dependencies (`prod`, `dev` and `optional`).
 
 ```ts
      // ...

--- a/packages/plugin-js-packages/README.md
+++ b/packages/plugin-js-packages/README.md
@@ -10,8 +10,11 @@ This plugin checks for known vulnerabilities and outdated dependencies.
 It supports the following package managers:
 
 - [NPM](https://docs.npmjs.com/)
-- [Yarn v1](https://classic.yarnpkg.com/docs/) & [Yarn v2+](https://yarnpkg.com/getting-started)
+- [Yarn v1](https://classic.yarnpkg.com/docs/)[Yarn v2+](https://yarnpkg.com/getting-started)
 - [PNPM](https://pnpm.io/pnpm-cli)
+
+> ![NOTE]
+> As of now, in order to check outdated dependencies for Yarn v2+, you need to install [`yarn-plugin-outdated`](https://github.com/mskelton/yarn-plugin-outdated).
 
 ## Getting started
 

--- a/packages/plugin-js-packages/src/lib/js-packages-plugin.ts
+++ b/packages/plugin-js-packages/src/lib/js-packages-plugin.ts
@@ -50,10 +50,10 @@ export async function jsPackagesPlugin(
 
   return {
     slug: 'js-packages',
-    title: 'Plugin for JS packages',
+    title: 'JS Packages',
     icon: pkgManagerIcons[pkgManager],
     description:
-      'This plugin runs audit to uncover vulnerabilities and lists outdated dependencies. It supports npm, yarn classic and berry, pnpm package managers.',
+      'This plugin runs audit to uncover vulnerabilities and lists outdated dependencies. It supports npm, yarn classic, yarn modern, and pnpm package managers.',
     docsUrl: pkgManagerDocs[pkgManager],
     packageName: name,
     version,
@@ -75,9 +75,17 @@ function createGroups(
       docsUrl: auditDocs[pkgManager],
       refs: [
         // eslint-disable-next-line no-magic-numbers
-        { slug: `${pkgManager}-audit-prod`, weight: 8 },
+        { slug: `${pkgManager}-audit-prod`, weight: 3 },
         { slug: `${pkgManager}-audit-dev`, weight: 1 },
-        { slug: `${pkgManager}-audit-optional`, weight: 1 },
+        // Yarn v2 does not support audit for optional dependencies
+        ...(pkgManager === 'yarn-modern'
+          ? []
+          : [
+              {
+                slug: `${pkgManager}-audit-optional`,
+                weight: 1,
+              },
+            ]),
       ],
     },
     outdated: {
@@ -87,7 +95,7 @@ function createGroups(
       docsUrl: outdatedDocs[pkgManager],
       refs: [
         // eslint-disable-next-line no-magic-numbers
-        { slug: `${pkgManager}-outdated-prod`, weight: 8 },
+        { slug: `${pkgManager}-outdated-prod`, weight: 3 },
         { slug: `${pkgManager}-outdated-dev`, weight: 1 },
         { slug: `${pkgManager}-outdated-optional`, weight: 1 },
       ],
@@ -114,12 +122,17 @@ function createAudits(
       description: getAuditDescription(check, 'dev'),
       docsUrl: dependencyDocs.dev,
     },
-    {
-      slug: `${pkgManager}-${check}-optional`,
-      title: getAuditTitle(pkgManager, check, 'optional'),
-      description: getAuditDescription(check, 'optional'),
-      docsUrl: dependencyDocs.optional,
-    },
+    // Yarn v2 does not support audit for optional dependencies
+    ...(pkgManager === 'yarn-modern' && check === 'audit'
+      ? []
+      : [
+          {
+            slug: `${pkgManager}-${check}-optional`,
+            title: getAuditTitle(pkgManager, check, 'optional'),
+            description: getAuditDescription(check, 'optional'),
+            docsUrl: dependencyDocs.optional,
+          },
+        ]),
   ]);
 }
 

--- a/packages/plugin-js-packages/src/lib/js-packages-plugin.unit.test.ts
+++ b/packages/plugin-js-packages/src/lib/js-packages-plugin.unit.test.ts
@@ -16,7 +16,7 @@ describe('jsPackagesPlugin', () => {
     ).resolves.toStrictEqual(
       expect.objectContaining({
         slug: 'js-packages',
-        title: 'Plugin for JS packages',
+        title: 'JS Packages',
         audits: expect.any(Array),
         groups: expect.any(Array),
         runner: expect.any(Object),
@@ -69,7 +69,7 @@ describe('jsPackagesPlugin', () => {
           expect.objectContaining<Partial<Group>>({
             slug: 'yarn-classic-audit',
             refs: [
-              { slug: 'yarn-classic-audit-prod', weight: 8 },
+              { slug: 'yarn-classic-audit-prod', weight: 3 },
               { slug: 'yarn-classic-audit-dev', weight: 1 },
               { slug: 'yarn-classic-audit-optional', weight: 1 },
             ],

--- a/packages/plugin-js-packages/src/lib/runner/audit/transform.ts
+++ b/packages/plugin-js-packages/src/lib/runner/audit/transform.ts
@@ -69,7 +69,7 @@ export function vulnerabilitiesToIssues(
     return [];
   }
 
-  return Object.values(vulnerabilities).map((detail): Issue => {
+  return vulnerabilities.map((detail): Issue => {
     const versionRange =
       detail.versionRange === '*'
         ? '**all** versions'

--- a/packages/plugin-js-packages/src/lib/runner/audit/types.ts
+++ b/packages/plugin-js-packages/src/lib/runner/audit/types.ts
@@ -81,3 +81,21 @@ export type Yarnv1AuditResultJson = [
   ...Yarnv1AuditAdvisory[],
   Yarnv1AuditSummary,
 ];
+
+// Subset of Yarn v2+ audit JSON type
+/* eslint-disable @typescript-eslint/naming-convention */
+export type Yarnv2AuditAdvisory = {
+  module_name: string;
+  severity: PackageAuditLevel;
+  vulnerable_versions: string;
+  recommendation: string;
+  title: string;
+  url: string;
+  findings: { paths: string[] }[]; // TODO indirect?
+};
+/* eslint-enable @typescript-eslint/naming-convention */
+
+export type Yarnv2AuditResultJson = {
+  advisories: Record<string, Yarnv2AuditAdvisory>;
+  metadata: { vulnerabilities: Record<PackageAuditLevel, number> };
+};

--- a/packages/plugin-js-packages/src/lib/runner/outdated/constants.ts
+++ b/packages/plugin-js-packages/src/lib/runner/outdated/constants.ts
@@ -1,7 +1,11 @@
 import { IssueSeverity } from '@code-pushup/models';
 import { PackageManager } from '../../config';
 import { OutdatedResult, VersionType } from './types';
-import { npmToOutdatedResult, yarnv1ToOutdatedResult } from './unify-type';
+import {
+  npmToOutdatedResult,
+  yarnv1ToOutdatedResult,
+  yarnv2ToOutdatedResult,
+} from './unify-type';
 
 export const outdatedSeverity: Record<VersionType, IssueSeverity> = {
   major: 'error',
@@ -12,7 +16,7 @@ export const outdatedSeverity: Record<VersionType, IssueSeverity> = {
 export const outdatedArgs: Record<PackageManager, string[]> = {
   npm: ['--json', '--long'],
   'yarn-classic': ['--json'],
-  'yarn-modern': [],
+  'yarn-modern': ['--json'],
   pnpm: [],
 };
 
@@ -22,7 +26,6 @@ export const normalizeOutdatedMapper: Record<
 > = {
   npm: npmToOutdatedResult,
   'yarn-classic': yarnv1ToOutdatedResult,
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  'yarn-modern': _ => [],
+  'yarn-modern': yarnv2ToOutdatedResult,
   pnpm: _ => [],
 };

--- a/packages/plugin-js-packages/src/lib/runner/outdated/types.ts
+++ b/packages/plugin-js-packages/src/lib/runner/outdated/types.ts
@@ -1,4 +1,3 @@
-// Subset of NPM outdated JSON type
 export const versionType = ['major', 'minor', 'patch'] as const;
 export type VersionType = (typeof versionType)[number];
 export type PackageVersion = Record<VersionType, number>;
@@ -7,18 +6,28 @@ export type DependencyGroupLong =
   | 'devDependencies'
   | 'optionalDependencies';
 
-export type VersionOverview = {
+// Unified Outdated result type
+export type OutdatedResult = {
+  name: string;
+  current: string;
+  latest: string;
+  type: DependencyGroupLong;
+  url?: string;
+}[];
+
+// Subset of NPM outdated JSON type
+export type NpmVersionOverview = {
   current?: string;
   latest: string;
   type: DependencyGroupLong;
   homepage?: string;
 };
 
-export type NormalizedVersionOverview = Omit<VersionOverview, 'current'> & {
+export type NpmNormalizedOverview = Omit<NpmVersionOverview, 'current'> & {
   current: string;
 };
-export type NormalizedOutdatedEntries = [string, NormalizedVersionOverview][];
-export type NpmOutdatedResultJson = Record<string, VersionOverview>;
+
+export type NpmOutdatedResultJson = Record<string, NpmVersionOverview>;
 
 // Subset of Yarn v1 outdated JSON type
 export type Yarnv1VersionOverview = [
@@ -41,11 +50,12 @@ type Yarnv1Table = {
 
 export type Yarnv1OutdatedResultJson = [Yarnv1Info, Yarnv1Table];
 
-// Unified Outdated result type
-export type OutdatedResult = {
-  name: string;
+// Subset of Yarn v2 outdated JSON type
+export type Yarnv2VersionOverview = {
   current: string;
   latest: string;
+  name: string;
   type: DependencyGroupLong;
-  url?: string;
-}[];
+};
+
+export type Yarnv2OutdatedResultJson = Yarnv2VersionOverview[];

--- a/packages/plugin-js-packages/src/lib/runner/outdated/unify-type.ts
+++ b/packages/plugin-js-packages/src/lib/runner/outdated/unify-type.ts
@@ -1,9 +1,10 @@
 import { fromJsonLines, objectToEntries } from '@code-pushup/utils';
 import {
-  NormalizedVersionOverview,
+  NpmNormalizedOverview,
   NpmOutdatedResultJson,
   OutdatedResult,
   Yarnv1OutdatedResultJson,
+  Yarnv2OutdatedResultJson,
 } from './types';
 
 export function npmToOutdatedResult(output: string): OutdatedResult {
@@ -12,7 +13,7 @@ export function npmToOutdatedResult(output: string): OutdatedResult {
   // https://stackoverflow.com/questions/42267101/npm-outdated-command-shows-missing-in-current-version
   return objectToEntries(npmOutdated)
     .filter(
-      (entry): entry is [string, NormalizedVersionOverview] =>
+      (entry): entry is [string, NpmNormalizedOverview] =>
         entry[1].current != null,
     )
     .map(([name, overview]) => ({
@@ -34,5 +35,16 @@ export function yarnv1ToOutdatedResult(output: string): OutdatedResult {
     latest,
     type,
     url,
+  }));
+}
+
+export function yarnv2ToOutdatedResult(output: string): OutdatedResult {
+  const npmOutdated = JSON.parse(output) as Yarnv2OutdatedResultJson;
+
+  return npmOutdated.map(({ name, current, latest, type }) => ({
+    name,
+    current,
+    latest,
+    type,
   }));
 }

--- a/packages/plugin-js-packages/src/lib/runner/outdated/unify-type.unit.test.ts
+++ b/packages/plugin-js-packages/src/lib/runner/outdated/unify-type.unit.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, it } from 'vitest';
 import { toJsonLines } from '@code-pushup/utils';
-import { OutdatedResult } from './types';
-import { npmToOutdatedResult, yarnv1ToOutdatedResult } from './unify-type';
+import { OutdatedResult, Yarnv2OutdatedResultJson } from './types';
+import {
+  npmToOutdatedResult,
+  yarnv1ToOutdatedResult,
+  yarnv2ToOutdatedResult,
+} from './unify-type';
 
-describe('npmOutdatedToOutdatedResult', () => {
+describe('npmToOutdatedResult', () => {
   it('should transform NPM outdated to unified outdated result', () => {
     expect(
       npmToOutdatedResult(
@@ -59,7 +63,7 @@ describe('npmOutdatedToOutdatedResult', () => {
   });
 });
 
-describe('yarnv1OutdatedToOutdatedResult', () => {
+describe('yarnv1ToOutdatedResult', () => {
   const yarnInfo = { type: 'info', data: 'Colours' };
   it('should transform Yarn v1 outdated to unified outdated result', () => {
     const table = {
@@ -88,5 +92,32 @@ describe('yarnv1OutdatedToOutdatedResult', () => {
     const table = { type: 'table', data: { body: [] } };
 
     expect(yarnv1ToOutdatedResult(toJsonLines([yarnInfo, table]))).toEqual([]);
+  });
+});
+
+describe('yarnv2ToOutdatedResult', () => {
+  it('should transform Yarn v2 outdated to unified outdated result', () => {
+    const outdated = [
+      {
+        name: 'nx',
+        current: '16.8.1',
+        latest: '17.0.0',
+        type: 'dependencies',
+      },
+      {
+        name: 'vite',
+        current: '4.3.1',
+        latest: '5.1.4',
+        type: 'devDependencies',
+      },
+    ] satisfies Yarnv2OutdatedResultJson;
+
+    expect(yarnv2ToOutdatedResult(JSON.stringify(outdated))).toStrictEqual(
+      outdated,
+    );
+  });
+
+  it('should transform no dependencies to empty array', () => {
+    expect(yarnv2ToOutdatedResult('[]')).toEqual([]);
   });
 });


### PR DESCRIPTION
Related to #542 

In this PR, I add the support for Yarn v2. Notable changes:
- I updated the documentation regarding the Yarn v2 specific things.
- Yarn v2 does not support security audit for optional dependencies. This audit is skipped.
- I improved the plugin title.

Known issues:
- I was unable to find an indirect vulnerability so the logic is not verified.

The results were tested on jest repository.