### PR TITLE
fix(plugin-coverage): handle different Jest/Vitest config scenarios in Nx helper

### DIFF
--- a/e2e/cli-e2e/project.json
+++ b/e2e/cli-e2e/project.json
@@ -14,7 +14,7 @@
     "e2e": {
       "executor": "@nx/vite:test",
       "options": {
-        "config": "e2e/cli-e2e/vite.config.e2e.ts"
+        "configFile": "e2e/cli-e2e/vite.config.e2e.ts"
       }
     }
   },

--- a/e2e/nx-plugin-e2e/project.json
+++ b/e2e/nx-plugin-e2e/project.json
@@ -14,7 +14,7 @@
     "e2e": {
       "executor": "@nx/vite:test",
       "options": {
-        "config": "e2e/nx-plugin-e2e/vite.config.e2e.ts"
+        "configFile": "e2e/nx-plugin-e2e/vite.config.e2e.ts"
       }
     }
   },

--- a/examples/plugins/project.json
+++ b/examples/plugins/project.json
@@ -26,7 +26,7 @@
       "executor": "@nx/vite:test",
       "outputs": ["{options.reportsDirectory}"],
       "options": {
-        "config": "examples/plugins/vite.config.unit.ts",
+        "configFile": "examples/plugins/vite.config.unit.ts",
         "reportsDirectory": "../../coverage/examples-plugins/unit-tests"
       }
     },
@@ -34,7 +34,7 @@
       "executor": "@nx/vite:test",
       "outputs": ["{options.reportsDirectory}"],
       "options": {
-        "config": "examples/plugins/vite.config.integration.ts",
+        "configFile": "examples/plugins/vite.config.integration.ts",
         "reportsDirectory": "../../coverage/examples-plugins/integration-tests"
       }
     },

--- a/examples/react-todos-app/project.json
+++ b/examples/react-todos-app/project.json
@@ -41,7 +41,7 @@
       "executor": "@nx/vite:test",
       "outputs": ["{options.reportsDirectory}"],
       "options": {
-        "config": "examples/react-todos-app/vite.config.ts",
+        "configFile": "examples/react-todos-app/vite.config.ts",
         "reportsDirectory": "../../coverage/react-todos-app"
       }
     },

--- a/packages/cli/project.json
+++ b/packages/cli/project.json
@@ -32,13 +32,13 @@
     "unit-test": {
       "executor": "@nx/vite:test",
       "options": {
-        "config": "packages/cli/vite.config.unit.ts"
+        "configFile": "packages/cli/vite.config.unit.ts"
       }
     },
     "integration-test": {
       "executor": "@nx/vite:test",
       "options": {
-        "config": "packages/cli/vite.config.integration.ts"
+        "configFile": "packages/cli/vite.config.integration.ts"
       }
     },
     "run-help": {

--- a/packages/core/project.json
+++ b/packages/core/project.json
@@ -32,13 +32,13 @@
     "unit-test": {
       "executor": "@nx/vite:test",
       "options": {
-        "config": "packages/core/vite.config.unit.ts"
+        "configFile": "packages/core/vite.config.unit.ts"
       }
     },
     "integration-test": {
       "executor": "@nx/vite:test",
       "options": {
-        "config": "packages/core/vite.config.integration.ts"
+        "configFile": "packages/core/vite.config.integration.ts"
       }
     }
   },

--- a/packages/core/src/lib/implementation/read-rc-file.ts
+++ b/packages/core/src/lib/implementation/read-rc-file.ts
@@ -5,7 +5,7 @@ import {
   SUPPORTED_CONFIG_FILE_FORMATS,
   coreConfigSchema,
 } from '@code-pushup/models';
-import { fileExists, importEsmModule } from '@code-pushup/utils';
+import { fileExists, importModule } from '@code-pushup/utils';
 
 export class ConfigPathError extends Error {
   constructor(configPath: string) {
@@ -25,7 +25,7 @@ export async function readRcByPath(
     throw new ConfigPathError(filepath);
   }
 
-  const cfg = await importEsmModule({ filepath, tsconfig });
+  const cfg = await importModule({ filepath, tsconfig, format: 'esm' });
 
   return coreConfigSchema.parse(cfg);
 }

--- a/packages/models/project.json
+++ b/packages/models/project.json
@@ -32,13 +32,13 @@
     "unit-test": {
       "executor": "@nx/vite:test",
       "options": {
-        "config": "packages/models/vite.config.unit.ts"
+        "configFile": "packages/models/vite.config.unit.ts"
       }
     },
     "integration-test": {
       "executor": "@nx/vite:test",
       "options": {
-        "config": "packages/models/vite.config.integration.ts"
+        "configFile": "packages/models/vite.config.integration.ts"
       }
     },
     "generate-docs": {

--- a/packages/nx-plugin/project.json
+++ b/packages/nx-plugin/project.json
@@ -54,13 +54,13 @@
     "unit-test": {
       "executor": "@nx/vite:test",
       "options": {
-        "config": "packages/nx-plugin/vite.config.unit.ts"
+        "configFile": "packages/nx-plugin/vite.config.unit.ts"
       }
     },
     "integration-test": {
       "executor": "@nx/vite:test",
       "options": {
-        "config": "packages/nx-plugin/vite.config.integration.ts"
+        "configFile": "packages/nx-plugin/vite.config.integration.ts"
       }
     }
   },

--- a/packages/plugin-coverage/package.json
+++ b/packages/plugin-coverage/package.json
@@ -9,10 +9,18 @@
     "zod": "^3.22.4"
   },
   "peerDependencies": {
-    "@nx/devkit": "^17.0.0 || ^18.0.0 || ^19.0.0"
+    "@nx/devkit": "^17.0.0 || ^18.0.0 || ^19.0.0",
+    "@nx/jest": "^17.0.0 || ^18.0.0 || ^19.0.0",
+    "@nx/vite": "^17.0.0 || ^18.0.0 || ^19.0.0"
   },
   "peerDependenciesMeta": {
     "@nx/devkit": {
+      "optional": true
+    },
+    "@nx/jest": {
+      "optional": true
+    },
+    "@nx/vite": {
       "optional": true
     }
   }

--- a/packages/plugin-coverage/project.json
+++ b/packages/plugin-coverage/project.json
@@ -29,13 +29,13 @@
     "unit-test": {
       "executor": "@nx/vite:test",
       "options": {
-        "config": "packages/plugin-coverage/vite.config.unit.ts"
+        "configFile": "packages/plugin-coverage/vite.config.unit.ts"
       }
     },
     "integration-test": {
       "executor": "@nx/vite:test",
       "options": {
-        "config": "packages/plugin-coverage/vite.config.integration.ts"
+        "configFile": "packages/plugin-coverage/vite.config.integration.ts"
       }
     },
     "publish": {

--- a/packages/plugin-coverage/src/lib/nx/coverage-paths.ts
+++ b/packages/plugin-coverage/src/lib/nx/coverage-paths.ts
@@ -165,16 +165,14 @@ export async function getCoveragePathForJest(
 ) {
   const { jestConfig } = options;
 
-  const { coverageDirectory, coverageReporters } =
-    options.coverageDirectory && options.coverageReporters
-      ? options // skip import if both overrides available
-      : {
-          ...(await importEsmModule<JestCoverageConfig>({
-            filepath: jestConfig,
-            format: 'cjs',
-          })),
-          ...options,
-        };
+  const testConfig = await importEsmModule<JestCoverageConfig>({
+    filepath: jestConfig,
+    format: 'cjs',
+  });
+  const { coverageDirectory, coverageReporters } = {
+    ...testConfig,
+    ...options,
+  };
 
   if (coverageDirectory == null) {
     throw new Error(
@@ -182,7 +180,7 @@ export async function getCoveragePathForJest(
     );
   }
 
-  if (!coverageReporters?.includes('lcov')) {
+  if (!coverageReporters?.includes('lcov') && !('preset' in testConfig)) {
     throw new Error(
       `Jest coverage configuration at ${jestConfig} does not include LCOV report format for target ${target} in ${project.name}. Add 'lcov' format under coverageReporters.`,
     );

--- a/packages/plugin-coverage/src/lib/nx/coverage-paths.ts
+++ b/packages/plugin-coverage/src/lib/nx/coverage-paths.ts
@@ -8,7 +8,7 @@ import type { JestExecutorOptions } from '@nx/jest/src/executors/jest/schema';
 import type { VitestExecutorOptions } from '@nx/vite/executors';
 import chalk from 'chalk';
 import { isAbsolute, join } from 'node:path';
-import { importEsmModule, ui } from '@code-pushup/utils';
+import { importModule, ui } from '@code-pushup/utils';
 import { CoverageResult } from '../config';
 
 /**
@@ -128,7 +128,7 @@ export async function getCoveragePathForVitest(
     );
   }
 
-  const vitestConfig = await importEsmModule<VitestCoverageConfig>({
+  const vitestConfig = await importModule<VitestCoverageConfig>({
     filepath: config,
     format: 'esm',
   });
@@ -165,9 +165,8 @@ export async function getCoveragePathForJest(
 ) {
   const { jestConfig } = options;
 
-  const testConfig = await importEsmModule<JestCoverageConfig>({
+  const testConfig = await importModule<JestCoverageConfig>({
     filepath: jestConfig,
-    format: 'cjs',
   });
   const { coverageDirectory, coverageReporters } = {
     ...testConfig,

--- a/packages/plugin-coverage/src/lib/nx/coverage-paths.ts
+++ b/packages/plugin-coverage/src/lib/nx/coverage-paths.ts
@@ -1,5 +1,11 @@
 /// <reference types="vitest" />
-import type { ProjectGraphProjectNode, TargetConfiguration } from '@nx/devkit';
+import type {
+  ProjectConfiguration,
+  ProjectGraphProjectNode,
+  Tree,
+} from '@nx/devkit';
+import type { JestExecutorOptions } from '@nx/jest/src/executors/jest/schema';
+import type { VitestExecutorOptions } from '@nx/vite/executors';
 import chalk from 'chalk';
 import { join } from 'node:path';
 import { importEsmModule, ui } from '@code-pushup/utils';
@@ -30,13 +36,7 @@ export async function getNxCoveragePaths(
 
       return await Promise.all(
         relevantNodes.map<Promise<CoverageResult>>(async ({ name, data }) => {
-          const targetConfig = data.targets?.[target] as TargetConfiguration;
-          const coveragePaths = await getCoveragePathsForTarget(
-            targetConfig,
-            data.root,
-            `${target} in ${name}`,
-          );
-
+          const coveragePaths = await getCoveragePathsForTarget(data, target);
           if (verbose) {
             ui().logger.info(`- ${name}: ${target}`);
           }
@@ -75,78 +75,114 @@ export type JestCoverageConfig = {
 };
 
 export async function getCoveragePathsForTarget(
-  targetConfig: TargetConfiguration,
-  pathToRoot: string,
-  targetContext: string,
+  project: ProjectConfiguration,
+  target: string,
 ): Promise<CoverageResult> {
-  const { config } = targetConfig.options as { config: string };
+  const targetConfig = project.targets?.[target];
+
+  if (!targetConfig) {
+    throw new Error(
+      `No configuration found for target ${target} in project ${project.name}`,
+    );
+  }
 
   if (targetConfig.executor?.includes('@nx/vite')) {
-    return await getCoveragePathForVitest(config, pathToRoot, targetContext);
+    return getCoveragePathForVitest(
+      targetConfig.options as VitestExecutorOptions,
+      project,
+      target,
+    );
   }
 
   if (targetConfig.executor?.includes('@nx/jest')) {
-    return await getCoveragePathForJest(config, pathToRoot, targetContext);
+    return getCoveragePathForJest(
+      targetConfig.options as JestExecutorOptions,
+      project,
+      target,
+    );
   }
 
   throw new Error(
-    `Unsupported executor ${targetConfig.executor}. @nx/vite and @nx/jest are currently supported.`,
+    `Unsupported executor ${targetConfig.executor}. Only @nx/vite and @nx/jest are currently supported.`,
   );
 }
 
 export async function getCoveragePathForVitest(
-  pathToConfig: string,
-  pathToRoot: string,
-  context: string,
+  options: VitestExecutorOptions,
+  project: ProjectConfiguration,
+  target: string,
 ) {
+  const {
+    default: { normalizeViteConfigFilePathWithTree },
+  } = await import('@nx/vite');
+  const config = normalizeViteConfigFilePathWithTree(
+    // HACK: only tree.exists is called, so injecting existSync from node:fs instead
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions, n/no-sync
+    { exists: (await import('node:fs')).existsSync } as Tree,
+    project.root,
+    options.configFile,
+  );
+  if (!config) {
+    throw new Error(
+      `Could not find Vitest config file for target ${target} in project ${project.name}`,
+    );
+  }
+
   const vitestConfig = await importEsmModule<VitestCoverageConfig>({
-    filepath: pathToConfig,
+    filepath: config,
     format: 'esm',
   });
 
-  const reportsDirectory = vitestConfig.test.coverage?.reportsDirectory;
+  const reportsDirectory =
+    options.reportsDirectory ?? vitestConfig.test.coverage?.reportsDirectory;
   const reporter = vitestConfig.test.coverage?.reporter;
 
   if (reportsDirectory == null) {
     throw new Error(
-      `Vitest coverage configuration at ${pathToConfig} does not include coverage path for target ${context}. Add the path under coverage > reportsDirectory.`,
+      `Vitest coverage configuration at ${config} does not include coverage path for target ${target} in project ${project.name}. Add the path under coverage > reportsDirectory.`,
     );
   }
 
   if (!reporter?.includes('lcov')) {
     throw new Error(
-      `Vitest coverage configuration at ${pathToConfig} does not include LCOV report format for target ${context}. Add 'lcov' format under coverage > reporter.`,
+      `Vitest coverage configuration at ${config} does not include LCOV report format for target ${target} in project ${project.name}. Add 'lcov' format under coverage > reporter.`,
     );
   }
 
   return {
-    pathToProject: pathToRoot,
-    resultsPath: join(pathToRoot, reportsDirectory, 'lcov.info'),
+    pathToProject: project.root,
+    resultsPath: join(project.root, reportsDirectory, 'lcov.info'),
   };
 }
 
 export async function getCoveragePathForJest(
-  pathToConfig: string,
-  pathToRoot: string,
-  context: string,
+  options: JestExecutorOptions,
+  project: ProjectConfiguration,
+  target: string,
 ) {
-  const testConfig = await importEsmModule<JestCoverageConfig>({
-    filepath: pathToConfig,
-    format: 'cjs',
-  });
+  const { jestConfig } = options;
 
-  const coverageDirectory = testConfig.coverageDirectory;
+  const { coverageDirectory, coverageReporters } =
+    options.coverageDirectory && options.coverageReporters
+      ? options // skip import if both overrides available
+      : {
+          ...(await importEsmModule<JestCoverageConfig>({
+            filepath: jestConfig,
+            format: 'cjs',
+          })),
+          ...options,
+        };
 
   if (coverageDirectory == null) {
     throw new Error(
-      `Jest coverage configuration at ${pathToConfig} does not include coverage path for target ${context}. Add the path under coverageDirectory.`,
+      `Jest coverage configuration at ${jestConfig} does not include coverage path for target ${target} in ${project.name}. Add the path under coverageDirectory.`,
     );
   }
 
-  if (!testConfig.coverageReporters?.includes('lcov')) {
+  if (!coverageReporters?.includes('lcov')) {
     throw new Error(
-      `Jest coverage configuration at ${pathToConfig} does not include LCOV report format for target ${context}. Add 'lcov' format under coverageReporters.`,
+      `Jest coverage configuration at ${jestConfig} does not include LCOV report format for target ${target} in ${project.name}. Add 'lcov' format under coverageReporters.`,
     );
   }
-  return join(pathToRoot, coverageDirectory, 'lcov.info');
+  return join(project.root, coverageDirectory, 'lcov.info');
 }

--- a/packages/plugin-coverage/src/lib/nx/coverage-paths.ts
+++ b/packages/plugin-coverage/src/lib/nx/coverage-paths.ts
@@ -7,7 +7,7 @@ import type {
 import type { JestExecutorOptions } from '@nx/jest/src/executors/jest/schema';
 import type { VitestExecutorOptions } from '@nx/vite/executors';
 import chalk from 'chalk';
-import { join } from 'node:path';
+import { isAbsolute, join } from 'node:path';
 import { importEsmModule, ui } from '@code-pushup/utils';
 import { CoverageResult } from '../config';
 
@@ -149,6 +149,9 @@ export async function getCoveragePathForVitest(
     );
   }
 
+  if (isAbsolute(reportsDirectory)) {
+    return join(reportsDirectory, 'lcov.info');
+  }
   return {
     pathToProject: project.root,
     resultsPath: join(project.root, reportsDirectory, 'lcov.info'),
@@ -183,6 +186,10 @@ export async function getCoveragePathForJest(
     throw new Error(
       `Jest coverage configuration at ${jestConfig} does not include LCOV report format for target ${target} in ${project.name}. Add 'lcov' format under coverageReporters.`,
     );
+  }
+
+  if (isAbsolute(coverageDirectory)) {
+    return join(coverageDirectory, 'lcov.info');
   }
   return join(project.root, coverageDirectory, 'lcov.info');
 }

--- a/packages/plugin-coverage/src/lib/nx/coverage-paths.unit.test.ts
+++ b/packages/plugin-coverage/src/lib/nx/coverage-paths.unit.test.ts
@@ -51,6 +51,11 @@ vi.mock('bundle-require', () => ({
       coverageDirectory: 'coverage',
     };
 
+    const JEST_PRESET: JestCoverageConfig & { preset?: string } = {
+      preset: '../../jest.preset.ts',
+      coverageDirectory: 'coverage',
+    };
+
     const wrapReturnValue = (
       value: VitestCoverageConfig | JestCoverageConfig,
     ) => ({ mod: { default: value } });
@@ -69,6 +74,8 @@ vi.mock('bundle-require', () => ({
         return wrapReturnValue(JEST_NO_LCOV);
       case 'jest-no-dir':
         return wrapReturnValue(JEST_NO_DIR);
+      case 'jest-preset':
+        return wrapReturnValue(JEST_PRESET);
       default:
         return wrapReturnValue({});
     }
@@ -325,6 +332,29 @@ describe('getCoveragePathForJest', () => {
         'integration-test',
       ),
     ).rejects.toThrow(/configuration .* does not include LCOV report format/);
+  });
+
+  it('should not throw if lcov reporter in both project.json and jest config', async () => {
+    await expect(
+      getCoveragePathForJest(
+        {
+          jestConfig: 'jest-valid.config.integration.ts',
+          coverageReporters: ['lcov'],
+        },
+        { name: 'core', root: join('packages', 'core') },
+        'integration-test',
+      ),
+    ).resolves.toBeTypeOf('string');
+  });
+
+  it('should not throw regarding missing lcov reporter if jest config uses preset', async () => {
+    await expect(
+      getCoveragePathForJest(
+        { jestConfig: 'jest-preset.config.ts' },
+        { name: 'core', root: join('packages', 'core') },
+        'test',
+      ),
+    ).resolves.toBeTypeOf('string');
   });
 
   it('should handle absolute path in coverageDirectory', async () => {

--- a/packages/plugin-coverage/src/lib/nx/coverage-paths.unit.test.ts
+++ b/packages/plugin-coverage/src/lib/nx/coverage-paths.unit.test.ts
@@ -219,6 +219,21 @@ describe('getCoveragePathForVitest', () => {
       ),
     ).rejects.toThrow(/configuration .* does not include LCOV report format/);
   });
+
+  it('should handle absolute path in reportsDirectory', async () => {
+    await expect(
+      getCoveragePathForVitest(
+        {
+          configFile: 'vitest-valid.config.unit.ts',
+          reportsDirectory: join(process.cwd(), 'coverage', 'packages', 'cli'),
+        },
+        { name: 'cli', root: join('packages', 'cli') },
+        'unit-test',
+      ),
+    ).resolves.toBe(
+      join(process.cwd(), 'coverage', 'packages', 'cli', 'lcov.info'),
+    );
+  });
 });
 
 describe('getCoveragePathForJest', () => {
@@ -310,5 +325,20 @@ describe('getCoveragePathForJest', () => {
         'integration-test',
       ),
     ).rejects.toThrow(/configuration .* does not include LCOV report format/);
+  });
+
+  it('should handle absolute path in coverageDirectory', async () => {
+    await expect(
+      getCoveragePathForJest(
+        {
+          jestConfig: 'jest-valid.config.unit.ts',
+          coverageDirectory: join(process.cwd(), 'coverage', 'packages', 'cli'),
+        },
+        { name: 'cli', root: join('packages', 'cli') },
+        'unit-test',
+      ),
+    ).resolves.toBe(
+      join(process.cwd(), 'coverage', 'packages', 'cli', 'lcov.info'),
+    );
   });
 });

--- a/packages/plugin-eslint/project.json
+++ b/packages/plugin-eslint/project.json
@@ -33,13 +33,13 @@
     "unit-test": {
       "executor": "@nx/vite:test",
       "options": {
-        "config": "packages/plugin-eslint/vite.config.unit.ts"
+        "configFile": "packages/plugin-eslint/vite.config.unit.ts"
       }
     },
     "integration-test": {
       "executor": "@nx/vite:test",
       "options": {
-        "config": "packages/plugin-eslint/vite.config.integration.ts"
+        "configFile": "packages/plugin-eslint/vite.config.integration.ts"
       }
     }
   },

--- a/packages/plugin-js-packages/project.json
+++ b/packages/plugin-js-packages/project.json
@@ -29,13 +29,13 @@
     "unit-test": {
       "executor": "@nx/vite:test",
       "options": {
-        "config": "packages/plugin-js-packages/vite.config.unit.ts"
+        "configFile": "packages/plugin-js-packages/vite.config.unit.ts"
       }
     },
     "integration-test": {
       "executor": "@nx/vite:test",
       "options": {
-        "config": "packages/plugin-js-packages/vite.config.integration.ts"
+        "configFile": "packages/plugin-js-packages/vite.config.integration.ts"
       }
     },
     "publish": {

--- a/packages/plugin-lighthouse/project.json
+++ b/packages/plugin-lighthouse/project.json
@@ -28,13 +28,13 @@
     "unit-test": {
       "executor": "@nx/vite:test",
       "options": {
-        "config": "packages/plugin-lighthouse/vite.config.unit.ts"
+        "configFile": "packages/plugin-lighthouse/vite.config.unit.ts"
       }
     },
     "integration-test": {
       "executor": "@nx/vite:test",
       "options": {
-        "config": "packages/plugin-lighthouse/vite.config.integration.ts"
+        "configFile": "packages/plugin-lighthouse/vite.config.integration.ts"
       }
     }
   },

--- a/packages/plugin-lighthouse/src/lib/runner/utils.ts
+++ b/packages/plugin-lighthouse/src/lib/runner/utils.ts
@@ -6,7 +6,7 @@ import experimentalConfig from 'lighthouse/core/config/experimental-config.js';
 import perfConfig from 'lighthouse/core/config/perf-config.js';
 import { Result } from 'lighthouse/types/lhr/audit-result';
 import { AuditOutput, AuditOutputs } from '@code-pushup/models';
-import { importEsmModule, readJsonFile, ui } from '@code-pushup/utils';
+import { importModule, readJsonFile, ui } from '@code-pushup/utils';
 import type { LighthouseOptions } from '../types';
 import { logUnsupportedDetails, toAuditDetails } from './details/details';
 import { LighthouseCliFlags } from './types';
@@ -126,7 +126,7 @@ export async function getConfig(
       // Resolve the config file path relative to where cli was called.
       return readJsonFile<Config>(filepath);
     } else if (/\.(ts|js|mjs)$/.test(filepath)) {
-      return importEsmModule<Config>({ filepath });
+      return importModule<Config>({ filepath, format: 'esm' });
     } else {
       ui().logger.info(`Format of file ${filepath} not supported`);
     }

--- a/packages/utils/mocks/fixtures/valid-cjs-module-export.cjs
+++ b/packages/utils/mocks/fixtures/valid-cjs-module-export.cjs
@@ -1,0 +1,1 @@
+module.exports = 'valid-cjs-module-export';

--- a/packages/utils/project.json
+++ b/packages/utils/project.json
@@ -44,13 +44,13 @@
     "unit-test": {
       "executor": "@nx/vite:test",
       "options": {
-        "config": "packages/utils/vite.config.unit.ts"
+        "configFile": "packages/utils/vite.config.unit.ts"
       }
     },
     "integration-test": {
       "executor": "@nx/vite:test",
       "options": {
-        "config": "packages/utils/vite.config.integration.ts"
+        "configFile": "packages/utils/vite.config.integration.ts"
       }
     }
   },

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -17,7 +17,7 @@ export {
   fileExists,
   filePathToCliArg,
   findLineNumberInText,
-  importEsmModule,
+  importModule,
   logMultipleFileResults,
   pluginWorkDir,
   readJsonFile,

--- a/packages/utils/src/lib/file-system.integration.test.ts
+++ b/packages/utils/src/lib/file-system.integration.test.ts
@@ -1,31 +1,41 @@
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { importEsmModule } from './file-system';
+import { importModule } from './file-system';
 
-describe('importEsmModule', () => {
+describe('importModule', () => {
   const mockDir = join(process.cwd(), 'packages', 'utils', 'mocks', 'fixtures');
 
   it('should load a valid ES module', async () => {
     await expect(
-      importEsmModule({
+      importModule({
         filepath: join(mockDir, 'valid-es-module-export.mjs'),
       }),
     ).resolves.toBe('valid-es-module-export');
   });
 
+  it('should load a valid CommonJS module', async () => {
+    await expect(
+      importModule({
+        filepath: join(mockDir, 'valid-cjs-module-export.cjs'),
+      }),
+    ).resolves.toBe('valid-cjs-module-export');
+  });
+
+  it('should load an ES module without default export', async () => {
+    await expect(
+      importModule({
+        filepath: join(mockDir, 'no-default-export.mjs'),
+      }),
+    ).resolves.toEqual(
+      expect.objectContaining({ exportedVar: 'exported-variable' }),
+    );
+  });
+
   it('should throw if the file does not exist', async () => {
     await expect(
-      importEsmModule({
+      importModule({
         filepath: 'path/to/non-existent-export.mjs',
       }),
     ).rejects.toThrow('non-existent-export.mjs');
-  });
-
-  it('should throw if the file does not have any default export', async () => {
-    await expect(
-      importEsmModule({
-        filepath: join(mockDir, 'no-default-export.mjs'),
-      }),
-    ).rejects.toThrow('No default export found');
   });
 });

--- a/packages/utils/src/lib/file-system.ts
+++ b/packages/utils/src/lib/file-system.ts
@@ -75,24 +75,13 @@ export function logMultipleFileResults(
   );
 }
 
-export class NoExportError extends Error {
-  constructor(filepath: string) {
-    super(`No default export found in ${filepath}`);
-  }
-}
+export async function importModule<T = unknown>(options: Options): Promise<T> {
+  const { mod } = await bundleRequire<object>(options);
 
-export async function importEsmModule<T = unknown>(
-  options: Options,
-): Promise<T> {
-  const { mod } = await bundleRequire<object>({
-    format: 'esm',
-    ...options,
-  });
-
-  if (!('default' in mod)) {
-    throw new NoExportError(options.filepath);
+  if (typeof mod === 'object' && 'default' in mod) {
+    return mod.default as T;
   }
-  return mod.default as T;
+  return mod as T;
 }
 
 export function pluginWorkDir(slug: string): string {

--- a/testing/test-utils/project.json
+++ b/testing/test-utils/project.json
@@ -25,7 +25,7 @@
     "unit-test": {
       "executor": "@nx/vite:test",
       "options": {
-        "config": "testing/test-utils/vite.config.unit.ts"
+        "configFile": "testing/test-utils/vite.config.unit.ts"
       }
     }
   },


### PR DESCRIPTION
Fixes:
- #716
- #728 
- #727 
- #726 

All of these fixes are needed for integrating coverage plugin in portal.