### PR TITLE
feat(plugin-lighthouse): add logLevel to lighthouse runner flags

### DIFF
--- a/code-pushup.config.ts
+++ b/code-pushup.config.ts
@@ -80,6 +80,7 @@ const config: CoreConfig = {
 
     await lighthousePlugin('https://codepushup.dev/', {
       chromeFlags: DEFAULT_FLAGS.concat(['--headless']),
+      verbose: true,
     }),
   ],
 

--- a/packages/plugin-lighthouse/src/lib/normalize-flags.unit.test.ts
+++ b/packages/plugin-lighthouse/src/lib/normalize-flags.unit.test.ts
@@ -45,7 +45,6 @@ describe('logUnsupportedFlagsInUse', () => {
 describe('normalizeFlags', () => {
   const normalizedDefaults = {
     verbose: false,
-    quiet: false,
     saveAssets: false,
     // needed to pass CI on linux and windows (locally it works without headless too)
     chromeFlags: ['--headless=shell'],
@@ -54,6 +53,7 @@ describe('normalizeFlags', () => {
     view: false,
     channel: 'cli',
     // custom overwrites in favour of the plugin
+    quiet: true,
     onlyAudits: [],
     skipAudits: [],
     onlyCategories: [],

--- a/packages/plugin-lighthouse/src/lib/runner/constants.ts
+++ b/packages/plugin-lighthouse/src/lib/runner/constants.ts
@@ -88,7 +88,6 @@ export const DEFAULT_CLI_FLAGS = {
   // default values extracted from
   // https://github.com/GoogleChrome/lighthouse/blob/7d80178c37a1b600ea8f092fc0b098029799a659/cli/cli-flags.js#L80
   verbose: false,
-  quiet: false,
   saveAssets: false,
   // needed to pass CI on linux and windows (locally it works without headless too)
   chromeFlags: ['--headless=shell'],
@@ -97,6 +96,8 @@ export const DEFAULT_CLI_FLAGS = {
   view: false,
   channel: 'cli',
   // custom overwrites in favour of the plugin
+  // hide logs by default
+  quiet: true,
   onlyAudits: [],
   skipAudits: [],
   onlyCategories: [],

--- a/packages/plugin-lighthouse/src/lib/runner/runner.ts
+++ b/packages/plugin-lighthouse/src/lib/runner/runner.ts
@@ -6,9 +6,9 @@ import { ensureDirectoryExists } from '@code-pushup/utils';
 import { DEFAULT_CLI_FLAGS } from './constants';
 import { LighthouseCliFlags } from './types';
 import {
+  determineAndSetLogLevel,
   getConfig,
   normalizeAuditOutputs,
-  setLogLevel,
   toAuditOutputs,
 } from './utils';
 
@@ -24,7 +24,7 @@ export function createRunnerFunction(
       ...parsedFlags
     }: Partial<LighthouseCliFlags> = flags;
 
-    setLogLevel(parsedFlags);
+    const logLevel = determineAndSetLogLevel(parsedFlags);
 
     const config = await getConfig({ configPath, preset });
     if (outputPath) {
@@ -33,6 +33,7 @@ export function createRunnerFunction(
 
     const enrichedFlags = {
       ...parsedFlags,
+      logLevel,
       outputPath,
     };
 

--- a/packages/plugin-lighthouse/src/lib/runner/utils.ts
+++ b/packages/plugin-lighthouse/src/lib/runner/utils.ts
@@ -101,21 +101,32 @@ export function logUnsupportedDetails(
   }
 }
 
-export function setLogLevel({
+export type LighthouseLogLevel =
+  | 'verbose'
+  | 'error'
+  | 'info'
+  | 'silent'
+  | 'warn'
+  | undefined;
+export function determineAndSetLogLevel({
   verbose,
   quiet,
 }: {
   verbose?: boolean;
   quiet?: boolean;
-} = {}) {
+} = {}): LighthouseLogLevel {
+  // eslint-disable-next-line functional/no-let
+  let logLevel: LighthouseLogLevel = 'info';
   // set logging preferences
   if (verbose) {
-    log.setLevel('verbose');
+    logLevel = 'verbose';
   } else if (quiet) {
-    log.setLevel('silent');
-  } else {
-    log.setLevel('info');
+    logLevel = 'silent';
   }
+
+  log.setLevel(logLevel);
+
+  return logLevel;
 }
 
 export type ConfigOptions = Partial<

--- a/packages/plugin-lighthouse/src/lib/runner/utils.unit.test.ts
+++ b/packages/plugin-lighthouse/src/lib/runner/utils.unit.test.ts
@@ -10,9 +10,9 @@ import { CoreConfig, auditOutputsSchema } from '@code-pushup/models';
 import { MEMFS_VOLUME, getLogMessages } from '@code-pushup/test-utils';
 import { ui } from '@code-pushup/utils';
 import {
+  determineAndSetLogLevel,
   getConfig,
   logUnsupportedDetails,
-  setLogLevel,
   toAuditOutputs,
   unsupportedDetailTypes,
 } from './utils';
@@ -415,7 +415,7 @@ describe('getConfig', () => {
   });
 });
 
-describe('setLogLevel', () => {
+describe('determineAndSetLogLevel', () => {
   const debugLib = debug as { enabled: (flag: string) => boolean };
   beforeEach(() => {
     log.setLevel('info');
@@ -439,30 +439,32 @@ describe('setLogLevel', () => {
    *    debug.enable('LH:*, -LH:*:verbose');
    */
 
-  it('should set log level to info if no options are given', () => {
-    setLogLevel();
+  it('should set log level to info and return "info" as level if no options are given', () => {
+    expect(determineAndSetLogLevel()).toBe('info');
     expect(log.isVerbose()).toBe(false);
     expect(debugLib.enabled('LH:*')).toBe(true);
     expect(debugLib.enabled('LH:*:verbose')).toBe(false);
   });
 
-  it('should set log level to verbose', () => {
-    setLogLevel({ verbose: true });
+  it('should set log level to verbose and return "verbose" as level', () => {
+    expect(determineAndSetLogLevel({ verbose: true })).toBe('verbose');
     expect(log.isVerbose()).toBe(true);
     expect(debugLib.enabled('LH:*')).toBe(true);
     expect(debugLib.enabled('LH:*:verbose')).toBe(false);
   });
 
-  it('should set log level to quiet', () => {
-    setLogLevel({ quiet: true });
+  it('should set log level to quiet and return "silent" as level', () => {
+    expect(determineAndSetLogLevel({ quiet: true })).toBe('silent');
     expect(log.isVerbose()).toBe(false);
     expect(debugLib.enabled('LH:*')).toBe(true);
     expect(debugLib.enabled('-LH:*')).toBe(true);
     expect(debugLib.enabled('LH:*:verbose')).toBe(false);
   });
 
-  it('should set log level to verbose if verbose and quiet are given', () => {
-    setLogLevel({ verbose: true, quiet: true });
+  it('should set log level to verbose if verbose and quiet are given and return "verbose" as level', () => {
+    expect(determineAndSetLogLevel({ verbose: true, quiet: true })).toBe(
+      'verbose',
+    );
     expect(log.isVerbose()).toBe(true);
     expect(debugLib.enabled('LH:*')).toBe(true);
     expect(debugLib.enabled('LH:*:verbose')).toBe(false);


### PR DESCRIPTION
This PR is part of #695 


It includes:
- set and forward logLevel in `plugin-lighthouse` runner
- set lighthouse CLI flag `quiet` to `true` by default (hide logs by default)
- adopt and rename setLoglevel function
- extend unit-tests
- use new implementation to display logs in the CI