### PR TITLE
feat(plugin-eslint): eslint config from nx projects helpers

### DIFF
--- a/code-pushup.config.ts
+++ b/code-pushup.config.ts
@@ -12,7 +12,7 @@ import coveragePlugin, {
   getNxCoveragePaths,
 } from './dist/packages/plugin-coverage';
 import eslintPlugin, {
-  eslintConfigFromNxProjects,
+  eslintConfigFromAllNxProjects,
 } from './dist/packages/plugin-eslint';
 import jsPackagesPlugin from './dist/packages/plugin-js-packages';
 import {
@@ -46,7 +46,7 @@ const config: CoreConfig = {
     }),
 
   plugins: [
-    await eslintPlugin(await eslintConfigFromNxProjects()),
+    await eslintPlugin(await eslintConfigFromAllNxProjects()),
 
     await coveragePlugin({
       coverageToolCommand: {

--- a/packages/plugin-eslint/README.md
+++ b/packages/plugin-eslint/README.md
@@ -72,15 +72,15 @@ Detected ESLint rules are mapped to Code PushUp audits. Audit reports are calcul
      };
      ```
 
-   - If you wish to target a specific project along with other projects it depends on, use the `eslintConfigFromNxProject` helper and pass in in your project name:
+   - If you wish to target a specific project along with other projects it depends on, use the `eslintConfigFromNxProjectAndDeps` helper and pass in in your project name:
 
      ```js
-     import eslintPlugin, { eslintConfigFromNxProject } from '@code-pushup/eslint-plugin';
+     import eslintPlugin, { eslintConfigFromNxProjectAndDeps } from '@code-pushup/eslint-plugin';
 
      export default {
        plugins: [
          // ...
-         await eslintPlugin(await eslintConfigFromNxProject('<PROJECT-NAME>')),
+         await eslintPlugin(await eslintConfigFromNxProjectAndDeps('<PROJECT-NAME>')),
        ],
      };
      ```

--- a/packages/plugin-eslint/README.md
+++ b/packages/plugin-eslint/README.md
@@ -59,15 +59,15 @@ Detected ESLint rules are mapped to Code PushUp audits. Audit reports are calcul
 
    If you're using an Nx monorepo, additional helper functions are provided to simplify your configuration:
 
-   - If you wish to combine all projects in your workspace into one report, use the `eslintConfigFromNxProjects` helper:
+   - If you wish to combine all projects in your workspace into one report, use the `eslintConfigFromAllNxProjects` helper:
 
      ```js
-     import eslintPlugin, { eslintConfigFromNxProjects } from '@code-pushup/eslint-plugin';
+     import eslintPlugin, { eslintConfigFromAllNxProjects } from '@code-pushup/eslint-plugin';
 
      export default {
        plugins: [
          // ...
-         await eslintPlugin(await eslintConfigFromNxProjects()),
+         await eslintPlugin(await eslintConfigFromAllNxProjects()),
        ],
      };
      ```

--- a/packages/plugin-eslint/src/index.ts
+++ b/packages/plugin-eslint/src/index.ts
@@ -7,4 +7,5 @@ export type { ESLintPluginConfig } from './lib/config';
 export {
   eslintConfigFromNxProject,
   eslintConfigFromNxProjects,
+  eslintConfigFromAllNxProjects,
 } from './lib/nx';

--- a/packages/plugin-eslint/src/index.ts
+++ b/packages/plugin-eslint/src/index.ts
@@ -6,6 +6,7 @@ export type { ESLintPluginConfig } from './lib/config';
 
 export {
   eslintConfigFromNxProjectAndDeps,
+  // eslint-disable-next-line deprecation/deprecation
   eslintConfigFromNxProjects,
   eslintConfigFromAllNxProjects,
   eslintConfigFromNxProject,

--- a/packages/plugin-eslint/src/index.ts
+++ b/packages/plugin-eslint/src/index.ts
@@ -8,4 +8,5 @@ export {
   eslintConfigFromNxProjectAndDeps,
   eslintConfigFromNxProjects,
   eslintConfigFromAllNxProjects,
+  eslintConfigFromNxProject,
 } from './lib/nx';

--- a/packages/plugin-eslint/src/index.ts
+++ b/packages/plugin-eslint/src/index.ts
@@ -5,7 +5,7 @@ export default eslintPlugin;
 export type { ESLintPluginConfig } from './lib/config';
 
 export {
-  eslintConfigFromNxProject,
+  eslintConfigFromNxProjectAndDeps,
   eslintConfigFromNxProjects,
   eslintConfigFromAllNxProjects,
 } from './lib/nx';

--- a/packages/plugin-eslint/src/lib/nx.integration.test.ts
+++ b/packages/plugin-eslint/src/lib/nx.integration.test.ts
@@ -147,12 +147,10 @@ describe('Nx helpers', () => {
       async project => {
         const targets = await eslintConfigFromNxProject(project);
 
-        expect(targets).toEqual([
-          {
-            eslintrc: `./packages/${project}/.eslintrc.json`,
-            patterns: expect.arrayContaining([`packages/${project}/**/*.ts`]),
-          },
-        ]);
+        expect(targets).toEqual({
+          eslintrc: `./packages/${project}/.eslintrc.json`,
+          patterns: expect.arrayContaining([`packages/${project}/**/*.ts`]),
+        });
       },
     );
   });

--- a/packages/plugin-eslint/src/lib/nx.integration.test.ts
+++ b/packages/plugin-eslint/src/lib/nx.integration.test.ts
@@ -3,7 +3,10 @@ import { fileURLToPath } from 'node:url';
 import { setWorkspaceRoot, workspaceRoot } from 'nx/src/utils/workspace-root';
 import type { MockInstance } from 'vitest';
 import { type ESLintTarget } from './config';
-import { eslintConfigFromAllNxProjects, eslintConfigFromNxProject } from './nx';
+import {
+  eslintConfigFromAllNxProjects,
+  eslintConfigFromNxProjectAndDeps,
+} from './nx';
 
 describe('Nx helpers', () => {
   let cwdSpy: MockInstance<[], string>;
@@ -109,7 +112,7 @@ describe('Nx helpers', () => {
     ])(
       'project %j - expected configurations for projects %j',
       async (project, expectedProjects) => {
-        const targets = await eslintConfigFromNxProject(project);
+        const targets = await eslintConfigFromNxProjectAndDeps(project);
 
         expect(targets).toEqual(
           expectedProjects.map(

--- a/packages/plugin-eslint/src/lib/nx.integration.test.ts
+++ b/packages/plugin-eslint/src/lib/nx.integration.test.ts
@@ -3,7 +3,7 @@ import { fileURLToPath } from 'node:url';
 import { setWorkspaceRoot, workspaceRoot } from 'nx/src/utils/workspace-root';
 import type { MockInstance } from 'vitest';
 import { type ESLintTarget } from './config';
-import { eslintConfigFromNxProject, eslintConfigFromNxProjects } from './nx';
+import { eslintConfigFromAllNxProjects, eslintConfigFromNxProject } from './nx';
 
 describe('Nx helpers', () => {
   let cwdSpy: MockInstance<[], string>;
@@ -33,7 +33,7 @@ describe('Nx helpers', () => {
 
   describe('create config from all Nx projects', () => {
     it('should include eslintrc and patterns of each project', async () => {
-      await expect(eslintConfigFromNxProjects()).resolves.toEqual([
+      await expect(eslintConfigFromAllNxProjects()).resolves.toEqual([
         {
           eslintrc: './packages/cli/.eslintrc.json',
           patterns: [

--- a/packages/plugin-eslint/src/lib/nx/find-all-projects.ts
+++ b/packages/plugin-eslint/src/lib/nx/find-all-projects.ts
@@ -9,21 +9,27 @@ import { nxProjectsToConfig } from './projects-to-config';
  *
  * @example
  * import eslintPlugin, {
- *   eslintConfigFromNxProjects,
+ *   eslintConfigFromAllNxProjects,
  * } from '@code-pushup/eslint-plugin';
  *
  * export default {
  *   plugins: [
  *     await eslintPlugin(
- *       await eslintConfigFromNxProjects()
+ *       await eslintConfigFromAllNxProjects()
  *     )
  *   ]
  * }
  *
  * @returns ESLint config and patterns, intended to be passed to {@link eslintPlugin}
  */
-export async function eslintConfigFromNxProjects(): Promise<ESLintTarget[]> {
+export async function eslintConfigFromAllNxProjects(): Promise<ESLintTarget[]> {
   const { createProjectGraphAsync } = await import('@nx/devkit');
   const projectGraph = await createProjectGraphAsync({ exitOnError: false });
   return nxProjectsToConfig(projectGraph);
 }
+
+/**
+ * @deprecated
+ * Helper is renamed, please use `eslintConfigFromAllNxProjects` function instead.
+ */
+export const eslintConfigFromNxProjects = eslintConfigFromAllNxProjects;

--- a/packages/plugin-eslint/src/lib/nx/find-all-projects.ts
+++ b/packages/plugin-eslint/src/lib/nx/find-all-projects.ts
@@ -5,7 +5,7 @@ import { nxProjectsToConfig } from './projects-to-config';
  * Finds all Nx projects in workspace and converts their lint configurations to Code PushUp ESLint plugin parameters.
  *
  * Use when you wish to automatically include every Nx project in a single Code PushUp project.
- * If you prefer to only include a subset of your Nx monorepo, refer to {@link eslintConfigFromNxProject} instead.
+ * If you prefer to only include a subset of your Nx monorepo, refer to {@link eslintConfigFromNxProjectAndDeps} instead.
  *
  * @example
  * import eslintPlugin, {

--- a/packages/plugin-eslint/src/lib/nx/find-project-with-deps.ts
+++ b/packages/plugin-eslint/src/lib/nx/find-project-with-deps.ts
@@ -5,8 +5,8 @@ import { findAllDependencies } from './traverse-graph';
 /**
  * Accepts a target Nx projects, finds projects it depends on, and converts lint configurations to Code PushUp ESLint plugin parameters.
  *
- * Use when you wish to include a targetted subset of your Nx monorepo in your Code PushUp project.
- * If you prefer to include all Nx projects, refer to {@link eslintConfigFromNxProjects} instead.
+ * Use when you wish to include a targeted subset of your Nx monorepo in your Code PushUp project.
+ * If you prefer to include all Nx projects, refer to {@link eslintConfigFromAllNxProjects} instead.
  *
  * @example
  * import eslintPlugin, {

--- a/packages/plugin-eslint/src/lib/nx/find-project-with-deps.ts
+++ b/packages/plugin-eslint/src/lib/nx/find-project-with-deps.ts
@@ -10,7 +10,7 @@ import { findAllDependencies } from './traverse-graph';
  *
  * @example
  * import eslintPlugin, {
- *   eslintConfigFromNxProject,
+ *   eslintConfigFromNxProjectAndDeps,
  * } from '@code-pushup/eslint-plugin';
  *
  * const projectName = 'backoffice'; // <-- name from project.json
@@ -18,7 +18,7 @@ import { findAllDependencies } from './traverse-graph';
  * export default {
  *   plugins: [
  *     await eslintPlugin(
- *       await eslintConfigFromNxProject(projectName)
+ *       await eslintConfigFromNxProjectAndDeps(projectName)
  *     )
  *   ]
  * }
@@ -26,7 +26,7 @@ import { findAllDependencies } from './traverse-graph';
  * @param projectName Nx project serving as main entry point
  * @returns ESLint config and patterns, intended to be passed to {@link eslintPlugin}
  */
-export async function eslintConfigFromNxProject(
+export async function eslintConfigFromNxProjectAndDeps(
   projectName: string,
 ): Promise<ESLintTarget[]> {
   const { createProjectGraphAsync } = await import('@nx/devkit');

--- a/packages/plugin-eslint/src/lib/nx/find-project-without-deps.ts
+++ b/packages/plugin-eslint/src/lib/nx/find-project-without-deps.ts
@@ -1,17 +1,16 @@
 import type { ESLintTarget } from '../config';
 import { nxProjectsToConfig } from './projects-to-config';
-import { findAllDependencies } from './traverse-graph';
 
 /**
- * Accepts a target Nx projects, finds projects it depends on, and converts lint configurations to Code PushUp ESLint plugin parameters.
+ * Accepts a target Nx projects, converts lint configurations to Code PushUp ESLint plugin parameters.
  *
  * Use when you wish to include a targeted subset of your Nx monorepo in your Code PushUp project.
- * If you prefer to include all Nx projects, refer to {@link eslintConfigFromAllNxProjects} instead.
- * if you'd like to skip dependencies of the provided target project use {@link eslintConfigFromNxProject} instead.
+ * If you prefer to include all Nx projects, refer to {@link eslintConfigFromAllNxProjects} instead,
+ * if you'd like to auto include all dependencies of the provided target project use {@link eslintConfigFromNxProjectAndDeps} instead.
  *
  * @example
  * import eslintPlugin, {
- *   eslintConfigFromNxProjectAndDeps,
+ *   eslintConfigFromNxProject,
  * } from '@code-pushup/eslint-plugin';
  *
  * const projectName = 'backoffice'; // <-- name from project.json
@@ -19,7 +18,7 @@ import { findAllDependencies } from './traverse-graph';
  * export default {
  *   plugins: [
  *     await eslintPlugin(
- *       await eslintConfigFromNxProjectAndDeps(projectName)
+ *       await eslintConfigFromNxProject(projectName)
  *     )
  *   ]
  * }
@@ -27,18 +26,14 @@ import { findAllDependencies } from './traverse-graph';
  * @param projectName Nx project serving as main entry point
  * @returns ESLint config and patterns, intended to be passed to {@link eslintPlugin}
  */
-export async function eslintConfigFromNxProjectAndDeps(
+export async function eslintConfigFromNxProject(
   projectName: string,
 ): Promise<ESLintTarget[]> {
   const { createProjectGraphAsync } = await import('@nx/devkit');
   const projectGraph = await createProjectGraphAsync({ exitOnError: false });
 
-  const dependencies = findAllDependencies(projectName, projectGraph);
-
   return nxProjectsToConfig(
     projectGraph,
-    project =>
-      !!project.name &&
-      (project.name === projectName || dependencies.has(project.name)),
+    project => !!project.name && project.name === projectName,
   );
 }

--- a/packages/plugin-eslint/src/lib/nx/find-project-without-deps.ts
+++ b/packages/plugin-eslint/src/lib/nx/find-project-without-deps.ts
@@ -2,11 +2,11 @@ import type { ESLintTarget } from '../config';
 import { nxProjectsToConfig } from './projects-to-config';
 
 /**
- * Accepts a target Nx projects, converts lint configurations to Code PushUp ESLint plugin parameters.
+ * Accepts a target Nx project, converts its lint configuration to Code PushUp ESLint plugin parameters.
  *
- * Use when you wish to include a targeted subset of your Nx monorepo in your Code PushUp project.
- * If you prefer to include all Nx projects, refer to {@link eslintConfigFromAllNxProjects} instead,
- * if you'd like to auto include all dependencies of the provided target project use {@link eslintConfigFromNxProjectAndDeps} instead.
+ * Use when you wish to only have a single Nx project as your Code PushUp project, without any other dependencies.
+ * If you prefer to include all Nx projects, refer to {@link eslintConfigFromAllNxProjects} instead.
+ * If you'd like to auto include all dependencies of the provided target project use {@link eslintConfigFromNxProjectAndDeps} instead.
  *
  * @example
  * import eslintPlugin, {
@@ -23,17 +23,22 @@ import { nxProjectsToConfig } from './projects-to-config';
  *   ]
  * }
  *
- * @param projectName Nx project serving as main entry point
+ * @param projectName Nx project name
  * @returns ESLint config and patterns, intended to be passed to {@link eslintPlugin}
  */
 export async function eslintConfigFromNxProject(
   projectName: string,
-): Promise<ESLintTarget[]> {
+): Promise<ESLintTarget> {
   const { createProjectGraphAsync } = await import('@nx/devkit');
   const projectGraph = await createProjectGraphAsync({ exitOnError: false });
 
-  return nxProjectsToConfig(
+  const [project] = nxProjectsToConfig(
     projectGraph,
     project => !!project.name && project.name === projectName,
   );
+  
+  if (!project) {
+    throw new Error(`Couldn't find Nx project named "${projectName}"`);
+  }
+  return project;
 }

--- a/packages/plugin-eslint/src/lib/nx/find-project-without-deps.ts
+++ b/packages/plugin-eslint/src/lib/nx/find-project-without-deps.ts
@@ -32,13 +32,14 @@ export async function eslintConfigFromNxProject(
   const { createProjectGraphAsync } = await import('@nx/devkit');
   const projectGraph = await createProjectGraphAsync({ exitOnError: false });
 
-  const [project] = nxProjectsToConfig(
+  const [project] = await nxProjectsToConfig(
     projectGraph,
-    project => !!project.name && project.name === projectName,
+    ({ name }) => !!name && name === projectName,
   );
-  
+
   if (!project) {
     throw new Error(`Couldn't find Nx project named "${projectName}"`);
   }
+
   return project;
 }

--- a/packages/plugin-eslint/src/lib/nx/index.ts
+++ b/packages/plugin-eslint/src/lib/nx/index.ts
@@ -1,2 +1,5 @@
-export { eslintConfigFromNxProjects } from './find-all-projects';
+export {
+  eslintConfigFromNxProjects,
+  eslintConfigFromAllNxProjects,
+} from './find-all-projects';
 export { eslintConfigFromNxProject } from './find-project-with-deps';

--- a/packages/plugin-eslint/src/lib/nx/index.ts
+++ b/packages/plugin-eslint/src/lib/nx/index.ts
@@ -2,4 +2,5 @@ export {
   eslintConfigFromNxProjects,
   eslintConfigFromAllNxProjects,
 } from './find-all-projects';
+export { eslintConfigFromNxProject } from './find-project-without-deps';
 export { eslintConfigFromNxProjectAndDeps } from './find-project-with-deps';

--- a/packages/plugin-eslint/src/lib/nx/index.ts
+++ b/packages/plugin-eslint/src/lib/nx/index.ts
@@ -1,4 +1,5 @@
 export {
+  // eslint-disable-next-line deprecation/deprecation
   eslintConfigFromNxProjects,
   eslintConfigFromAllNxProjects,
 } from './find-all-projects';

--- a/packages/plugin-eslint/src/lib/nx/index.ts
+++ b/packages/plugin-eslint/src/lib/nx/index.ts
@@ -2,4 +2,4 @@ export {
   eslintConfigFromNxProjects,
   eslintConfigFromAllNxProjects,
 } from './find-all-projects';
-export { eslintConfigFromNxProject } from './find-project-with-deps';
+export { eslintConfigFromNxProjectAndDeps } from './find-project-with-deps';


### PR DESCRIPTION
fixes #675 

Desired helpers API after the changes:
- [x] eslintConfigFromAllNxProjects() - includes all deps of all projects
- [x] eslintConfigFromNxProjectAndDeps('project') - includes all deps of provided project target
- [x] eslintConfigFromNxProject('project') - includes just the project target