### PR TITLE
test(nx-plugin-e2e): remove unnecessary Verdaccio setup to fix interference with cli-e2e

### DIFF
--- a/e2e/nx-plugin-e2e/vite.config.e2e.ts
+++ b/e2e/nx-plugin-e2e/vite.config.e2e.ts
@@ -16,7 +16,7 @@ export default defineConfig({
     },
     environment: 'node',
     include: ['tests/**/*.e2e.test.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
-    globalSetup: ['../../global-setup.e2e.ts'],
+    globalSetup: ['../../global-setup.ts'],
     setupFiles: ['../../testing/test-setup/src/lib/reset.mocks.ts'],
   },
 });


### PR DESCRIPTION
Follow-up to https://github.com/code-pushup/cli/pull/639#issuecomment-2072297576

Related to #643 

I removed the Verdaccio setup from `nx-plugin-e2e`. It's actually not needed, `nx g @code-pushup/nx-plugin:...` works the same for local plugin as for NPM package.

This enables E2E projects to be run in parallel, tested [here](https://github.com/code-pushup/cli/actions/runs/8800951344/job/24153214053#step:6:18).