### PR TITLE
test(cli-e2e): fix E2E tests after --skipPlugins option added

### DIFF
--- a/e2e/cli-e2e/tests/__snapshots__/help.e2e.test.ts.snap
+++ b/e2e/cli-e2e/tests/__snapshots__/help.e2e.test.ts.snap
@@ -23,6 +23,8 @@ Global Options:
                       file.                                             [string]
       --onlyPlugins  List of plugins to run. If not set all plugins are run.
                                                            [array] [default: []]
+      --skipPlugins  List of plugins to skip. If not set all plugins are run.
+                                                           [array] [default: []]
 
 Persist Options:
       --persist.outputDir  Directory for the produced reports           [string]
@@ -47,6 +49,9 @@ Examples:
   code-pushup collect --onlyPlugins=covera  Run collect with only coverage plugi
   ge                                        n, other plugins from config file wi
                                             ll be skipped.
+  code-pushup collect --skipPlugins=covera  Run collect skiping the coverage plu
+  ge                                        gin, other plugins from config file
+                                            will be included.
   code-pushup upload --persist.outputDir=d  Upload dist/cp-report.json to portal
   ist --persist.filename=cp-report --uploa   using API key from environment vari
   d.apiKey=$CP_API_KEY                      able

--- a/e2e/cli-e2e/tests/print-config.e2e.test.ts
+++ b/e2e/cli-e2e/tests/print-config.e2e.test.ts
@@ -14,7 +14,6 @@ describe('print-config', () => {
         command: 'code-pushup',
         args: [
           'print-config',
-          '--verbose',
           '--no-progress',
           `--config=${configFilePath(ext)}`,
           '--tsconfig=tsconfig.base.json',
@@ -46,17 +45,12 @@ describe('print-config', () => {
             server: 'https://e2e.com/api',
           },
           plugins: [
-            expect.objectContaining({ slug: 'eslint', title: 'ESLint' }),
             expect.objectContaining({
               slug: 'coverage',
               title: 'Code coverage',
             }),
           ],
-          categories: [
-            expect.objectContaining({ slug: 'bug-prevention' }),
-            expect.objectContaining({ slug: 'code-style' }),
-            expect.objectContaining({ slug: 'code-coverage' }),
-          ],
+          categories: [expect.objectContaining({ slug: 'code-coverage' })],
           onlyPlugins: ['coverage'],
           skipPlugins: ['eslint'],
         }),

--- a/packages/cli/src/lib/implementation/validate-plugin-filter-options.utils.ts
+++ b/packages/cli/src/lib/implementation/validate-plugin-filter-options.utils.ts
@@ -40,12 +40,12 @@ export function validatePluginFilterOption(
     );
   }
 
-  if (categories.length > 0) {
-    const removedCategorieSlugs = filterItemRefsBy(categories, ({ plugin }) =>
+  if (categories.length > 0 && verbose) {
+    const removedCategorySlugs = filterItemRefsBy(categories, ({ plugin }) =>
       filterFunction(plugin),
     ).map(({ slug }) => slug);
     ui().logger.info(
-      `The --${filterOption} argument removed categories with "${removedCategorieSlugs.join(
+      `The --${filterOption} argument removed categories with "${removedCategorySlugs.join(
         '", "',
       )}" slugs.
     `,


### PR DESCRIPTION
- Fixes [failing E2E tests](https://github.com/code-pushup/cli/actions/runs/9887801155/job/27310310532) after #730 was merged.
- Will look into how we can get GitHub Actions to trigger CI workflow for PRs from forks, and also skip Code PushUp upload ([fails due to missing secrets](https://github.com/code-pushup/cli/actions/runs/9830652625/job/27222815753)).