### PR TITLE
chore(plugin-js-packages): stop plugin for non-empty stderr

### DIFF
--- a/packages/plugin-js-packages/README.md
+++ b/packages/plugin-js-packages/README.md
@@ -113,7 +113,7 @@ The plugin accepts the following parameters:
 - `packageManager`: The package manager you are using. Supported values: `npm`, `yarn-classic` (v1), `yarn-modern` (v2+), `pnpm`.
 - (optional) `checks`: Array of checks to be run. Supported commands: `audit`, `outdated`. Both are configured by default.
 - (optional) `dependencyGroups`: Array of dependency groups to be checked. `prod` and `dev` are configured by default. `optional` are opt-in.
-- (optional) `packageJsonPath`: File path to `package.json`. Defaults to current folder. Multiple `package.json` files are currently not supported.
+- (optional) `packageJsonPaths`: File path(s) to `package.json`. Root `package.json` is used by default. Multiple `package.json` paths may be passed. If `{ autoSearch: true }` is provided, all `package.json` files in the repository are searched.
 - (optional) `auditLevelMapping`: If you wish to set a custom level of issue severity based on audit vulnerability level, you may do so here. Any omitted values will be filled in by defaults. Audit levels are: `critical`, `high`, `moderate`, `low` and `info`. Issue severities are: `error`, `warn` and `info`. By default the mapping is as follows: `critical` and `high` → `error`; `moderate` and `low` → `warning`; `info` → `info`.
 
 ### Audits and group

--- a/packages/plugin-js-packages/src/lib/config.ts
+++ b/packages/plugin-js-packages/src/lib/config.ts
@@ -17,6 +17,18 @@ const packageManagerIdSchema = z.enum([
 ]);
 export type PackageManagerId = z.infer<typeof packageManagerIdSchema>;
 
+const packageJsonPathSchema = z
+  .union([
+    z.array(z.string()).min(1),
+    z.object({ autoSearch: z.literal(true) }),
+  ])
+  .describe(
+    'File paths to package.json. Looks only at root package.json by default',
+  )
+  .default(['package.json']);
+
+export type PackageJsonPaths = z.infer<typeof packageJsonPathSchema>;
+
 export const packageAuditLevels = [
   'critical',
   'high',
@@ -63,10 +75,7 @@ export const jsPackagesPluginConfigSchema = z.object({
     })
     .default(defaultAuditLevelMapping)
     .transform(fillAuditLevelMapping),
-  packageJsonPath: z
-    .string()
-    .describe('File path to package.json. Defaults to current folder.')
-    .default('package.json'),
+  packageJsonPaths: packageJsonPathSchema,
 });
 
 export type JSPackagesPluginConfig = z.input<

--- a/packages/plugin-js-packages/src/lib/config.unit.test.ts
+++ b/packages/plugin-js-packages/src/lib/config.unit.test.ts
@@ -15,7 +15,7 @@ describe('jsPackagesPluginConfigSchema', () => {
         checks: ['audit'],
         packageManager: 'yarn-classic',
         dependencyGroups: ['prod'],
-        packageJsonPath: './ui-app/package.json',
+        packageJsonPaths: ['./ui-app/package.json', './ui-e2e/package.json'],
       } satisfies JSPackagesPluginConfig),
     ).not.toThrow();
   });
@@ -36,7 +36,7 @@ describe('jsPackagesPluginConfigSchema', () => {
       checks: ['audit', 'outdated'],
       packageManager: 'npm',
       dependencyGroups: ['prod', 'dev'],
-      packageJsonPath: 'package.json',
+      packageJsonPaths: ['package.json'],
       auditLevelMapping: {
         critical: 'error',
         high: 'error',
@@ -45,6 +45,15 @@ describe('jsPackagesPluginConfigSchema', () => {
         info: 'info',
       },
     });
+  });
+
+  it('should accept auto search for package.json files', () => {
+    expect(() =>
+      jsPackagesPluginConfigSchema.parse({
+        packageManager: 'yarn-classic',
+        packageJsonPaths: { autoSearch: true },
+      } satisfies JSPackagesPluginConfig),
+    ).not.toThrow();
   });
 
   it('should throw for no passed commands', () => {

--- a/packages/plugin-js-packages/src/lib/runner/index.ts
+++ b/packages/plugin-js-packages/src/lib/runner/index.ts
@@ -67,12 +67,17 @@ async function processOutdated(
   packageJsonPaths: PackageJsonPaths,
 ) {
   const pm = packageManagers[id];
-  const { stdout } = await executeProcess({
+  const { stdout, stderr } = await executeProcess({
     command: pm.command,
     args: pm.outdated.commandArgs,
     cwd: process.cwd(),
     ignoreExitCode: true, // outdated returns exit code 1 when outdated dependencies are found
   });
+
+  // Successful outdated check has empty stderr
+  if (stderr) {
+    throw new Error(`JS packages plugin: outdated error: ${stderr}`);
+  }
 
   // Locate all package.json files in the repository if not provided
   const finalPaths = Array.isArray(packageJsonPaths)
@@ -106,12 +111,16 @@ async function processAudit(
   const auditResults = await Promise.allSettled(
     compatibleAuditDepGroups.map(
       async (depGroup): Promise<[DependencyGroup, AuditResult]> => {
-        const { stdout } = await executeProcess({
+        const { stdout, stderr } = await executeProcess({
           command: pm.command,
           args: pm.audit.getCommandArgs(depGroup),
           cwd: process.cwd(),
           ignoreExitCode: pm.audit.ignoreExitCode,
         });
+        // Successful audit check has empty stderr
+        if (stderr) {
+          throw new Error(`JS packages plugin: audit error: ${stderr}`);
+        }
         return [depGroup, pm.audit.unifyResult(stdout)];
       },
     ),

--- a/packages/plugin-js-packages/src/lib/runner/outdated/types.ts
+++ b/packages/plugin-js-packages/src/lib/runner/outdated/types.ts
@@ -12,6 +12,7 @@ type PackageJsonDependencies = Record<string, string>;
 export type PackageJson = Partial<
   Record<DependencyGroupLong, PackageJsonDependencies>
 >;
+export type DependencyTotals = Record<DependencyGroupLong, number>;
 
 // Unified Outdated result type
 export type OutdatedDependency = {

--- a/packages/plugin-js-packages/src/lib/runner/runner.integration.test.ts
+++ b/packages/plugin-js-packages/src/lib/runner/runner.integration.test.ts
@@ -13,7 +13,7 @@ describe('createRunnerConfig', () => {
       checks: ['audit'],
       auditLevelMapping: defaultAuditLevelMapping,
       dependencyGroups: ['prod', 'dev'],
-      packageJsonPath: 'package.json',
+      packageJsonPaths: ['package.json'],
     });
     expect(runnerConfig).toStrictEqual<RunnerConfig>({
       command: 'node',
@@ -29,7 +29,7 @@ describe('createRunnerConfig', () => {
       checks: ['outdated'],
       dependencyGroups: ['prod', 'dev'],
       auditLevelMapping: { ...defaultAuditLevelMapping, moderate: 'error' },
-      packageJsonPath: 'package.json',
+      packageJsonPaths: ['package.json'],
     };
     await createRunnerConfig('executeRunner.ts', pluginConfig);
     const config = await readJsonFile<FinalJSPackagesPluginConfig>(

--- a/packages/plugin-js-packages/src/lib/runner/utils.unit.test.ts
+++ b/packages/plugin-js-packages/src/lib/runner/utils.unit.test.ts
@@ -2,10 +2,36 @@ import { vol } from 'memfs';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { MEMFS_VOLUME } from '@code-pushup/test-utils';
-import { DependencyGroup } from '../config';
 import { AuditResult, Vulnerability } from './audit/types';
-import { PackageJson } from './outdated/types';
-import { filterAuditResult, getTotalDependencies } from './utils';
+import { DependencyTotals, PackageJson } from './outdated/types';
+import {
+  filterAuditResult,
+  findAllPackageJson,
+  getTotalDependencies,
+} from './utils';
+
+describe('findAllPackageJson', () => {
+  beforeEach(() => {
+    vol.fromJSON(
+      {
+        'package.json': '',
+        [join('ui', 'package.json')]: '',
+        [join('ui', 'ng-package.json')]: '', // non-exact file match should be excluded
+        [join('.nx', 'cache', 'ui', 'package.json')]: '', // nx cache should be excluded
+        [join('node_modules', 'eslint', 'package.json')]: '', // root node_modules should be excluded
+        [join('ui', 'node_modules', 'eslint', 'package.json')]: '', // project node_modules should be excluded
+      },
+      MEMFS_VOLUME,
+    );
+  });
+
+  it('should return all valid package.json files (exclude .nx, node_modules)', async () => {
+    await expect(findAllPackageJson()).resolves.toEqual([
+      'package.json',
+      join('ui', 'package.json'),
+    ]);
+  });
+});
 
 describe('getTotalDependencies', () => {
   beforeEach(() => {
@@ -19,6 +45,18 @@ describe('getTotalDependencies', () => {
             vitest: '1.3.1',
           },
         } satisfies PackageJson),
+        [join('ui', 'package.json')]: JSON.stringify({
+          dependencies: {
+            '@code-pushup/eslint-config': '1.0.0',
+            '@typescript-eslint/eslint-plugin': '2.0.0',
+          },
+          devDependencies: {
+            angular: '17.0.0',
+          },
+          optionalDependencies: {
+            '@esbuild/darwin-arm64': '^0.19.0',
+          },
+        } satisfies PackageJson),
       },
       MEMFS_VOLUME,
     );
@@ -26,12 +64,25 @@ describe('getTotalDependencies', () => {
 
   it('should return correct number of dependencies', async () => {
     await expect(
-      getTotalDependencies(join(MEMFS_VOLUME, 'package.json')),
+      getTotalDependencies([join(MEMFS_VOLUME, 'package.json')]),
     ).resolves.toStrictEqual({
-      prod: 1,
-      dev: 3,
-      optional: 0,
-    } satisfies Record<DependencyGroup, number>);
+      dependencies: 1,
+      devDependencies: 3,
+      optionalDependencies: 0,
+    } satisfies DependencyTotals);
+  });
+
+  it('should merge dependencies for multiple package.json files', async () => {
+    await expect(
+      getTotalDependencies([
+        join(MEMFS_VOLUME, 'package.json'),
+        join(MEMFS_VOLUME, 'ui', 'package.json'),
+      ]),
+    ).resolves.toStrictEqual({
+      dependencies: 2,
+      devDependencies: 4,
+      optionalDependencies: 1,
+    } satisfies DependencyTotals);
   });
 });
 


### PR DESCRIPTION
Closes #666

In this PR, I implement the following changes:
- When `stderr` is not empty for `audit` or `outdated`, plugin throws and prints the `stderr`.
- `package.json` search is implemented: By default, only root `package.json` is used. An array of multiple `package.json` files may be explicitly provided. There is also an `autoSearch` option which merges all dependencies across all `package.json` files in the repository excluding cache and `node_modules`.


## Details
### Audit
All package managers seem to have empty `stderr` for a successful audit. Not sure about deprecated behaviour.
- `npm` and `pnpm` successfully perform audit even when there are out-of-sync issues.
- `yarn-classic` throws an error for out of sync.
- `yarn-modern` reports errors into `stdout` (?!) when there are dependencies out of sync.

### Outdated
All package managers seem to have empty `stderr` for a successful outdated check. Not sure about deprecated behaviour.
- `npm`, `pnpm` and `yarn-modern` successfully perform outdated check even when there are out-of-sync issues.
- `yarn-classic` throws an error for out of sync.