### PR TITLE
fix(plugin-coverage,plugin-js-packages): always include issues array, even if empty

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
         run: npm ci
       - name: Version, release and publish packages
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
         run: |
           echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> .npmrc

--- a/packages/cli/docs/custom-plugins.md
+++ b/packages/cli/docs/custom-plugins.md
@@ -504,15 +504,13 @@ async function runnerFunction(options: Options): Promise<AuditOutputs> {
   // assert file size information with budget
   const issues = data.map(({ file, size }) => assertFileSizeInfo(file, size, options.budget));
 
-  // add details if issues given
-  if (issues.length) {
-    fileSizeAuditOutput = {
-      ...fileSizeAuditOutput,
-      details: {
-        issues,
-      },
-    };
-  }
+  // add issues to details
+  fileSizeAuditOutput = {
+    ...fileSizeAuditOutput,
+    details: {
+      issues,
+    },
+  };
 
   return [fileSizeAuditOutput];
 }
@@ -585,7 +583,7 @@ The `report.md` file should contain a similar content like the following:
 ## Groups
 
 As an optional property a plugin can maintain `groups` as an array of [`Group`s](@TODO).
-While [categories](#plugins-and-categories) can score audits across plugins, groups are only targeting audits within a plugin.
+While [categories](#categories) can score audits across plugins, groups are only targeting audits within a plugin.
 For simple plugins this is not needed but it is beneficial in bigger plugins as audit groups also simplify the configuration.
 
 An audit group maintains:

--- a/packages/plugin-coverage/src/lib/runner/lcov/__snapshots__/lcov-runner.integration.test.ts.snap
+++ b/packages/plugin-coverage/src/lib/runner/lcov/__snapshots__/lcov-runner.integration.test.ts.snap
@@ -33,6 +33,9 @@ exports[`lcovResultsToAuditOutputs > should correctly convert lcov results to Au
     "value": 80,
   },
   {
+    "details": {
+      "issues": [],
+    },
     "displayValue": "100 %",
     "score": 1,
     "slug": "function-coverage",

--- a/packages/plugin-coverage/src/lib/runner/lcov/transform.ts
+++ b/packages/plugin-coverage/src/lib/runner/lcov/transform.ts
@@ -112,6 +112,8 @@ export function lcovCoverageToAuditOutput(
     score: toNumberPrecision(coverage, MAX_DECIMAL_PLACES),
     value: roundedIntValue,
     displayValue: `${roundedIntValue} %`,
-    ...(stat.issues.length > 0 && { details: { issues: stat.issues } }),
+    details: {
+      issues: stat.issues,
+    },
   };
 }

--- a/packages/plugin-coverage/src/lib/runner/lcov/transform.unit.test.ts
+++ b/packages/plugin-coverage/src/lib/runner/lcov/transform.unit.test.ts
@@ -304,6 +304,7 @@ describe('lcovCoverageToAudit', () => {
       score: 1,
       value: 100,
       displayValue: '100 %',
+      details: { issues: [] },
     });
   });
 
@@ -318,6 +319,7 @@ describe('lcovCoverageToAudit', () => {
       score: 1,
       value: 100,
       displayValue: '100 %',
+      details: { issues: [] },
     });
   });
 

--- a/packages/plugin-js-packages/src/lib/runner/audit/transform.ts
+++ b/packages/plugin-js-packages/src/lib/runner/audit/transform.ts
@@ -25,7 +25,7 @@ export function auditResultToAuditOutput(
     score: calculateAuditScore(result.summary),
     value: result.summary.total,
     displayValue: summaryToDisplayValue(result.summary),
-    ...(issues.length > 0 && { details: { issues } }),
+    details: { issues },
   };
 }
 

--- a/packages/plugin-js-packages/src/lib/runner/audit/transform.unit.test.ts
+++ b/packages/plugin-js-packages/src/lib/runner/audit/transform.unit.test.ts
@@ -33,6 +33,7 @@ describe('auditResultToAuditOutput', () => {
       score: 1,
       value: 0,
       displayValue: '0 vulnerabilities',
+      details: { issues: [] },
     });
   });
 

--- a/packages/plugin-js-packages/src/lib/runner/outdated/transform.ts
+++ b/packages/plugin-js-packages/src/lib/runner/outdated/transform.ts
@@ -1,5 +1,5 @@
 import { ReleaseType, clean, diff, neq } from 'semver';
-import type { Issue } from '@code-pushup/models';
+import type { AuditOutput, Issue } from '@code-pushup/models';
 import { objectFromEntries, pluralize } from '@code-pushup/utils';
 import { DependencyGroup, PackageManagerId } from '../../config';
 import { dependencyGroupToLong } from '../../constants';
@@ -10,7 +10,7 @@ export function outdatedResultToAuditOutput(
   result: OutdatedResult,
   packageManager: PackageManagerId,
   depGroup: DependencyGroup,
-) {
+): AuditOutput {
   const relevantDependencies: OutdatedResult = result.filter(
     dep => dep.type === dependencyGroupToLong[depGroup],
   );
@@ -51,7 +51,7 @@ export function outdatedResultToAuditOutput(
     ),
     value: outdatedDependencies.length,
     displayValue: outdatedToDisplayValue(outdatedStats),
-    ...(issues.length > 0 && { details: { issues } }),
+    details: { issues },
   };
 }
 

--- a/packages/plugin-js-packages/src/lib/runner/outdated/transform.unit.test.ts
+++ b/packages/plugin-js-packages/src/lib/runner/outdated/transform.unit.test.ts
@@ -166,6 +166,7 @@ describe('outdatedResultToAuditOutput', () => {
       score: 1,
       value: 0,
       displayValue: 'all dependencies are up to date',
+      details: { issues: [] },
     });
   });
 
@@ -188,6 +189,7 @@ describe('outdatedResultToAuditOutput', () => {
       score: 1,
       value: 0,
       displayValue: 'all dependencies are up to date',
+      details: { issues: [] },
     });
   });
 

--- a/tools/scripts/start-local-registry.ts
+++ b/tools/scripts/start-local-registry.ts
@@ -16,6 +16,12 @@ export default async () => {
     verbose: true,
   });
 
+  // find latest version
+  const version = execSync('git describe --tags --abbrev=0')
+    .toString()
+    .trim()
+    .replace(/^v/, '');
+
   // is is also possible to use nx release to publish the packages to the local registry
   execFileSync(
     'npx',
@@ -25,7 +31,7 @@ export default async () => {
       '--targets',
       'publish',
       '--ver',
-      '1.0.0',
+      version,
       '--tag',
       'e2e',
     ],


### PR DESCRIPTION
- To differentiate audits which may produce issues but didn't find any from audits which never produce issues (useful for display purposes), made sure Code coverage and JS Packages always output `issues` array.
- Fixed (hopefully :crossed_fingers:) NPM publish in release workflow, `nx release` uses a different environment variable for the NPM access token (according to [docs](https://nx.dev/recipes/nx-release/publish-in-ci-cd#configure-the-nodeauthtoken)).