### PR TITLE
fix: round down report scores to avoid misleading perfect results

### DIFF
--- a/packages/utils/src/lib/reports/utils.ts
+++ b/packages/utils/src/lib/reports/utils.ts
@@ -22,7 +22,12 @@ import { ScoredReport, SortableAuditReport, SortableGroup } from './types';
 const { image, bold: boldMd } = md;
 
 export function formatReportScore(score: number): string {
-  return Math.round(score * 100).toString();
+  const scaledScore = score * 100;
+  const roundedScore = Math.round(scaledScore);
+
+  return roundedScore === 100 && score !== 1
+    ? Math.floor(scaledScore).toString()
+    : roundedScore.toString();
 }
 
 export function formatScoreWithColor(

--- a/packages/utils/src/lib/reports/utils.unit.test.ts
+++ b/packages/utils/src/lib/reports/utils.unit.test.ts
@@ -35,7 +35,7 @@ describe('formatReportScore', () => {
     [0.123, '12'],
     [0.99, '99'],
     [0.994, '99'],
-    [0.995, '100'],
+    [0.995, '99'],
     [1, '100'],
   ] satisfies readonly [number, string][])(
     "should format a score of %d as '%s'",


### PR DESCRIPTION
## Description

This PR updates the `formatReportScore` function to refine the way scores are rounded and displayed. 

The function now scales the score by 100 and then checks if the rounded score is 100. If the score is close to, but not actually, a perfect score, it uses `Math.floor` to avoid rounding up to 100.

### Context:
In the portal repository (Issue [#394](https://github.com/code-pushup/portal/issues/394)), it was identified that the rounding method used was causing confusion by displaying near-perfect scores as 100. To maintain consistency and accuracy across projects, the CLI's score formatting function has been updated to address the same issue.