### PR TITLE
ci: fix workflow triggers for forks

### DIFF
--- a/.github/workflows/assign-pr-author.yml
+++ b/.github/workflows/assign-pr-author.yml
@@ -1,7 +1,7 @@
 name: Assign PR author
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened]
 
 jobs:
@@ -13,7 +13,6 @@ jobs:
       - name: Assign PR author
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             github.rest.issues.addAssignees({
               issue_number: context.issue.number,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: CI
 
-on: push
+on:
+  push:
+  pull_request:
+    branches: [main]
 
 env:
   NX_NON_NATIVE_HASHER: true

--- a/.github/workflows/code-pushup-fork.yml
+++ b/.github/workflows/code-pushup-fork.yml
@@ -1,9 +1,7 @@
-name: Code PushUp
+name: Code PushUp (fork)
 
 on:
-  push:
-    branches: [main]
-  pull_request:
+  pull_request_target:
     branches: [main]
 
 env:
@@ -16,12 +14,7 @@ jobs:
   code-pushup:
     runs-on: ubuntu-latest
     name: Code PushUp
-    if: github.repository_owner == 'code-pushup'
-    env:
-      CP_SERVER: ${{ secrets.CP_SERVER }}
-      CP_API_KEY: ${{ secrets.CP_API_KEY }}
-      CP_ORGANIZATION: code-pushup
-      CP_PROJECT: cli
+    if: github.repository_owner != 'code-pushup'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/code-pushup-fork.yml
+++ b/.github/workflows/code-pushup-fork.yml
@@ -14,7 +14,7 @@ jobs:
   code-pushup:
     runs-on: ubuntu-latest
     name: Code PushUp
-    if: github.repository_owner != 'code-pushup'
+    if: github.event.pull_request.head.repo.fork
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/code-pushup-fork.yml
+++ b/.github/workflows/code-pushup-fork.yml
@@ -1,5 +1,12 @@
 name: Code PushUp (fork)
 
+# separated from code-pushup.yml for security reasons
+# => requires permissions to create PR comment
+# => for PRs from forks, needs to run on `pull_request_target`, not `pull_request`
+# => `pull_request_target` is a security risk when secrets are being used
+# => secrets needed for code-pushup upload
+# => code-pushup for forks runs in separate workflow with no secrets access
+
 on:
   pull_request_target:
     branches: [main]

--- a/.github/workflows/code-pushup.yml
+++ b/.github/workflows/code-pushup.yml
@@ -16,7 +16,7 @@ jobs:
   code-pushup:
     runs-on: ubuntu-latest
     name: Code PushUp
-    if: github.repository_owner == 'code-pushup'
+    if: ${{ !github.event.pull_request.head.repo.fork }}
     env:
       CP_SERVER: ${{ secrets.CP_SERVER }}
       CP_API_KEY: ${{ secrets.CP_API_KEY }}

--- a/.github/workflows/code-pushup.yml
+++ b/.github/workflows/code-pushup.yml
@@ -3,7 +3,7 @@ name: Code PushUp
 on:
   push:
     branches: [main]
-  pull_request:
+  pull_request_target:
     branches: [main]
 
 env:

--- a/.github/workflows/code-pushup.yml
+++ b/.github/workflows/code-pushup.yml
@@ -16,6 +16,7 @@ jobs:
   code-pushup:
     runs-on: ubuntu-latest
     name: Code PushUp
+    # ignore PRs from forks, handled by code-pushup-fork.yml
     if: ${{ !github.event.pull_request.head.repo.fork }}
     env:
       CP_SERVER: ${{ secrets.CP_SERVER }}

--- a/code-pushup.config.ts
+++ b/code-pushup.config.ts
@@ -22,28 +22,23 @@ import {
 import type { CoreConfig } from './packages/models/src';
 
 // load upload configuration from environment
-const envSchema = z
-  .object({
-    CP_SERVER: z.string().url(),
-    CP_API_KEY: z.string().min(1),
-    CP_ORGANIZATION: z.string().min(1),
-    CP_PROJECT: z.string().min(1),
-  })
-  .partial();
-const env = await envSchema.parseAsync(process.env);
+const envSchema = z.object({
+  CP_SERVER: z.string().url(),
+  CP_API_KEY: z.string().min(1),
+  CP_ORGANIZATION: z.string().min(1),
+  CP_PROJECT: z.string().min(1),
+});
+const { data: env } = await envSchema.safeParseAsync(process.env);
 
 const config: CoreConfig = {
-  ...(env.CP_SERVER &&
-    env.CP_API_KEY &&
-    env.CP_ORGANIZATION &&
-    env.CP_PROJECT && {
-      upload: {
-        server: env.CP_SERVER,
-        apiKey: env.CP_API_KEY,
-        organization: env.CP_ORGANIZATION,
-        project: env.CP_PROJECT,
-      },
-    }),
+  ...(env && {
+    upload: {
+      server: env.CP_SERVER,
+      apiKey: env.CP_API_KEY,
+      organization: env.CP_ORGANIZATION,
+      project: env.CP_PROJECT,
+    },
+  }),
 
   plugins: [
     await eslintPlugin(await eslintConfigFromAllNxProjects()),


### PR DESCRIPTION
PR from forks weren't triggering our main CI workflow, and other workflows were broken. Attempted to fix these problems and tested what I could.
- CI workflow now runs on `pull_request` event also (forks don't run on `push`).
- Code PushUp workflow needs access to secrets, so it is now skipped for forks. 
- Create a separate Code PushUp workflow without secrets that should run only for forks. It won't upload anything, but the PR comments should still work. Can't test it before merging the workflow though, due to [how `pull_request_target` event works](https://github.com/orgs/community/discussions/54937#discussioncomment-5848312).
- Assigning PR author failed for my fork because of invalid permissions, should be solved by changing `pull_request` to `pull_request_target` (again, can't test until it's merged).

Tested triggers on:
- #742

<details><summary> :framed_picture:  tested PR from fork</summary>
<p>

![image](https://github.com/code-pushup/cli/assets/34691111/2ddfe431-06e7-451b-909c-18af0b81af12)


</p>
</details> 

