### PR TITLE
ci(plugin-lighthouse): turn off verbose logging to make code-pushup output readable

### DIFF
--- a/code-pushup.config.ts
+++ b/code-pushup.config.ts
@@ -75,10 +75,7 @@ const config: CoreConfig = {
 
     await lighthousePlugin(
       'https://github.com/code-pushup/cli?tab=readme-ov-file#code-pushup-cli/',
-      {
-        chromeFlags: DEFAULT_FLAGS.concat(['--headless']),
-        verbose: true,
-      },
+      { chromeFlags: DEFAULT_FLAGS.concat(['--headless']) },
     ),
   ],
 


### PR DESCRIPTION
The `verbose: true` in Lighthouse plugin spams all our `code-pushup` runs with over 17.5k logs ([example here](https://github.com/code-pushup/cli/actions/runs/9947211072/job/27479400492?pr=750#step:5:17590)) :scream: 