### PR TITLE
refactor(plugin-js-packages): use semver for version diff

### DIFF
--- a/packages/plugin-js-packages/package.json
+++ b/packages/plugin-js-packages/package.json
@@ -4,6 +4,7 @@
   "dependencies": {
     "@code-pushup/models": "0.39.0",
     "@code-pushup/utils": "0.39.0",
+    "semver": "^7.6.0",
     "zod": "^3.22.4"
   }
 }

--- a/packages/plugin-js-packages/src/lib/runner/outdated/constants.ts
+++ b/packages/plugin-js-packages/src/lib/runner/outdated/constants.ts
@@ -1,8 +1,16 @@
+import type { ReleaseType } from 'semver';
 import type { IssueSeverity } from '@code-pushup/models';
-import { VersionType } from './types';
+import { objectToKeys } from '@code-pushup/utils';
 
-export const outdatedSeverity: Record<VersionType, IssueSeverity> = {
+export const outdatedSeverity: Record<ReleaseType, IssueSeverity> = {
   major: 'error',
+  premajor: 'info',
   minor: 'warning',
+  preminor: 'info',
   patch: 'info',
+  prepatch: 'info',
+  prerelease: 'info',
 };
+
+// RELEASE_TYPES directly exported from semver don't work out of the box
+export const RELEASE_TYPES = objectToKeys(outdatedSeverity);

--- a/packages/plugin-js-packages/src/lib/runner/outdated/transform.ts
+++ b/packages/plugin-js-packages/src/lib/runner/outdated/transform.ts
@@ -1,14 +1,10 @@
-import { Issue } from '@code-pushup/models';
-import { pluralize } from '@code-pushup/utils';
+import { ReleaseType, clean, diff, neq } from 'semver';
+import type { Issue } from '@code-pushup/models';
+import { objectFromEntries, pluralize } from '@code-pushup/utils';
 import { DependencyGroup, PackageManagerId } from '../../config';
 import { dependencyGroupToLong } from '../../constants';
-import { outdatedSeverity } from './constants';
-import {
-  OutdatedResult,
-  PackageVersion,
-  VersionType,
-  versionType,
-} from './types';
+import { RELEASE_TYPES, outdatedSeverity } from './constants';
+import { OutdatedResult } from './types';
 
 export function outdatedResultToAuditOutput(
   result: OutdatedResult,
@@ -18,22 +14,29 @@ export function outdatedResultToAuditOutput(
   const relevantDependencies: OutdatedResult = result.filter(
     dep => dep.type === dependencyGroupToLong[depGroup],
   );
-  // TODO use semver logic to compare versions
-  const outdatedDependencies = relevantDependencies
-    .filter(dep => dep.current !== dep.latest)
+
+  const validDependencies = relevantDependencies
+    .map(dep => ({
+      ...dep,
+      current: clean(dep.current),
+      latest: clean(dep.latest),
+    }))
     .filter(
-      dep =>
-        dep.current.split('-')[0]?.toString() !==
-        dep.latest.split('-')[0]?.toString(),
+      (dep): dep is OutdatedResult[number] =>
+        dep.current != null && dep.latest != null,
     );
 
-  const outdatedStats = outdatedDependencies.reduce(
-    (acc, dep) => {
-      const outdatedLevel = getOutdatedLevel(dep.current, dep.latest);
-      return { ...acc, [outdatedLevel]: acc[outdatedLevel] + 1 };
-    },
-    { major: 0, minor: 0, patch: 0 },
+  const outdatedDependencies = validDependencies.filter(dep =>
+    neq(dep.current, dep.latest),
   );
+
+  const outdatedStats = outdatedDependencies.reduce((acc, dep) => {
+    const outdatedLevel = diff(dep.current, dep.latest);
+    if (outdatedLevel == null) {
+      return acc;
+    }
+    return { ...acc, [outdatedLevel]: acc[outdatedLevel] + 1 };
+  }, objectFromEntries(RELEASE_TYPES.map(versionType => [versionType, 0])));
 
   const issues =
     outdatedDependencies.length === 0
@@ -59,12 +62,12 @@ export function calculateOutdatedScore(
   return totalDeps > 0 ? (totalDeps - majorOutdated) / totalDeps : 1;
 }
 
-export function outdatedToDisplayValue(stats: Record<VersionType, number>) {
-  const total = stats.major + stats.minor + stats.patch;
+export function outdatedToDisplayValue(stats: Record<ReleaseType, number>) {
+  const total = Object.values(stats).reduce((acc, value) => acc + value, 0);
 
-  const versionBreakdown = versionType
-    .map(version => (stats[version] > 0 ? `${stats[version]} ${version}` : ''))
-    .filter(text => text !== '');
+  const versionBreakdown = RELEASE_TYPES.map(version =>
+    stats[version] > 0 ? `${stats[version]} ${version}` : '',
+  ).filter(text => text !== '');
 
   if (versionBreakdown.length === 0) {
     return 'all dependencies are up to date';
@@ -85,7 +88,8 @@ export function outdatedToDisplayValue(stats: Record<VersionType, number>) {
 export function outdatedToIssues(dependencies: OutdatedResult): Issue[] {
   return dependencies.map<Issue>(dep => {
     const { name, current, latest, url } = dep;
-    const outdatedLevel = getOutdatedLevel(current, latest);
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const outdatedLevel = diff(current, latest)!;
     const packageReference =
       url == null ? `\`${name}\`` : `[\`${name}\`](${url})`;
 
@@ -94,37 +98,4 @@ export function outdatedToIssues(dependencies: OutdatedResult): Issue[] {
       severity: outdatedSeverity[outdatedLevel],
     };
   });
-}
-
-export function getOutdatedLevel(
-  currentFullVersion: string,
-  latestFullVersion: string,
-): VersionType {
-  const current = splitPackageVersion(currentFullVersion);
-  const latest = splitPackageVersion(latestFullVersion);
-
-  if (current.major < latest.major) {
-    return 'major';
-  }
-
-  if (current.minor < latest.minor) {
-    return 'minor';
-  }
-
-  if (current.patch < latest.patch) {
-    return 'patch';
-  }
-
-  throw new Error('Package is not outdated.');
-}
-
-export function splitPackageVersion(fullVersion: string): PackageVersion {
-  const semanticVersion = String(fullVersion.split('-')[0]);
-  const [major, minor, patch] = semanticVersion.split('.').map(Number);
-
-  if (major == null || minor == null || patch == null) {
-    throw new Error(`Invalid version description ${fullVersion}`);
-  }
-
-  return { major, minor, patch };
 }

--- a/packages/plugin-js-packages/src/lib/runner/outdated/types.ts
+++ b/packages/plugin-js-packages/src/lib/runner/outdated/types.ts
@@ -1,6 +1,6 @@
-export const versionType = ['major', 'minor', 'patch'] as const;
-export type VersionType = (typeof versionType)[number];
-export type PackageVersion = Record<VersionType, number>;
+import type { ReleaseType } from 'semver';
+
+export type PackageVersion = Record<ReleaseType, number>;
 export type DependencyGroupLong =
   | 'dependencies'
   | 'devDependencies'


### PR DESCRIPTION
Related to #597 

In this PR, I use [`semver` functions](https://github.com/npm/node-semver?tab=readme-ov-file#functions) to determine the version difference.