### PR TITLE
fix(plugin-js-packages): omit unspecified direct dependency

### DIFF
--- a/packages/plugin-js-packages/src/lib/runner/audit/transform.ts
+++ b/packages/plugin-js-packages/src/lib/runner/audit/transform.ts
@@ -75,7 +75,8 @@ export function vulnerabilitiesToIssues(
         ? '**all** versions'
         : `versions **${detail.versionRange}**`;
     const directDependency =
-      typeof detail.directDependency === 'string'
+      typeof detail.directDependency === 'string' &&
+      detail.directDependency !== ''
         ? `\`${detail.directDependency}\``
         : '';
     const depHierarchy =

--- a/packages/plugin-js-packages/src/lib/runner/audit/transform.unit.test.ts
+++ b/packages/plugin-js-packages/src/lib/runner/audit/transform.unit.test.ts
@@ -279,8 +279,26 @@ describe('vulnerabilitiesToIssues', () => {
     ).toEqual<Issue[]>([
       expect.objectContaining({
         message: expect.stringContaining(
-          "`cypress`' dependency `@cypress/request`",
+          "`cypress`' dependency `@cypress/request` has",
         ),
+      }),
+    ]);
+  });
+
+  it('should omit direct dependency when not provided', () => {
+    expect(
+      vulnerabilitiesToIssues(
+        [
+          {
+            name: 'semver',
+            directDependency: '',
+          },
+        ] as Vulnerability[],
+        defaultAuditLevelMapping,
+      ),
+    ).toEqual<Issue[]>([
+      expect.objectContaining({
+        message: expect.stringContaining('`semver` dependency has'),
       }),
     ]);
   });


### PR DESCRIPTION
Related to #597 

When unable to detect direct dependency name, the issue message omits it now.
Before it formatted the empty string.