### PR TITLE
feat(utils): merge configs function

### DIFF
--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -58,6 +58,7 @@ export {
 } from './lib/guards';
 export { logMultipleResults } from './lib/log-results';
 export { CliUi, Column, link, ui } from './lib/logging';
+export { mergeConfigs } from './lib/merge-configs';
 export { ProgressBar, getProgressBar } from './lib/progress';
 export {
   CODE_PUSHUP_DOMAIN,

--- a/packages/utils/src/lib/merge-configs.ts
+++ b/packages/utils/src/lib/merge-configs.ts
@@ -1,0 +1,229 @@
+import {
+  CategoryConfig,
+  CoreConfig,
+  Group,
+  GroupRef,
+  PersistConfig,
+  PluginConfig,
+  UploadConfig,
+} from '@code-pushup/models';
+
+export function mergeConfigs(
+  config: CoreConfig,
+  ...configs: Partial<CoreConfig>[]
+) {
+  return configs.reduce(
+    (acc, obj) => ({
+      ...acc,
+      ...mergeCategories(acc.categories, obj.categories),
+      ...mergePlugins(acc.plugins, obj.plugins),
+      ...mergePersist(acc.persist, obj.persist),
+      ...mergeUpload(acc.upload, obj.upload),
+    }),
+    config,
+  );
+}
+
+function mergeCategories(
+  a: CategoryConfig[] | undefined,
+  b: CategoryConfig[] | undefined,
+) {
+  if (!a && !b) {
+    return {};
+  }
+
+  const mergedMap = new Map<string, CategoryConfig>();
+
+  const addToMap = (categories: CategoryConfig[]) => {
+    categories.forEach(newObject => {
+      if (mergedMap.has(newObject.slug)) {
+        const existingObject: CategoryConfig | undefined = mergedMap.get(
+          newObject.slug,
+        );
+
+        mergedMap.set(newObject.slug, {
+          ...existingObject,
+          ...newObject,
+
+          refs: mergeBySlugs(existingObject?.refs, newObject.refs),
+        });
+      } else {
+        mergedMap.set(newObject.slug, newObject);
+      }
+    });
+  };
+
+  if (a) {
+    addToMap(a);
+  }
+  if (b) {
+    addToMap(b);
+  }
+
+  // Convert the map back to an array
+  return { categories: [...mergedMap.values()] };
+}
+
+function mergePlugins(
+  a: PluginConfig[] | undefined,
+  b: PluginConfig[] | undefined,
+) {
+  if (!a && !b) {
+    return {};
+  }
+
+  const mergedMap = new Map<string, PluginConfig>();
+
+  const addToMap = (plugins: PluginConfig[]) => {
+    plugins.forEach(newObject => {
+      if (mergedMap.has(newObject.slug)) {
+        const existingObject: PluginConfig | undefined = mergedMap.get(
+          newObject.slug,
+        );
+
+        mergedMap.set(newObject.slug, {
+          ...existingObject,
+          ...newObject,
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+          ...(newObject.audits && {
+            audits: mergeBySlugs(existingObject?.audits, newObject.audits),
+          }),
+          ...((existingObject?.groups ?? newObject.groups) && {
+            groups: mergeGroupsBySlugs(
+              existingObject?.groups,
+              newObject.groups,
+            ),
+          }),
+        });
+      } else {
+        mergedMap.set(newObject.slug, newObject);
+      }
+    });
+  };
+
+  if (a) {
+    addToMap(a);
+  }
+  if (b) {
+    addToMap(b);
+  }
+
+  return { plugins: [...mergedMap.values()] };
+}
+
+function mergeGroupRefsBySlugs<T extends GroupRef>(
+  a: T[] | undefined,
+  b: T[] | undefined,
+) {
+  const map = new Map<string, T>();
+
+  const addToMap = (groups: T[]) => {
+    groups.forEach(group => {
+      if (map.has(group.slug)) {
+        map.set(group.slug, { ...map.get(group.slug), ...group });
+      } else {
+        map.set(group.slug, group);
+      }
+    });
+  };
+
+  // Add objects from both arrays to the map
+  if (a) {
+    addToMap(a);
+  }
+  if (b) {
+    addToMap(b);
+  }
+
+  return [...map.values()];
+}
+
+function mergeGroupsBySlugs<T extends Group>(
+  a: T[] | undefined,
+  b: T[] | undefined,
+) {
+  const map = new Map<string, T>();
+
+  const addToMap = (groups: T[]) => {
+    groups.forEach(newGroup => {
+      const existingGroup: Group | undefined = map.get(newGroup.slug);
+
+      if (map.has(newGroup.slug)) {
+        map.set(newGroup.slug, {
+          ...map.get(newGroup.slug),
+          ...newGroup,
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+          ...(newGroup.refs && {
+            refs: mergeGroupRefsBySlugs(existingGroup?.refs, newGroup.refs),
+          }),
+        });
+      } else {
+        map.set(newGroup.slug, newGroup);
+      }
+    });
+  };
+
+  // Add objects from both arrays to the map
+  if (a) {
+    addToMap(a);
+  }
+  if (b) {
+    addToMap(b);
+  }
+
+  return [...map.values()];
+}
+
+function mergePersist(
+  a: PersistConfig | undefined,
+  b: PersistConfig | undefined,
+) {
+  if (!a && !b) {
+    return {};
+  }
+
+  if (a) {
+    return b ? { persist: { ...a, ...b } } : {};
+  } else {
+    return { persist: b };
+  }
+}
+
+function mergeBySlugs<T extends { slug: string }>(
+  a: T[] | undefined,
+  b: T[] | undefined,
+) {
+  const map = new Map<string, T>();
+
+  const addToMap = (refs: T[]) => {
+    refs.forEach(ref => {
+      if (map.has(ref.slug)) {
+        map.set(ref.slug, { ...map.get(ref.slug), ...ref });
+      } else {
+        map.set(ref.slug, ref);
+      }
+    });
+  };
+
+  // Add objects from both arrays to the map
+  if (a) {
+    addToMap(a);
+  }
+  if (b) {
+    addToMap(b);
+  }
+
+  return [...map.values()];
+}
+
+function mergeUpload(a: UploadConfig | undefined, b: UploadConfig | undefined) {
+  if (!a && !b) {
+    return {};
+  }
+
+  if (a) {
+    return b ? { upload: { ...a, ...b } } : {};
+  } else {
+    return { upload: b };
+  }
+}

--- a/packages/utils/src/lib/merge-configs.ts
+++ b/packages/utils/src/lib/merge-configs.ts
@@ -11,7 +11,7 @@ import {
 export function mergeConfigs(
   config: CoreConfig,
   ...configs: Partial<CoreConfig>[]
-) {
+): Partial<CoreConfig> {
   return configs.reduce(
     (acc, obj) => ({
       ...acc,
@@ -27,7 +27,7 @@ export function mergeConfigs(
 function mergeCategories(
   a: CategoryConfig[] | undefined,
   b: CategoryConfig[] | undefined,
-) {
+): Pick<CoreConfig, 'categories'> {
   if (!a && !b) {
     return {};
   }
@@ -67,9 +67,9 @@ function mergeCategories(
 function mergePlugins(
   a: PluginConfig[] | undefined,
   b: PluginConfig[] | undefined,
-) {
+): Pick<CoreConfig, 'plugins'> {
   if (!a && !b) {
-    return {};
+    return { plugins: [] };
   }
 
   const mergedMap = new Map<string, PluginConfig>();
@@ -114,7 +114,7 @@ function mergePlugins(
 function mergeGroupRefsBySlugs<T extends GroupRef>(
   a: T[] | undefined,
   b: T[] | undefined,
-) {
+): T[] {
   const map = new Map<string, T>();
 
   const addToMap = (groups: T[]) => {
@@ -177,7 +177,7 @@ function mergeGroupsBySlugs<T extends Group>(
 function mergePersist(
   a: PersistConfig | undefined,
   b: PersistConfig | undefined,
-) {
+): Pick<CoreConfig, 'persist'> {
   if (!a && !b) {
     return {};
   }
@@ -216,7 +216,10 @@ function mergeBySlugs<T extends { slug: string }>(
   return [...map.values()];
 }
 
-function mergeUpload(a: UploadConfig | undefined, b: UploadConfig | undefined) {
+function mergeUpload(
+  a: UploadConfig | undefined,
+  b: UploadConfig | undefined,
+): Pick<CoreConfig, 'upload'> {
   if (!a && !b) {
     return {};
   }

--- a/packages/utils/src/lib/merge-configs.unit.test.ts
+++ b/packages/utils/src/lib/merge-configs.unit.test.ts
@@ -198,6 +198,13 @@ describe('mergeObjects', () => {
     });
   });
 
+  it('should append upload config to plugins configs', () => {
+    expect(mergeConfigs(MOCK_UPLOAD_CONFIG, MOCK_CONFIG_FULL_ESLINT)).toEqual({
+      ...MOCK_UPLOAD_CONFIG,
+      ...MOCK_CONFIG_FULL_ESLINT,
+    });
+  });
+
   it('should replace API key in upload config', () => {
     expect(
       mergeConfigs(MOCK_UPLOAD_CONFIG, {

--- a/packages/utils/src/lib/merge-configs.unit.test.ts
+++ b/packages/utils/src/lib/merge-configs.unit.test.ts
@@ -1,0 +1,404 @@
+import { describe, expect, it } from 'vitest';
+import { CoreConfig, PluginConfig } from '@code-pushup/models';
+import { mergeConfigs } from './merge-configs';
+
+const MOCK_CONFIG_PERSIST = {
+  persist: {
+    outputDir: '.code-pushup/packages/app',
+    format: ['json', 'md'],
+  },
+} as CoreConfig;
+
+const MOCK_JUST_ESLINT_PLUGIN = {
+  slug: 'eslint',
+  title: 'ESLint',
+  icon: 'eslint',
+  description: 'Mock Code PushUp ESLint plugin',
+  docsUrl: 'https://www.npmjs.com/package/@code-pushup/eslint-plugin',
+  packageName: '@code-pushup/eslint-plugin',
+  version: '0.0.0',
+
+  audits: [
+    {
+      slug: 'no-const-assign',
+      title: 'Disallow reassigning `const` variables',
+      description: 'ESLint rule **no-const-assign**.',
+      docsUrl: 'https://eslint.org/docs/latest/rules/no-const-assign',
+    },
+    {
+      slug: 'no-debugger',
+      title: 'Disallow the use of `debugger`',
+      description: 'ESLint rule **no-debugger**.',
+      docsUrl: 'https://eslint.org/docs/latest/rules/no-debugger',
+    },
+  ],
+
+  groups: [
+    {
+      slug: 'problems',
+      title: 'Problems',
+      description:
+        'Code that either will cause an error or may cause confusing behavior.',
+      refs: [
+        { slug: 'no-const-assign', weight: 1 },
+        { slug: 'no-debugger', weight: 1 },
+      ],
+    },
+  ],
+
+  runner: {
+    command: 'node',
+    args: ['bin.js'],
+    outputFile: 'node_modules/.code-pushup/runner-output.json',
+  },
+} as const satisfies PluginConfig;
+
+const MOCK_CONFIG_FULL_ESLINT: CoreConfig = {
+  plugins: [MOCK_JUST_ESLINT_PLUGIN],
+};
+
+const MOCK_CONFIG_NX_VALIDATORS: CoreConfig = {
+  plugins: [{ slug: 'my-plugin' } as PluginConfig],
+  categories: [
+    {
+      slug: 'nx-validators',
+      title: 'Workspace Validation',
+      refs: [],
+    },
+  ],
+};
+
+const MOCK_CONFIG_BASIC_PLUGIN: CoreConfig = {
+  plugins: [{ slug: 'basic-plugin' } as PluginConfig],
+  categories: [
+    {
+      slug: 'bug-prevention',
+      title: 'Bug prevention',
+      refs: [
+        { type: 'group', plugin: 'basic-plugin', slug: 'problems', weight: 1 },
+      ],
+    },
+    {
+      slug: 'code-style',
+      title: 'Code style',
+      refs: [
+        {
+          type: 'group',
+          plugin: 'basic-plugin',
+          slug: 'suggestions',
+          weight: 1,
+        },
+      ],
+    },
+  ],
+};
+
+const MOCK_UPLOAD_CONFIG = {
+  upload: {
+    server: 'https://portal:80/graphql',
+    apiKey: 'cp_apiKey',
+    organization: 'entain',
+    project: 'fe-monorepo',
+  },
+} as CoreConfig;
+
+describe('mergeObjects', () => {
+  it('should merge nx-validators plugin into empty config', () => {
+    expect(mergeConfigs({} as CoreConfig, MOCK_CONFIG_NX_VALIDATORS)).toEqual({
+      plugins: [{ slug: 'my-plugin' } as PluginConfig],
+      categories: [
+        {
+          slug: 'nx-validators',
+          title: 'Workspace Validation',
+          refs: [],
+        },
+      ],
+    });
+  });
+
+  it('should merge nx-validators plugin into persist config', () => {
+    expect(
+      mergeConfigs(MOCK_CONFIG_PERSIST, MOCK_CONFIG_NX_VALIDATORS),
+    ).toEqual({ ...MOCK_CONFIG_PERSIST, ...MOCK_CONFIG_NX_VALIDATORS });
+  });
+
+  it('should merge eslint plugin into config with configured nx-validators plugin', () => {
+    expect(
+      mergeConfigs(
+        MOCK_CONFIG_PERSIST,
+        MOCK_CONFIG_NX_VALIDATORS,
+        MOCK_CONFIG_BASIC_PLUGIN,
+      ),
+    ).toEqual({
+      persist: {
+        outputDir: '.code-pushup/packages/app',
+        format: ['json', 'md'],
+      },
+      plugins: [
+        { slug: 'my-plugin' } as PluginConfig,
+        { slug: 'basic-plugin' } as PluginConfig,
+      ],
+      categories: [
+        {
+          slug: 'nx-validators',
+          title: 'Workspace Validation',
+          refs: [],
+        },
+        {
+          slug: 'bug-prevention',
+          title: 'Bug prevention',
+          refs: [
+            {
+              type: 'group',
+              plugin: 'basic-plugin',
+              slug: 'problems',
+              weight: 1,
+            },
+          ],
+        },
+        {
+          slug: 'code-style',
+          title: 'Code style',
+          refs: [
+            {
+              type: 'group',
+              plugin: 'basic-plugin',
+              slug: 'suggestions',
+              weight: 1,
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it('should merge add upload to config', () => {
+    expect(
+      mergeConfigs(
+        MOCK_CONFIG_PERSIST,
+        MOCK_CONFIG_BASIC_PLUGIN,
+        MOCK_UPLOAD_CONFIG,
+      ),
+    ).toEqual({
+      ...MOCK_CONFIG_PERSIST,
+      ...MOCK_CONFIG_BASIC_PLUGIN,
+      ...MOCK_UPLOAD_CONFIG,
+    });
+  });
+
+  it('should merge upload configs', () => {
+    expect(
+      mergeConfigs(
+        { upload: { timeout: 10_000 } } as CoreConfig,
+        MOCK_UPLOAD_CONFIG,
+      ),
+    ).toEqual({ upload: { ...MOCK_UPLOAD_CONFIG.upload, timeout: 10_000 } });
+  });
+
+  it('should replace API key in upload config', () => {
+    expect(
+      mergeConfigs(MOCK_UPLOAD_CONFIG, {
+        upload: { apiKey: 'my-new-api-key' },
+      } as CoreConfig),
+    ).toEqual({
+      upload: { ...MOCK_UPLOAD_CONFIG.upload, apiKey: 'my-new-api-key' },
+    });
+  });
+
+  it('should merge configs and keep only the last persist config', () => {
+    expect(
+      mergeConfigs(
+        MOCK_CONFIG_NX_VALIDATORS,
+        {
+          persist: {
+            outputDir: '.code-pushup/some-app',
+            format: ['md'],
+          },
+        } as CoreConfig,
+        MOCK_CONFIG_PERSIST,
+      ),
+    ).toEqual({ ...MOCK_CONFIG_PERSIST, ...MOCK_CONFIG_NX_VALIDATORS });
+  });
+
+  it('should change a description of plugin audit config', () => {
+    expect(
+      mergeConfigs(MOCK_CONFIG_FULL_ESLINT, {
+        plugins: [
+          {
+            slug: 'eslint',
+            audits: [
+              {
+                slug: 'no-const-assign',
+                description: 'Do not touch the constants',
+              },
+            ],
+          },
+        ],
+      } as CoreConfig),
+    ).toEqual({
+      plugins: [
+        {
+          ...MOCK_JUST_ESLINT_PLUGIN,
+          audits: [
+            {
+              ...MOCK_JUST_ESLINT_PLUGIN.audits[0],
+              description: 'Do not touch the constants',
+            },
+            MOCK_JUST_ESLINT_PLUGIN.audits[1],
+          ],
+        },
+      ],
+    });
+  });
+
+  it('should change a weight of plugin groups config', () => {
+    expect(
+      mergeConfigs(
+        MOCK_CONFIG_FULL_ESLINT,
+        {
+          plugins: [
+            {
+              slug: 'eslint',
+              groups: [
+                {
+                  slug: 'problems',
+                  refs: [{ slug: 'no-const-assign', weight: 2 }],
+                },
+              ],
+            },
+          ],
+        } as CoreConfig,
+        MOCK_CONFIG_PERSIST,
+      ),
+    ).toEqual({
+      ...MOCK_CONFIG_PERSIST,
+      plugins: [
+        {
+          ...MOCK_JUST_ESLINT_PLUGIN,
+          groups: [
+            {
+              ...MOCK_JUST_ESLINT_PLUGIN.groups[0],
+              refs: [
+                {
+                  ...MOCK_JUST_ESLINT_PLUGIN.groups[0].refs[0],
+                  weight: 2,
+                },
+                MOCK_JUST_ESLINT_PLUGIN.groups[0].refs[1],
+              ],
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it('should merge same plugin configurations', () => {
+    expect(
+      mergeConfigs(MOCK_CONFIG_FULL_ESLINT, {
+        plugins: [
+          {
+            slug: 'eslint',
+            description: 'Mock Code PushUp ESLint plugin',
+            packageName: '@code-pushup/mock-eslint-plugin',
+            version: '1.0.0',
+          },
+        ],
+      } as CoreConfig),
+    ).toEqual({
+      plugins: [
+        {
+          ...MOCK_JUST_ESLINT_PLUGIN,
+          description: 'Mock Code PushUp ESLint plugin',
+          packageName: '@code-pushup/mock-eslint-plugin',
+          version: '1.0.0',
+        },
+      ],
+    });
+  });
+
+  it('should merge category ref config', () => {
+    expect(
+      mergeConfigs(MOCK_CONFIG_NX_VALIDATORS, MOCK_CONFIG_BASIC_PLUGIN, {
+        plugins: [
+          { slug: 'my-plugin' } as PluginConfig,
+          { slug: 'basic-plugin' } as PluginConfig,
+        ],
+        categories: [
+          {
+            slug: 'nx-validators',
+            title: 'Workspace Validation',
+            refs: [
+              {
+                type: 'group',
+                plugin: 'my-plugin',
+                slug: 'suggestions',
+                weight: 1,
+              },
+            ],
+          },
+          {
+            slug: 'code-style',
+            title: 'Code style',
+            refs: [
+              {
+                type: 'group',
+                plugin: 'basic-plugin',
+                slug: 'formatting',
+                weight: 1,
+              },
+            ],
+          },
+        ],
+      }),
+    ).toEqual({
+      plugins: [
+        { slug: 'my-plugin' } as PluginConfig,
+        { slug: 'basic-plugin' } as PluginConfig,
+      ],
+      categories: [
+        {
+          slug: 'nx-validators',
+          title: 'Workspace Validation',
+          refs: [
+            {
+              type: 'group',
+              plugin: 'my-plugin',
+              slug: 'suggestions',
+              weight: 1,
+            },
+          ],
+        },
+        {
+          slug: 'bug-prevention',
+          title: 'Bug prevention',
+          refs: [
+            {
+              type: 'group',
+              plugin: 'basic-plugin',
+              slug: 'problems',
+              weight: 1,
+            },
+          ],
+        },
+        {
+          slug: 'code-style',
+          title: 'Code style',
+          refs: [
+            {
+              type: 'group',
+              plugin: 'basic-plugin',
+              slug: 'suggestions',
+              weight: 1,
+            },
+            {
+              type: 'group',
+              plugin: 'basic-plugin',
+              slug: 'formatting',
+              weight: 1,
+            },
+          ],
+        },
+      ],
+    });
+  });
+});

--- a/packages/utils/src/lib/merge-configs.unit.test.ts
+++ b/packages/utils/src/lib/merge-configs.unit.test.ts
@@ -231,102 +231,6 @@ describe('mergeObjects', () => {
     ).toEqual({ ...MOCK_CONFIG_PERSIST, ...MOCK_CONFIG_NX_VALIDATORS });
   });
 
-  it('should change a description of plugin audit config', () => {
-    expect(
-      mergeConfigs(MOCK_CONFIG_FULL_ESLINT, {
-        plugins: [
-          {
-            slug: 'eslint',
-            audits: [
-              {
-                slug: 'no-const-assign',
-                description: 'Do not touch the constants',
-              },
-            ],
-          },
-        ],
-      } as CoreConfig),
-    ).toEqual({
-      plugins: [
-        {
-          ...MOCK_JUST_ESLINT_PLUGIN,
-          audits: [
-            {
-              ...MOCK_JUST_ESLINT_PLUGIN.audits[0],
-              description: 'Do not touch the constants',
-            },
-            MOCK_JUST_ESLINT_PLUGIN.audits[1],
-          ],
-        },
-      ],
-    });
-  });
-
-  it('should change a weight of plugin groups config', () => {
-    expect(
-      mergeConfigs(
-        MOCK_CONFIG_FULL_ESLINT,
-        {
-          plugins: [
-            {
-              slug: 'eslint',
-              groups: [
-                {
-                  slug: 'problems',
-                  refs: [{ slug: 'no-const-assign', weight: 2 }],
-                },
-              ],
-            },
-          ],
-        } as CoreConfig,
-        MOCK_CONFIG_PERSIST,
-      ),
-    ).toEqual({
-      ...MOCK_CONFIG_PERSIST,
-      plugins: [
-        {
-          ...MOCK_JUST_ESLINT_PLUGIN,
-          groups: [
-            {
-              ...MOCK_JUST_ESLINT_PLUGIN.groups[0],
-              refs: [
-                {
-                  ...MOCK_JUST_ESLINT_PLUGIN.groups[0].refs[0],
-                  weight: 2,
-                },
-                MOCK_JUST_ESLINT_PLUGIN.groups[0].refs[1],
-              ],
-            },
-          ],
-        },
-      ],
-    });
-  });
-
-  it('should merge same plugin configurations', () => {
-    expect(
-      mergeConfigs(MOCK_CONFIG_FULL_ESLINT, {
-        plugins: [
-          {
-            slug: 'eslint',
-            description: 'Mock Code PushUp ESLint plugin',
-            packageName: '@code-pushup/mock-eslint-plugin',
-            version: '1.0.0',
-          },
-        ],
-      } as CoreConfig),
-    ).toEqual({
-      plugins: [
-        {
-          ...MOCK_JUST_ESLINT_PLUGIN,
-          description: 'Mock Code PushUp ESLint plugin',
-          packageName: '@code-pushup/mock-eslint-plugin',
-          version: '1.0.0',
-        },
-      ],
-    });
-  });
-
   it('should merge category ref config', () => {
     expect(
       mergeConfigs(MOCK_CONFIG_NX_VALIDATORS, MOCK_CONFIG_BASIC_PLUGIN, {
@@ -355,6 +259,12 @@ describe('mergeObjects', () => {
                 type: 'group',
                 plugin: 'basic-plugin',
                 slug: 'formatting',
+                weight: 1,
+              },
+              {
+                type: 'group',
+                plugin: 'some-other-plugin',
+                slug: 'suggestions',
                 weight: 1,
               },
             ],
@@ -405,6 +315,12 @@ describe('mergeObjects', () => {
               type: 'group',
               plugin: 'basic-plugin',
               slug: 'formatting',
+              weight: 1,
+            },
+            {
+              type: 'group',
+              plugin: 'some-other-plugin',
+              slug: 'suggestions',
               weight: 1,
             },
           ],

--- a/packages/utils/src/lib/merge-configs.unit.test.ts
+++ b/packages/utils/src/lib/merge-configs.unit.test.ts
@@ -192,7 +192,10 @@ describe('mergeObjects', () => {
         { upload: { timeout: 10_000 } } as CoreConfig,
         MOCK_UPLOAD_CONFIG,
       ),
-    ).toEqual({ upload: { ...MOCK_UPLOAD_CONFIG.upload, timeout: 10_000 } });
+    ).toEqual({
+      plugins: [],
+      upload: { ...MOCK_UPLOAD_CONFIG.upload, timeout: 10_000 },
+    });
   });
 
   it('should replace API key in upload config', () => {
@@ -201,6 +204,7 @@ describe('mergeObjects', () => {
         upload: { apiKey: 'my-new-api-key' },
       } as CoreConfig),
     ).toEqual({
+      plugins: [],
       upload: { ...MOCK_UPLOAD_CONFIG.upload, apiKey: 'my-new-api-key' },
     });
   });


### PR DESCRIPTION
Introducing a helper function to deep merge config objects.

Implemented:
- [x] Deep merge arrays with respect to the `slug` field
- [x] Merging of empty (partial) configs supported
- [x] Comprehensive tests

Could be used in https://github.com/code-pushup/cli/pull/706 to support extraction & simplify configs