### PR TITLE
fix(plugin-js-packages): skip package labels until semver is integrated

### DIFF
--- a/packages/plugin-js-packages/src/lib/runner/outdated/transform.ts
+++ b/packages/plugin-js-packages/src/lib/runner/outdated/transform.ts
@@ -18,9 +18,14 @@ export function outdatedResultToAuditOutput(
   const relevantDependencies: OutdatedResult = result.filter(
     dep => dep.type === dependencyGroupToLong[depGroup],
   );
-  const outdatedDependencies = relevantDependencies.filter(
-    dep => dep.current !== dep.latest,
-  );
+  // TODO use semver logic to compare versions
+  const outdatedDependencies = relevantDependencies
+    .filter(dep => dep.current !== dep.latest)
+    .filter(
+      dep =>
+        dep.current.split('-')[0]?.toString() !==
+        dep.latest.split('-')[0]?.toString(),
+    );
 
   const outdatedStats = outdatedDependencies.reduce(
     (acc, dep) => {
@@ -114,7 +119,8 @@ export function getOutdatedLevel(
 }
 
 export function splitPackageVersion(fullVersion: string): PackageVersion {
-  const [major, minor, patch] = fullVersion.split('.').map(Number);
+  const semanticVersion = String(fullVersion.split('-')[0]);
+  const [major, minor, patch] = semanticVersion.split('.').map(Number);
 
   if (major == null || minor == null || patch == null) {
     throw new Error(`Invalid version description ${fullVersion}`);

--- a/packages/plugin-js-packages/src/lib/runner/outdated/transform.unit.test.ts
+++ b/packages/plugin-js-packages/src/lib/runner/outdated/transform.unit.test.ts
@@ -87,7 +87,7 @@ describe('outdatedResultToAuditOutput', () => {
           {
             name: 'nx',
             current: '15.8.1',
-            latest: '17.0.0',
+            latest: '17.0.0-stable',
             type: 'dependencies',
           },
           {
@@ -164,6 +164,34 @@ describe('outdatedResultToAuditOutput', () => {
       ),
     ).toEqual<AuditOutput>({
       slug: 'npm-outdated-optional',
+      score: 1,
+      value: 0,
+      displayValue: 'all dependencies are up to date',
+    });
+  });
+
+  it('should skip identical semantic versions with different label', () => {
+    expect(
+      outdatedResultToAuditOutput(
+        [
+          {
+            name: 'cypress',
+            current: '13.7.0-alpha',
+            latest: '13.7.0-beta',
+            type: 'devDependencies',
+          },
+          {
+            name: 'nx',
+            current: '17.0.0-12',
+            latest: '17.0.0-15',
+            type: 'devDependencies',
+          },
+        ],
+        'npm',
+        'dev',
+      ),
+    ).toEqual<AuditOutput>({
+      slug: 'npm-outdated-dev',
       score: 1,
       value: 0,
       displayValue: 'all dependencies are up to date',


### PR DESCRIPTION
In this PR, I am temporarily skipping package labels and stick to comparing semantic versions.
Including the extended version description will be once `semver` is integrated in #597.
I documented current behaviour in unit tests.