### PR TITLE
fix(plugin-eslint): revert to explicit config file in nx helper

### DIFF
--- a/packages/plugin-eslint/README.md
+++ b/packages/plugin-eslint/README.md
@@ -43,7 +43,7 @@ Detected ESLint rules are mapped to Code PushUp audits. Audit reports are calcul
 
 4. Add this plugin to the `plugins` array in your Code PushUp CLI config file (e.g. `code-pushup.config.js`).
 
-   Pass in the glob patterns for which files you wish to target (relative to `process.cwd()`).
+   Pass in the path to your ESLint config file, along with glob patterns for which files you wish to target (relative to `process.cwd()`).
 
    ```js
    import eslintPlugin from '@code-pushup/eslint-plugin';
@@ -52,7 +52,7 @@ Detected ESLint rules are mapped to Code PushUp audits. Audit reports are calcul
      // ...
      plugins: [
        // ...
-       await eslintPlugin(['src/**/*.js']),
+       await eslintPlugin({ eslintrc: '.eslintrc.js', patterns: ['src/**/*.js'] }),
      ],
    };
    ```

--- a/packages/plugin-eslint/src/lib/nx.integration.test.ts
+++ b/packages/plugin-eslint/src/lib/nx.integration.test.ts
@@ -42,6 +42,7 @@ describe('Nx helpers', () => {
     it('should include eslintrc and patterns of each project', async () => {
       await expect(eslintConfigFromAllNxProjects()).resolves.toEqual([
         {
+          eslintrc: './packages/cli/.eslintrc.json',
           patterns: [
             'packages/cli/**/*.ts',
             'packages/cli/package.json',
@@ -52,6 +53,7 @@ describe('Nx helpers', () => {
           ],
         },
         {
+          eslintrc: './packages/core/.eslintrc.json',
           patterns: [
             'packages/core/**/*.ts',
             'packages/core/package.json',
@@ -62,6 +64,7 @@ describe('Nx helpers', () => {
           ],
         },
         {
+          eslintrc: './packages/nx-plugin/.eslintrc.json',
           patterns: [
             'packages/nx-plugin/**/*.ts',
             'packages/nx-plugin/package.json',
@@ -73,6 +76,7 @@ describe('Nx helpers', () => {
           ],
         },
         {
+          eslintrc: './packages/utils/.eslintrc.json',
           patterns: [
             'packages/utils/**/*.ts',
             'packages/utils/package.json',
@@ -114,6 +118,7 @@ describe('Nx helpers', () => {
         expect(targets).toEqual(
           expectedProjects.map(
             (p): ESLintTarget => ({
+              eslintrc: `./packages/${p}/.eslintrc.json`,
               patterns: expect.arrayContaining([`packages/${p}/**/*.ts`]),
             }),
           ),
@@ -143,6 +148,7 @@ describe('Nx helpers', () => {
         const targets = await eslintConfigFromNxProject(project);
 
         expect(targets).toEqual({
+          eslintrc: `./packages/${project}/.eslintrc.json`,
           patterns: expect.arrayContaining([`packages/${project}/**/*.ts`]),
         });
       },

--- a/packages/plugin-eslint/src/lib/nx/projects-to-config.unit.test.ts
+++ b/packages/plugin-eslint/src/lib/nx/projects-to-config.unit.test.ts
@@ -68,12 +68,15 @@ describe('nxProjectsToConfig', () => {
 
     expect(config).toEqual<ESLintPluginConfig>([
       {
+        eslintrc: './apps/client/.eslintrc.json',
         patterns: expect.arrayContaining(['apps/client/**/*.ts']),
       },
       {
+        eslintrc: './apps/server/.eslintrc.json',
         patterns: expect.arrayContaining(['apps/server/**/*.ts']),
       },
       {
+        eslintrc: './libs/models/.eslintrc.json',
         patterns: expect.arrayContaining(['libs/models/**/*.ts']),
       },
     ]);
@@ -105,6 +108,7 @@ describe('nxProjectsToConfig', () => {
 
     expect(config).toEqual<ESLintPluginConfig>([
       {
+        eslintrc: './libs/models/.eslintrc.json',
         patterns: expect.arrayContaining(['libs/models/**/*.ts']),
       },
     ]);
@@ -146,9 +150,11 @@ describe('nxProjectsToConfig', () => {
 
     expect(config).toEqual<ESLintPluginConfig>([
       {
+        eslintrc: './apps/client/.eslintrc.json',
         patterns: expect.arrayContaining(['apps/client/**/*.ts']),
       },
       {
+        eslintrc: './apps/server/.eslintrc.json',
         patterns: expect.arrayContaining(['apps/server/**/*.ts']),
       },
     ]);
@@ -212,12 +218,14 @@ describe('nxProjectsToConfig', () => {
 
     await expect(nxProjectsToConfig(projectGraph)).resolves.toEqual([
       {
+        eslintrc: './apps/client/.eslintrc.json',
         patterns: expect.arrayContaining([
           'apps/client/**/*.ts',
           'apps/client/**/*.html',
         ]),
       },
       {
+        eslintrc: './apps/server/.eslintrc.json',
         patterns: expect.arrayContaining(['apps/server/**/*.ts']),
       },
     ] satisfies ESLintPluginConfig);

--- a/packages/plugin-eslint/src/lib/nx/utils.ts
+++ b/packages/plugin-eslint/src/lib/nx/utils.ts
@@ -35,5 +35,5 @@ export function getEslintConfig(
   const options = project.targets?.['lint']?.options as
     | { eslintConfig?: string }
     | undefined;
-  return options?.eslintConfig;
+  return options?.eslintConfig ?? `./${project.root}/.eslintrc.json`;
 }


### PR DESCRIPTION
Partially reverts #683. Omitting the config file produces [warnings](https://github.com/code-pushup/cli/actions/runs/9284755601/job/25547803390?pr=686#step:5:14438). I'm keeping the config file optional, but reverting back to explicit config in Nx helpers since it appears to be introducing more problems if otherwise :confused: 