### PR TITLE
docs: fix outdated version badge in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ---
 
-[![version](https://img.shields.io/github/package-json/v/code-pushup/cli)](https://www.npmjs.com/package/%40code-pushup%2Fcli)
+[![version](https://img.shields.io/github/v/release/code-pushup/cli)](https://github.com/code-pushup/cli/releases/latest)
 [![release date](https://img.shields.io/github/release-date/code-pushup/cli)](https://github.com/code-pushup/cli/releases)
 [![license](https://img.shields.io/github/license/code-pushup/cli)](https://opensource.org/licenses/MIT)
 [![commit activity](https://img.shields.io/github/commit-activity/m/code-pushup/cli)](https://github.com/code-pushup/cli/pulse/monthly)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@code-pushup/cli-source",
-  "version": "0.29.0",
+  "version": "0.0.0",
   "license": "MIT",
   "homepage": "https://github.com/code-pushup/cli#readme",
   "bugs": {


### PR DESCRIPTION
When we used `jscutlery/semver`, it used to bump the version in root `package.json`, but `nx release` doesn't do that. So I changed the source to [latest GitHub Release](https://github.com/code-pushup/cli/releases/latest).

## Previews
- [before](https://github.com/code-pushup/cli/tree/7216f6eb689825f5e108fed4942510ae3ba8f368?tab=readme-ov-file#comprehensive-tech-quality-monitoring)
- [after](https://github.com/code-pushup/cli/tree/5fdeee0a898e71417bcebc6ee67dd4f022e5b3d1?tab=readme-ov-file#comprehensive-tech-quality-monitoring)