### PR TITLE
ci: do not assign docs label if .md file changed in __snapshots__

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -51,6 +51,7 @@
 📖 Project documentation:
   - changed-files:
       - any-glob-to-any-file: '**/*.md'
+      - all-globs-to-all-files: '!**/__snapshots/**'
 
 🛠️ tooling:
   - changed-files:


### PR DESCRIPTION
E.g. PR #622 was assigned [📖 Project documentation](https://github.com/code-pushup/cli/labels/%F0%9F%93%96%20Project%20documentation) label, but the `.md` changes are all test snapshots.