### PR TITLE
chore: adjust coverage configuration and included files

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -34,11 +34,11 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Execute all tests and generate coverage reports
-        run: npx nx run ${{ matrix.lib }}:${{ matrix.scope }}-test --coverage.enabled
+        run: npx nx run ${{ matrix.lib }}:${{ matrix.scope }}-test --coverage.enabled --skipNxCache
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4
         with:
-          directory: ./coverage/${{ matrix.lib }}/${{ matrix.scope }}-tests/
+          directory: coverage/${{ matrix.lib }}/${{ matrix.scope }}-tests/
           files: ./lcov.info
           flags: ${{ matrix.lib }}-${{ matrix.scope }}
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/packages/cli/project.json
+++ b/packages/cli/project.json
@@ -31,18 +31,14 @@
     },
     "unit-test": {
       "executor": "@nx/vite:test",
-      "outputs": ["{options.reportsDirectory}"],
       "options": {
-        "config": "packages/cli/vite.config.unit.ts",
-        "reportsDirectory": "../../coverage/cli/unit-tests"
+        "config": "packages/cli/vite.config.unit.ts"
       }
     },
     "integration-test": {
       "executor": "@nx/vite:test",
-      "outputs": ["{options.reportsDirectory}"],
       "options": {
-        "config": "packages/cli/vite.config.integration.ts",
-        "reportsDirectory": "../../coverage/cli/integration-tests"
+        "config": "packages/cli/vite.config.integration.ts"
       }
     },
     "run-help": {

--- a/packages/cli/vite.config.integration.ts
+++ b/packages/cli/vite.config.integration.ts
@@ -16,7 +16,7 @@ export default defineConfig({
     coverage: {
       reporter: ['text', 'lcov'],
       reportsDirectory: '../../coverage/cli/integration-tests',
-      exclude: ['mocks/**'],
+      exclude: ['mocks/**', '**/types.ts'],
     },
     environment: 'node',
     include: ['src/**/*.integration.test.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],

--- a/packages/cli/vite.config.unit.ts
+++ b/packages/cli/vite.config.unit.ts
@@ -16,7 +16,7 @@ export default defineConfig({
     coverage: {
       reporter: ['text', 'lcov'],
       reportsDirectory: '../../coverage/cli/unit-tests',
-      exclude: ['mocks/**'],
+      exclude: ['mocks/**', '**/types.ts'],
     },
     environment: 'node',
     include: ['src/**/*.unit.test.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],

--- a/packages/core/project.json
+++ b/packages/core/project.json
@@ -31,18 +31,14 @@
     },
     "unit-test": {
       "executor": "@nx/vite:test",
-      "outputs": ["{options.reportsDirectory}"],
       "options": {
-        "config": "packages/core/vite.config.unit.ts",
-        "reportsDirectory": "../../coverage/core/unit-tests"
+        "config": "packages/core/vite.config.unit.ts"
       }
     },
     "integration-test": {
       "executor": "@nx/vite:test",
-      "outputs": ["{options.reportsDirectory}"],
       "options": {
-        "config": "packages/core/vite.config.integration.ts",
-        "reportsDirectory": "../../coverage/core/integration-tests"
+        "config": "packages/core/vite.config.integration.ts"
       }
     }
   },

--- a/packages/core/vite.config.integration.ts
+++ b/packages/core/vite.config.integration.ts
@@ -16,7 +16,7 @@ export default defineConfig({
     coverage: {
       reporter: ['text', 'lcov'],
       reportsDirectory: '../../coverage/core/integration-tests',
-      exclude: ['mocks/**'],
+      exclude: ['mocks/**', '**/types.ts'],
     },
     environment: 'node',
     include: ['src/**/*.integration.test.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],

--- a/packages/core/vite.config.unit.ts
+++ b/packages/core/vite.config.unit.ts
@@ -16,7 +16,7 @@ export default defineConfig({
     coverage: {
       reporter: ['text', 'lcov'],
       reportsDirectory: '../../coverage/core/unit-tests',
-      exclude: ['mocks/**'],
+      exclude: ['mocks/**', '**/types.ts'],
     },
     environment: 'node',
     include: ['src/**/*.unit.test.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],

--- a/packages/models/project.json
+++ b/packages/models/project.json
@@ -31,18 +31,14 @@
     },
     "unit-test": {
       "executor": "@nx/vite:test",
-      "outputs": ["{options.reportsDirectory}"],
       "options": {
-        "config": "packages/models/vite.config.unit.ts",
-        "reportsDirectory": "../../coverage/models/unit-tests"
+        "config": "packages/models/vite.config.unit.ts"
       }
     },
     "integration-test": {
       "executor": "@nx/vite:test",
-      "outputs": ["{options.reportsDirectory}"],
       "options": {
-        "config": "packages/models/vite.config.integration.ts",
-        "reportsDirectory": "../../coverage/models/integration-tests"
+        "config": "packages/models/vite.config.integration.ts"
       }
     },
     "generate-docs": {

--- a/packages/models/vite.config.integration.ts
+++ b/packages/models/vite.config.integration.ts
@@ -16,7 +16,7 @@ export default defineConfig({
     coverage: {
       reporter: ['text', 'lcov'],
       reportsDirectory: '../../coverage/models/integration-tests',
-      exclude: ['mocks/**', 'zod2md.config.ts'],
+      exclude: ['mocks/**', '**/types.ts', 'zod2md.config.ts'],
     },
     environment: 'node',
     include: ['src/**/*.integration.test.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],

--- a/packages/models/vite.config.unit.ts
+++ b/packages/models/vite.config.unit.ts
@@ -16,7 +16,7 @@ export default defineConfig({
     coverage: {
       reporter: ['text', 'lcov'],
       reportsDirectory: '../../coverage/models/unit-tests',
-      exclude: ['mocks/**', 'zod2md.config.ts'],
+      exclude: ['mocks/**', '**/types.ts', 'zod2md.config.ts'],
     },
     environment: 'node',
     include: ['src/**/*.unit.test.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],

--- a/packages/nx-plugin/project.json
+++ b/packages/nx-plugin/project.json
@@ -53,18 +53,14 @@
     },
     "unit-test": {
       "executor": "@nx/vite:test",
-      "outputs": ["{options.reportsDirectory}"],
       "options": {
-        "config": "packages/nx-plugin/vite.config.unit.ts",
-        "reportsDirectory": "../../coverage/nx-plugin/unit-tests"
+        "config": "packages/nx-plugin/vite.config.unit.ts"
       }
     },
     "integration-test": {
       "executor": "@nx/vite:test",
-      "outputs": ["{options.reportsDirectory}"],
       "options": {
-        "config": "packages/nx-plugin/vite.config.integration.ts",
-        "reportsDirectory": "../../coverage/nx-plugin/integration-tests"
+        "config": "packages/nx-plugin/vite.config.integration.ts"
       }
     }
   },

--- a/packages/nx-plugin/vite.config.integration.ts
+++ b/packages/nx-plugin/vite.config.integration.ts
@@ -16,7 +16,7 @@ export default defineConfig({
     coverage: {
       reporter: ['text', 'lcov'],
       reportsDirectory: '../../coverage/nx-plugin/integration-tests',
-      exclude: ['mocks/**'],
+      exclude: ['mocks/**', '**/types.ts'],
     },
     environment: 'node',
     include: ['src/**/*.integration.test.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],

--- a/packages/nx-plugin/vite.config.unit.ts
+++ b/packages/nx-plugin/vite.config.unit.ts
@@ -16,7 +16,7 @@ export default defineConfig({
     coverage: {
       reporter: ['text', 'lcov'],
       reportsDirectory: '../../coverage/nx-plugin/unit-tests',
-      exclude: ['mocks/**'],
+      exclude: ['mocks/**', '**/types.ts'],
     },
     environment: 'node',
     include: ['src/**/*.unit.test.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],

--- a/packages/plugin-coverage/project.json
+++ b/packages/plugin-coverage/project.json
@@ -28,18 +28,14 @@
     },
     "unit-test": {
       "executor": "@nx/vite:test",
-      "outputs": ["{options.reportsDirectory}"],
       "options": {
-        "config": "packages/plugin-coverage/vite.config.unit.ts",
-        "reportsDirectory": "../../coverage/plugin-coverage/unit-tests"
+        "config": "packages/plugin-coverage/vite.config.unit.ts"
       }
     },
     "integration-test": {
       "executor": "@nx/vite:test",
-      "outputs": ["{options.reportsDirectory}"],
       "options": {
-        "config": "packages/plugin-coverage/vite.config.integration.ts",
-        "reportsDirectory": "../../coverage/plugin-coverage/integration-tests"
+        "config": "packages/plugin-coverage/vite.config.integration.ts"
       }
     },
     "publish": {

--- a/packages/plugin-coverage/src/lib/nx/coverage-paths.ts
+++ b/packages/plugin-coverage/src/lib/nx/coverage-paths.ts
@@ -1,7 +1,8 @@
+/// <reference types="vitest" />
 import type { ProjectGraphProjectNode, TargetConfiguration } from '@nx/devkit';
 import chalk from 'chalk';
 import { join } from 'node:path';
-import { ui } from '@code-pushup/utils';
+import { importEsmModule, ui } from '@code-pushup/utils';
 import { CoverageResult } from '../config';
 
 /**
@@ -21,25 +22,33 @@ export async function getNxCoveragePaths(
   const { createProjectGraphAsync } = await import('@nx/devkit');
   const { nodes } = await createProjectGraphAsync({ exitOnError: false });
 
-  const coverageResults = targets.map(target => {
-    const relevantNodes = Object.values(nodes).filter(graph =>
-      hasNxTarget(graph, target),
-    );
+  const coverageResults = await Promise.all(
+    targets.map(async target => {
+      const relevantNodes = Object.values(nodes).filter(graph =>
+        hasNxTarget(graph, target),
+      );
 
-    return relevantNodes.map<CoverageResult>(({ name, data }) => {
-      const targetConfig = data.targets?.[target] as TargetConfiguration;
-      const coveragePath = getCoveragePathForTarget(target, targetConfig, name);
-      const rootToReportsDir = join(data.root, coveragePath);
+      return await Promise.all(
+        relevantNodes.map<Promise<CoverageResult>>(async ({ name, data }) => {
+          const targetConfig = data.targets?.[target] as TargetConfiguration;
+          const coveragePath = await getCoveragePathForTarget(
+            target,
+            targetConfig,
+            name,
+          );
+          const rootToReportsDir = join(data.root, coveragePath);
 
-      if (verbose) {
-        ui().logger.info(`- ${name}: ${target}`);
-      }
-      return {
-        pathToProject: data.root,
-        resultsPath: join(rootToReportsDir, 'lcov.info'),
-      };
-    });
-  });
+          if (verbose) {
+            ui().logger.info(`- ${name}: ${target}`);
+          }
+          return {
+            pathToProject: data.root,
+            resultsPath: join(rootToReportsDir, 'lcov.info'),
+          };
+        }),
+      );
+    }),
+  );
 
   if (verbose) {
     ui().logger.info('\n');
@@ -55,19 +64,44 @@ function hasNxTarget(
   return project.data.targets != null && target in project.data.targets;
 }
 
-function getCoveragePathForTarget(
+export type VitestCoverageConfig = {
+  test: {
+    coverage?: {
+      reporter?: string[];
+      reportsDirectory?: string;
+    };
+  };
+};
+
+export type JestCoverageConfig = {
+  coverageDirectory?: string;
+  coverageReporters?: string[];
+};
+
+export async function getCoveragePathForTarget(
   target: string,
   targetConfig: TargetConfiguration,
   projectName: string,
-): string {
+): Promise<string> {
+  const { config } = targetConfig.options as { config: string };
+
   if (targetConfig.executor?.includes('@nx/vite')) {
-    const { reportsDirectory } = targetConfig.options as {
-      reportsDirectory?: string;
-    };
+    const testConfig = await importEsmModule<VitestCoverageConfig>({
+      filepath: config,
+    });
+
+    const reportsDirectory = testConfig.test.coverage?.reportsDirectory;
+    const reporter = testConfig.test.coverage?.reporter;
 
     if (reportsDirectory == null) {
       throw new Error(
-        `Coverage configuration not found for target ${target} in ${projectName}. Define your Vitest coverage directory in the reportsDirectory option.`,
+        `Vitest coverage configuration at ${config} does not include coverage path for target ${target} in ${projectName}. Add the path under coverage > reportsDirectory.`,
+      );
+    }
+
+    if (!reporter?.includes('lcov')) {
+      throw new Error(
+        `Vitest coverage configuration at ${config} does not include LCOV report format for target ${target} in ${projectName}. Add 'lcov' format under coverage > reporter.`,
       );
     }
 
@@ -75,13 +109,21 @@ function getCoveragePathForTarget(
   }
 
   if (targetConfig.executor?.includes('@nx/jest')) {
-    const { coverageDirectory } = targetConfig.options as {
-      coverageDirectory?: string;
-    };
+    const testConfig = await importEsmModule<JestCoverageConfig>({
+      filepath: config,
+    });
+
+    const coverageDirectory = testConfig.coverageDirectory;
 
     if (coverageDirectory == null) {
       throw new Error(
-        `Coverage configuration not found for target ${target} in ${projectName}. Define your Jest coverage directory in the coverageDirectory option.`,
+        `Jest coverage configuration at ${config} does not include coverage path for target ${target} in ${projectName}. Add the path under coverageDirectory.`,
+      );
+    }
+
+    if (!testConfig.coverageReporters?.includes('lcov')) {
+      throw new Error(
+        `Jest coverage configuration at ${config} does not include LCOV report format for target ${target} in ${projectName}. Add 'lcov' format under coverageReporters.`,
       );
     }
     return coverageDirectory;

--- a/packages/plugin-coverage/src/lib/nx/coverage-paths.unit.test.ts
+++ b/packages/plugin-coverage/src/lib/nx/coverage-paths.unit.test.ts
@@ -1,0 +1,150 @@
+import { vol } from 'memfs';
+import { describe, expect, it } from 'vitest';
+import { MEMFS_VOLUME } from '@code-pushup/test-utils';
+import {
+  JestCoverageConfig,
+  VitestCoverageConfig,
+  getCoveragePathForTarget,
+} from './coverage-paths';
+
+vi.mock('bundle-require', () => ({
+  bundleRequire: vi.fn().mockImplementation((options: { filepath: string }) => {
+    const config = options.filepath.split('.')[0];
+    const VITEST_VALID: VitestCoverageConfig = {
+      test: {
+        coverage: { reporter: ['lcov'], reportsDirectory: 'coverage/cli' },
+      },
+    };
+
+    const VITEST_NO_DIR: VitestCoverageConfig = {
+      test: { coverage: { reporter: ['lcov'] } },
+    };
+
+    const JEST_VALID: JestCoverageConfig = {
+      coverageReporters: ['lcov'],
+      coverageDirectory: 'coverage/core',
+    };
+
+    const JEST_NO_DIR: JestCoverageConfig = {
+      coverageReporters: ['lcov'],
+    };
+
+    const JEST_NO_LCOV: JestCoverageConfig = {
+      coverageReporters: ['json'],
+      coverageDirectory: 'coverage/utils',
+    };
+
+    return {
+      mod: {
+        default:
+          config === 'vitest-valid'
+            ? VITEST_VALID
+            : config === 'jest-valid'
+            ? JEST_VALID
+            : config === 'vitest-no-dir'
+            ? VITEST_NO_DIR
+            : config === 'jest-no-dir'
+            ? JEST_NO_DIR
+            : JEST_NO_LCOV,
+      },
+    };
+  }),
+}));
+
+describe('getCoveragePathForTarget', () => {
+  beforeEach(() => {
+    vol.fromJSON(
+      {
+        // values come from bundle-require mock above
+        'vitest-valid.config.unit.ts': '',
+        'jest-valid.config.unit.ts': '',
+        'vitest-no-dir.config.integration.ts': '',
+        'jest-no-dir.config.integration.ts': '',
+        'jest-no-lcov.config.integration.ts': '',
+      },
+      MEMFS_VOLUME,
+    );
+  });
+
+  it('should fetch Vitest reportsDirectory', async () => {
+    await expect(
+      getCoveragePathForTarget(
+        'unit-test',
+        {
+          executor: '@nx/vite:test',
+          options: { config: 'vitest-valid.config.unit.ts' },
+        },
+        'cli',
+      ),
+    ).resolves.toBe('coverage/cli');
+  });
+
+  it('should fetch Jest coverageDirectory', async () => {
+    await expect(
+      getCoveragePathForTarget(
+        'unit-test',
+        {
+          executor: '@nx/jest:jest',
+          options: { config: 'jest-valid.config.unit.ts' },
+        },
+        'core',
+      ),
+    ).resolves.toBe('coverage/core');
+  });
+
+  it('should throw when reportsDirectory is not set in vitest config', async () => {
+    await expect(() =>
+      getCoveragePathForTarget(
+        'integration-test',
+        {
+          executor: '@nx/vite:test',
+          options: { config: 'vitest-no-dir.config.integration.ts' },
+        },
+        'cli',
+      ),
+    ).rejects.toThrow(
+      /configuration .* does not include coverage path .* Add the path under coverage > reportsDirectory/,
+    );
+  });
+
+  it('should throw when reportsDirectory is not set in jest config', async () => {
+    await expect(() =>
+      getCoveragePathForTarget(
+        'integration-test',
+        {
+          executor: '@nx/jest:jest',
+          options: { config: 'jest-no-dir.config.integration.ts' },
+        },
+        'core',
+      ),
+    ).rejects.toThrow(
+      /configuration .* does not include coverage path .* Add the path under coverageDirectory/,
+    );
+  });
+
+  it('should throw when config does not include lcov reporter', async () => {
+    await expect(() =>
+      getCoveragePathForTarget(
+        'integration-test',
+        {
+          executor: '@nx/jest:jest',
+          options: { config: 'jest-no-lcov.config.integration.ts' },
+        },
+        'core',
+      ),
+    ).rejects.toThrow(/configuration .* does not include LCOV report format/);
+  });
+
+  it('should throw for unsupported executor (only vitest and jest are supported)', async () => {
+    await expect(() =>
+      getCoveragePathForTarget(
+        'component-test',
+        {
+          executor: '@nx/cypress',
+          options: { config: 'cypress.config.ts' },
+        },
+        'ui',
+      ),
+    ).rejects.toThrow('Unsupported executor @nx/cypress.');
+  });
+});

--- a/packages/plugin-coverage/vite.config.integration.ts
+++ b/packages/plugin-coverage/vite.config.integration.ts
@@ -16,7 +16,7 @@ export default defineConfig({
     coverage: {
       reporter: ['text', 'lcov'],
       reportsDirectory: '../../coverage/plugin-coverage/integration-tests',
-      exclude: ['mocks/**'],
+      exclude: ['mocks/**', '**/types.ts'],
     },
     environment: 'node',
     include: ['src/**/*.integration.test.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],

--- a/packages/plugin-coverage/vite.config.unit.ts
+++ b/packages/plugin-coverage/vite.config.unit.ts
@@ -16,7 +16,7 @@ export default defineConfig({
     coverage: {
       reporter: ['text', 'lcov'],
       reportsDirectory: '../../coverage/plugin-coverage/unit-tests',
-      exclude: ['mocks/**'],
+      exclude: ['mocks/**', '**/types.ts'],
     },
     environment: 'node',
     include: ['src/**/*.unit.test.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],

--- a/packages/plugin-eslint/project.json
+++ b/packages/plugin-eslint/project.json
@@ -32,18 +32,14 @@
     },
     "unit-test": {
       "executor": "@nx/vite:test",
-      "outputs": ["{options.reportsDirectory}"],
       "options": {
-        "config": "packages/plugin-eslint/vite.config.unit.ts",
-        "reportsDirectory": "../../coverage/plugin-eslint/unit-tests"
+        "config": "packages/plugin-eslint/vite.config.unit.ts"
       }
     },
     "integration-test": {
       "executor": "@nx/vite:test",
-      "outputs": ["{options.reportsDirectory}"],
       "options": {
-        "config": "packages/plugin-eslint/vite.config.integration.ts",
-        "reportsDirectory": "../../coverage/plugin-eslint/integration-tests"
+        "config": "packages/plugin-eslint/vite.config.integration.ts"
       }
     }
   },

--- a/packages/plugin-eslint/vite.config.integration.ts
+++ b/packages/plugin-eslint/vite.config.integration.ts
@@ -16,7 +16,7 @@ export default defineConfig({
     coverage: {
       reporter: ['text', 'lcov'],
       reportsDirectory: '../../coverage/plugin-eslint/integration-tests',
-      exclude: ['mocks/**'],
+      exclude: ['mocks/**', '**/types.ts'],
     },
     environment: 'node',
     include: ['src/**/*.integration.test.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],

--- a/packages/plugin-eslint/vite.config.unit.ts
+++ b/packages/plugin-eslint/vite.config.unit.ts
@@ -16,7 +16,7 @@ export default defineConfig({
     coverage: {
       reporter: ['text', 'lcov'],
       reportsDirectory: '../../coverage/plugin-eslint/unit-tests',
-      exclude: ['mocks/**'],
+      exclude: ['mocks/**', '**/types.ts'],
     },
     environment: 'node',
     include: ['src/**/*.unit.test.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],

--- a/packages/plugin-js-packages/project.json
+++ b/packages/plugin-js-packages/project.json
@@ -28,18 +28,14 @@
     },
     "unit-test": {
       "executor": "@nx/vite:test",
-      "outputs": ["{options.reportsDirectory}"],
       "options": {
-        "config": "packages/plugin-js-packages/vite.config.unit.ts",
-        "reportsDirectory": "../../coverage/plugin-js-packages/unit-tests"
+        "config": "packages/plugin-js-packages/vite.config.unit.ts"
       }
     },
     "integration-test": {
       "executor": "@nx/vite:test",
-      "outputs": ["{options.reportsDirectory}"],
       "options": {
-        "config": "packages/plugin-js-packages/vite.config.integration.ts",
-        "reportsDirectory": "../../coverage/plugin-js-packages/integration-tests"
+        "config": "packages/plugin-js-packages/vite.config.integration.ts"
       }
     },
     "publish": {

--- a/packages/plugin-js-packages/vite.config.integration.ts
+++ b/packages/plugin-js-packages/vite.config.integration.ts
@@ -16,7 +16,7 @@ export default defineConfig({
     coverage: {
       reporter: ['text', 'lcov'],
       reportsDirectory: '../../coverage/plugin-js-packages/integration-tests',
-      exclude: ['mocks/**'],
+      exclude: ['mocks/**', '**/types.ts'],
     },
     environment: 'node',
     include: ['src/**/*.integration.test.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],

--- a/packages/plugin-js-packages/vite.config.unit.ts
+++ b/packages/plugin-js-packages/vite.config.unit.ts
@@ -16,7 +16,7 @@ export default defineConfig({
     coverage: {
       reporter: ['text', 'lcov'],
       reportsDirectory: '../../coverage/plugin-js-packages/unit-tests',
-      exclude: ['mocks/**'],
+      exclude: ['mocks/**', '**/types.ts'],
     },
     environment: 'node',
     include: ['src/**/*.unit.test.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],

--- a/packages/plugin-lighthouse/project.json
+++ b/packages/plugin-lighthouse/project.json
@@ -27,18 +27,14 @@
     },
     "unit-test": {
       "executor": "@nx/vite:test",
-      "outputs": ["{options.reportsDirectory}"],
       "options": {
-        "config": "packages/plugin-lighthouse/vite.config.unit.ts",
-        "reportsDirectory": "../../coverage/plugin-lighthouse/unit-tests"
+        "config": "packages/plugin-lighthouse/vite.config.unit.ts"
       }
     },
     "integration-test": {
       "executor": "@nx/vite:test",
-      "outputs": ["{options.reportsDirectory}"],
       "options": {
-        "config": "packages/plugin-lighthouse/vite.config.integration.ts",
-        "reportsDirectory": "../../coverage/plugin-lighthouse/integration-tests"
+        "config": "packages/plugin-lighthouse/vite.config.integration.ts"
       }
     }
   },

--- a/packages/plugin-lighthouse/vite.config.integration.ts
+++ b/packages/plugin-lighthouse/vite.config.integration.ts
@@ -16,7 +16,7 @@ export default defineConfig({
     coverage: {
       reporter: ['text', 'lcov'],
       reportsDirectory: '../../coverage/plugin-lighthouse/integration-tests',
-      exclude: ['mocks/**'],
+      exclude: ['mocks/**', '**/types.ts'],
     },
     environment: 'node',
     include: ['src/**/*.integration.test.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],

--- a/packages/plugin-lighthouse/vite.config.unit.ts
+++ b/packages/plugin-lighthouse/vite.config.unit.ts
@@ -16,7 +16,7 @@ export default defineConfig({
     coverage: {
       reporter: ['text', 'lcov'],
       reportsDirectory: '../../coverage/plugin-lighthouse/unit-tests',
-      exclude: ['mocks/**'],
+      exclude: ['mocks/**', '**/types.ts'],
     },
     environment: 'node',
     include: ['src/**/*.unit.test.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],

--- a/packages/utils/project.json
+++ b/packages/utils/project.json
@@ -43,18 +43,14 @@
     },
     "unit-test": {
       "executor": "@nx/vite:test",
-      "outputs": ["{options.reportsDirectory}"],
       "options": {
-        "config": "packages/utils/vite.config.unit.ts",
-        "reportsDirectory": "../../coverage/utils/unit-tests"
+        "config": "packages/utils/vite.config.unit.ts"
       }
     },
     "integration-test": {
       "executor": "@nx/vite:test",
-      "outputs": ["{options.reportsDirectory}"],
       "options": {
-        "config": "packages/utils/vite.config.integration.ts",
-        "reportsDirectory": "../../coverage/utils/integration-tests"
+        "config": "packages/utils/vite.config.integration.ts"
       }
     }
   },

--- a/packages/utils/vite.config.integration.ts
+++ b/packages/utils/vite.config.integration.ts
@@ -16,7 +16,7 @@ export default defineConfig({
     coverage: {
       reporter: ['text', 'lcov'],
       reportsDirectory: '../../coverage/utils/integration-tests',
-      exclude: ['mocks/**', 'perf/**'],
+      exclude: ['mocks/**', 'perf/**', '**/types.ts'],
     },
     environment: 'node',
     include: ['src/**/*.integration.test.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],

--- a/packages/utils/vite.config.unit.ts
+++ b/packages/utils/vite.config.unit.ts
@@ -16,7 +16,7 @@ export default defineConfig({
     coverage: {
       reporter: ['text', 'lcov'],
       reportsDirectory: '../../coverage/utils/unit-tests',
-      exclude: ['mocks/**', 'perf/**'],
+      exclude: ['mocks/**', 'perf/**', '**/types.ts'],
     },
     environment: 'node',
     include: ['src/**/*.unit.test.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],

--- a/testing/test-utils/project.json
+++ b/testing/test-utils/project.json
@@ -24,10 +24,8 @@
     },
     "unit-test": {
       "executor": "@nx/vite:test",
-      "outputs": ["{options.reportsDirectory}"],
       "options": {
-        "config": "testing/test-utils/vite.config.unit.ts",
-        "reportsDirectory": "../../coverage/test-utils/unit-tests"
+        "config": "testing/test-utils/vite.config.unit.ts"
       }
     }
   },

--- a/testing/test-utils/vite.config.unit.ts
+++ b/testing/test-utils/vite.config.unit.ts
@@ -16,6 +16,7 @@ export default defineConfig({
     coverage: {
       reporter: ['text', 'lcov'],
       reportsDirectory: '../../coverage/test-utils/unit-tests',
+      exclude: ['**/*.mock.{mjs,ts}', '**/*.config.{js,mjs,ts}'],
     },
     environment: 'node',
     include: ['src/**/*.unit.test.ts'],


### PR DESCRIPTION
In this PR, I remove the duplicate coverage configuration:
- I remove outputs and test coverage path from `project.json` and add it in `vite.config.(unit|integration).ts`.
- I explicitly reset Nx cache.
- I adapt the `getNxCoveragePaths` to this change and cover the main functionality with unit tests.
- I narrow down included files for coverage.

Links:
- Successful [workflow run](https://github.com/code-pushup/cli/actions/runs/8597300703/job/23555699010).
- [Codecov ](https://app.codecov.io/gh/code-pushup/cli/tree/coverage-from-test-config)with uploaded results.