### PR TITLE
chore(plugin-coverage): fix path helper for Jest, warn about empty lcov files

### DIFF
--- a/packages/plugin-coverage/src/lib/runner/lcov/lcov-runner.integration.test.ts
+++ b/packages/plugin-coverage/src/lib/runner/lcov/lcov-runner.integration.test.ts
@@ -1,6 +1,6 @@
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { describe, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { osAgnosticAuditOutputs } from '@code-pushup/test-utils';
 import { lcovResultsToAuditOutputs } from './lcov-runner';
 

--- a/packages/plugin-coverage/src/lib/runner/lcov/lcov-runner.unit.test.ts
+++ b/packages/plugin-coverage/src/lib/runner/lcov/lcov-runner.unit.test.ts
@@ -1,0 +1,109 @@
+import { vol } from 'memfs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { getLogMessages } from '@code-pushup/test-utils';
+import { ui } from '@code-pushup/utils';
+import { parseLcovFiles } from './lcov-runner';
+
+describe('parseLcovFiles', () => {
+  const UTILS_REPORT = `
+TN:
+SF:${join('common', 'utils.ts')}
+FNF:0
+FNH:0
+DA:1,1
+DA:2,0
+LF:2
+LH:1
+BRDA:1,0,0,6
+BRF:1
+BRH:1
+end_of_record
+`;
+
+  const CONSTANTS_REPORT = `
+TN:
+SF:${join('src', 'lib', 'constants.ts')}
+FNF:0
+FNH:0
+DA:1,1
+LF:1
+LH:1
+BRF:0
+BRH:0
+end_of_record
+`;
+
+  beforeEach(() => {
+    vol.fromJSON(
+      {
+        [join('integration-tests', 'lcov.info')]: UTILS_REPORT, // file name value under SF used in tests
+        [join('unit-tests', 'lcov.info')]: CONSTANTS_REPORT, // file name value under SF used in tests
+        'lcov.info': '', // empty report file
+      },
+      'coverage',
+    );
+  });
+
+  it('should identify coverage path passed as a string', async () => {
+    await expect(
+      parseLcovFiles([join('coverage', 'integration-tests', 'lcov.info')]),
+    ).resolves.toEqual([
+      expect.objectContaining({ file: join('common', 'utils.ts') }),
+    ]);
+  });
+
+  it('should identify coverage path passed as an object and prepend project path to LCOV report', async () => {
+    await expect(
+      parseLcovFiles([
+        {
+          resultsPath: join('coverage', 'unit-tests', 'lcov.info'),
+          pathToProject: join('packages', 'cli'),
+        },
+      ]),
+    ).resolves.toEqual([
+      expect.objectContaining({
+        file: join('packages', 'cli', 'src', 'lib', 'constants.ts'),
+      }),
+    ]);
+  });
+
+  it('should correctly identify a mix of coverage path formats', async () => {
+    await expect(
+      parseLcovFiles([
+        {
+          resultsPath: join('coverage', 'unit-tests', 'lcov.info'),
+          pathToProject: join('packages', 'cli'),
+        },
+        join('coverage', 'integration-tests', 'lcov.info'),
+      ]),
+    ).resolves.toEqual([
+      expect.objectContaining({
+        file: join('packages', 'cli', 'src', 'lib', 'constants.ts'),
+      }),
+      expect.objectContaining({
+        file: join('common', 'utils.ts'),
+      }),
+    ]);
+  });
+
+  it('should throw for only empty reports', async () => {
+    await expect(() =>
+      parseLcovFiles([join('coverage', 'lcov.info')]),
+    ).rejects.toThrow('All provided results are empty.');
+  });
+
+  it('should warn about an empty lcov file', async () => {
+    await parseLcovFiles([
+      join('coverage', 'integration-tests', 'lcov.info'),
+      join('coverage', 'lcov.info'),
+    ]);
+
+    expect(getLogMessages(ui().logger)[0]).toContain(
+      `Coverage plugin: Empty lcov report file detected at ${join(
+        'coverage',
+        'lcov.info',
+      )}`,
+    );
+  });
+});

--- a/packages/plugin-coverage/vite.config.unit.ts
+++ b/packages/plugin-coverage/vite.config.unit.ts
@@ -22,6 +22,7 @@ export default defineConfig({
     include: ['src/**/*.unit.test.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
     globalSetup: ['../../global-setup.ts'],
     setupFiles: [
+      '../../testing/test-setup/src/lib/cliui.mock.ts',
       '../../testing/test-setup/src/lib/fs.mock.ts',
       '../../testing/test-setup/src/lib/console.mock.ts',
       '../../testing/test-setup/src/lib/reset.mocks.ts',


### PR DESCRIPTION
Closes #536 
Related to https://github.com/code-pushup/cli/pull/604#discussion_r1555497103

In this PR, I make the following changes:
- The nx path helper should now correctly resolve Jest config as commonJS.
- The nx path helper should now only include the project path for Vitest where it is relative and not for Jest.
- I added a warning for empty LCOV files. Unfortunately, since logs from within plugins are not displayed unless the plugin crashes, this will only be visible after #695 
- I unit tested the nx helper and parsing LCOV files (object or string can be passed as a path).