### PR TITLE
chore(plugin-coverage): skip missing coverage for empty-report function

### DIFF
--- a/e2e/cli-e2e/tests/__snapshots__/collect.e2e.test.ts.snap
+++ b/e2e/cli-e2e/tests/__snapshots__/collect.e2e.test.ts.snap
@@ -25,16 +25,6 @@ exports[`CLI collect > should run Code coverage plugin that runs coverage tool a
           "details": {
             "issues": [
               {
-                "message": "Function (empty-report) is not called in any test case.",
-                "severity": "error",
-                "source": {
-                  "file": "examples/react-todos-app/src/index.jsx",
-                  "position": {
-                    "startLine": 1,
-                  },
-                },
-              },
-              {
                 "message": "Function onSubmit is not called in any test case.",
                 "severity": "error",
                 "source": {
@@ -76,11 +66,11 @@ exports[`CLI collect > should run Code coverage plugin that runs coverage tool a
               },
             ],
           },
-          "displayValue": "50 %",
-          "score": 0.5,
+          "displayValue": "56 %",
+          "score": 0.5556,
           "slug": "function-coverage",
           "title": "Function coverage",
-          "value": 50,
+          "value": 56,
         },
         {
           "description": "Measures how many branches were executed after conditional statements in at least one test.",

--- a/packages/plugin-coverage/README.md
+++ b/packages/plugin-coverage/README.md
@@ -214,7 +214,11 @@ For instance, the following can be an audit output for line coverage.
 }
 ```
 
-### Providing coverage results in Nx monorepo
+### Coverage results alteration
+
+At the moment, the LCOV results include `(empty-report)` functions with missing coverage. These point to various imports or exports, not actual functions. For that reason, they are omitted from the results.
+
+## Providing coverage results in Nx monorepo
 
 As a part of the plugin, there is a `getNxCoveragePaths` helper for setting up paths to coverage results if you are using Nx. The helper accepts all relevant targets (e.g. `test` or `unit-test`) and searches for a coverage path option.
 Jest and Vitest configuration options are currently supported:

--- a/packages/plugin-coverage/src/lib/runner/constants.ts
+++ b/packages/plugin-coverage/src/lib/runner/constants.ts
@@ -8,3 +8,5 @@ export const PLUGIN_CONFIG_PATH = join(
   WORKDIR,
   'plugin-config.json',
 );
+
+export const INVALID_FUNCTION_NAME = '(empty-report)';

--- a/packages/plugin-coverage/src/lib/runner/lcov/transform.ts
+++ b/packages/plugin-coverage/src/lib/runner/lcov/transform.ts
@@ -2,28 +2,53 @@ import { LCOVRecord } from 'parse-lcov';
 import { AuditOutput, Issue } from '@code-pushup/models';
 import { toNumberPrecision, toOrdinal } from '@code-pushup/utils';
 import { CoverageType } from '../../config';
+import { INVALID_FUNCTION_NAME } from '../constants';
 import { LCOVStat } from './types';
 import { calculateCoverage, mergeConsecutiveNumbers } from './utils';
 
 export function lcovReportToFunctionStat(record: LCOVRecord): LCOVStat {
+  const validRecord = removeEmptyReport(record);
+
   return {
-    totalFound: record.functions.found,
-    totalHit: record.functions.hit,
+    totalFound: validRecord.functions.found,
+    totalHit: validRecord.functions.hit,
     issues:
-      record.functions.hit < record.functions.found
-        ? record.functions.details
+      validRecord.functions.hit < validRecord.functions.found
+        ? validRecord.functions.details
             .filter(detail => !detail.hit)
             .map(
               (detail): Issue => ({
                 message: `Function ${detail.name} is not called in any test case.`,
                 severity: 'error',
                 source: {
-                  file: record.file,
+                  file: validRecord.file,
                   position: { startLine: detail.line },
                 },
               }),
             )
         : [],
+  };
+}
+
+function removeEmptyReport(record: LCOVRecord): LCOVRecord {
+  const validFunctions = record.functions.details.filter(
+    detail => detail.name !== INVALID_FUNCTION_NAME,
+  );
+
+  if (validFunctions.length === record.functions.found) {
+    return record;
+  }
+
+  return {
+    ...record,
+    functions: {
+      details: validFunctions,
+      found: validFunctions.length,
+      hit: validFunctions.reduce(
+        (acc, fn) => acc + (fn.hit != null && fn.hit > 0 ? 1 : 0),
+        0,
+      ),
+    },
   };
 }
 

--- a/packages/plugin-coverage/src/lib/runner/lcov/transform.unit.test.ts
+++ b/packages/plugin-coverage/src/lib/runner/lcov/transform.unit.test.ts
@@ -1,6 +1,7 @@
 import { LCOVRecord } from 'parse-lcov';
 import { describe, it } from 'vitest';
 import type { AuditOutput, Issue } from '@code-pushup/models';
+import { INVALID_FUNCTION_NAME } from '../constants';
 import {
   lcovCoverageToAuditOutput,
   lcovReportToBranchStat,
@@ -91,6 +92,26 @@ describe('lcovReportToFunctionStat', () => {
         ],
       }),
     );
+  });
+
+  it('should skip a record of uncovered invalid function called (empty-report)', () => {
+    expect(
+      lcovReportToFunctionStat({
+        ...lcovRecordMock,
+        functions: {
+          hit: 1,
+          found: 2,
+          details: [
+            { line: 1, name: INVALID_FUNCTION_NAME, hit: 0 },
+            { line: 5, name: 'transform', hit: 4 },
+          ],
+        },
+      }),
+    ).toStrictEqual<LCOVStat>({
+      totalFound: 1,
+      totalHit: 1,
+      issues: [],
+    });
   });
 });
 


### PR DESCRIPTION
Closes #647 

In this PR, I skip missing coverage for functions called `(empty-report)`. They usually point to the first line of a file, an `import` or `export`. Therefore, this seems like an invalid function identification.