### PR TITLE
refactor(plugin-js-packages): make optional deps opt-in, adjust weights

### DIFF
--- a/packages/plugin-js-packages/README.md
+++ b/packages/plugin-js-packages/README.md
@@ -59,7 +59,7 @@ It supports the following package managers:
      // ...
      plugins: [
        // ...
-       await jsPackagesPlugin({ packageManager: ['yarn'], checks: ['audit'] }),
+       await jsPackagesPlugin({ packageManager: ['yarn-classic'], checks: ['audit'], dependencyGroups: ['prod'] }),
      ],
    };
    ```
@@ -112,11 +112,12 @@ The plugin accepts the following parameters:
 
 - `packageManager`: The package manager you are using. Supported values: `npm`, `yarn-classic` (v1), `yarn-modern` (v2+), `pnpm`.
 - (optional) `checks`: Array of checks to be run. Supported commands: `audit`, `outdated`. Both are configured by default.
+- (optional) `dependencyGroups`: Array of dependency groups to be checked. `prod` and `dev` are configured by default. `optional` are opt-in.
 - (optional) `auditLevelMapping`: If you wish to set a custom level of issue severity based on audit vulnerability level, you may do so here. Any omitted values will be filled in by defaults. Audit levels are: `critical`, `high`, `moderate`, `low` and `info`. Issue severities are: `error`, `warn` and `info`. By default the mapping is as follows: `critical` and `high` → `error`; `moderate` and `low` → `warning`; `info` → `info`.
 
 ### Audits and group
 
-This plugin provides a group per check for a convenient declaration in your config. Each group contains audits for all supported groups of dependencies (`prod`, `dev` and `optional`).
+This plugin provides a group per check for a convenient declaration in your config. Each group contains audits for all selected groups of dependencies that are supported (`prod`, `dev` or `optional`).
 
 ```ts
      // ...
@@ -144,7 +145,7 @@ This plugin provides a group per check for a convenient declaration in your conf
      ],
 ```
 
-Each dependency group has its own audit. If you want to check only a subset of dependencies (e.g. run audit and outdated for production dependencies) or assign different weights to them, you can do so in the following way:
+Each dependency group has its own audit. If you want to assign different weights to the audits or record different dependency groups for different checks (the bigger set needs to be included in the plugin configuration), you can do so in the following way:
 
 ```ts
      // ...

--- a/packages/plugin-js-packages/src/lib/config.ts
+++ b/packages/plugin-js-packages/src/lib/config.ts
@@ -3,6 +3,7 @@ import { IssueSeverity, issueSeveritySchema } from '@code-pushup/models';
 import { defaultAuditLevelMapping } from './constants';
 
 export const dependencyGroups = ['prod', 'dev', 'optional'] as const;
+const dependencyGroupSchema = z.enum(dependencyGroups);
 export type DependencyGroup = (typeof dependencyGroups)[number];
 
 const packageCommandSchema = z.enum(['audit', 'outdated']);
@@ -51,6 +52,10 @@ export const jsPackagesPluginConfigSchema = z.object({
   packageManager: packageManagerIdSchema.describe(
     'Package manager to be used.',
   ),
+  dependencyGroups: z
+    .array(dependencyGroupSchema)
+    .min(1)
+    .default(['prod', 'dev']),
   auditLevelMapping: z
     .record(packageAuditLevelSchema, issueSeveritySchema, {
       description:

--- a/packages/plugin-js-packages/src/lib/config.unit.test.ts
+++ b/packages/plugin-js-packages/src/lib/config.unit.test.ts
@@ -14,6 +14,7 @@ describe('jsPackagesPluginConfigSchema', () => {
         auditLevelMapping: { moderate: 'error' },
         checks: ['audit'],
         packageManager: 'yarn-classic',
+        dependencyGroups: ['prod'],
       } satisfies JSPackagesPluginConfig),
     ).not.toThrow();
   });
@@ -33,6 +34,7 @@ describe('jsPackagesPluginConfigSchema', () => {
     expect(config).toEqual<FinalJSPackagesPluginConfig>({
       checks: ['audit', 'outdated'],
       packageManager: 'npm',
+      dependencyGroups: ['prod', 'dev'],
       auditLevelMapping: {
         critical: 'error',
         high: 'error',
@@ -48,6 +50,15 @@ describe('jsPackagesPluginConfigSchema', () => {
       jsPackagesPluginConfigSchema.parse({
         packageManager: 'yarn-classic',
         checks: [],
+      }),
+    ).toThrow('too_small');
+  });
+
+  it('should throw for no passed dependency group', () => {
+    expect(() =>
+      jsPackagesPluginConfigSchema.parse({
+        packageManager: 'yarn-classic',
+        dependencyGroups: [],
       }),
     ).toThrow('too_small');
   });

--- a/packages/plugin-js-packages/src/lib/constants.ts
+++ b/packages/plugin-js-packages/src/lib/constants.ts
@@ -22,12 +22,13 @@ export const dependencyGroupToLong: Record<
   optional: 'optionalDependencies',
 };
 
+/* eslint-disable no-magic-numbers */
 export const dependencyGroupWeights: Record<DependencyGroup, number> = {
-  // eslint-disable-next-line no-magic-numbers
-  prod: 3,
-  dev: 1,
-  optional: 1,
+  prod: 80,
+  dev: 15,
+  optional: 5,
 };
+/* eslint-enable no-magic-numbers */
 
 export const dependencyDocs: Record<DependencyGroup, string> = {
   prod: 'https://classic.yarnpkg.com/docs/dependency-types#toc-dependencies',

--- a/packages/plugin-js-packages/src/lib/package-managers/types.ts
+++ b/packages/plugin-js-packages/src/lib/package-managers/types.ts
@@ -3,6 +3,8 @@ import { DependencyGroup, PackageManagerId } from '../config';
 import { AuditResult } from '../runner/audit/types';
 import { OutdatedResult } from '../runner/outdated/types';
 
+export type AuditResults = Partial<Record<DependencyGroup, AuditResult>>;
+
 export type PackageManager = {
   slug: PackageManagerId;
   name: string;
@@ -18,9 +20,7 @@ export type PackageManager = {
     ignoreExitCode?: boolean; // non-zero exit code will throw by default
     supportedDepGroups?: DependencyGroup[]; // all are supported by default
     unifyResult: (output: string) => AuditResult;
-    postProcessResult?: (
-      result: Record<DependencyGroup, AuditResult>,
-    ) => Record<DependencyGroup, AuditResult>;
+    postProcessResult?: (result: AuditResults) => AuditResults;
   };
   outdated: {
     commandArgs: string[];

--- a/packages/plugin-js-packages/src/lib/runner/runner.integration.test.ts
+++ b/packages/plugin-js-packages/src/lib/runner/runner.integration.test.ts
@@ -12,6 +12,7 @@ describe('createRunnerConfig', () => {
       packageManager: 'npm',
       checks: ['audit'],
       auditLevelMapping: defaultAuditLevelMapping,
+      dependencyGroups: ['prod', 'dev'],
     });
     expect(runnerConfig).toStrictEqual<RunnerConfig>({
       command: 'node',
@@ -25,6 +26,7 @@ describe('createRunnerConfig', () => {
     const pluginConfig: FinalJSPackagesPluginConfig = {
       packageManager: 'yarn-classic',
       checks: ['outdated'],
+      dependencyGroups: ['prod', 'dev'],
       auditLevelMapping: { ...defaultAuditLevelMapping, moderate: 'error' },
     };
     await createRunnerConfig('executeRunner.ts', pluginConfig);


### PR DESCRIPTION
In this PR, I make the following changes:
- dependency groups are configurable
- weights are adjusted to make optional dependencies have less influence on the score

As a side-effect, optional audits will no longer appear on portal for our current CLI config (can be changed).