### PR TITLE
feat(utils): add nested objects to cli args parsing

### DIFF
--- a/packages/nx-plugin/src/executors/internal/cli.ts
+++ b/packages/nx-plugin/src/executors/internal/cli.ts
@@ -36,6 +36,7 @@ export function objectToCliArgs<
 
     if (typeof value === 'object') {
       return Object.entries(value as Record<string, unknown>).flatMap(
+        // transform nested objects to the dot notation `key.subkey`
         ([k, v]) => objectToCliArgs({ [`${key}.${k}`]: v }),
       );
     }

--- a/packages/nx-plugin/src/executors/internal/cli.ts
+++ b/packages/nx-plugin/src/executors/internal/cli.ts
@@ -27,6 +27,7 @@ export function objectToCliArgs<
       // eslint-disable-next-line @typescript-eslint/no-unsafe-return
       return Array.isArray(value) ? value : [`${value}`];
     }
+
     const prefix = key.length === 1 ? '-' : '--';
     // "-*" arguments (shorthands)
     if (Array.isArray(value)) {
@@ -34,8 +35,8 @@ export function objectToCliArgs<
     }
 
     if (typeof value === 'object') {
-      return Object.entries(value as Record<string, unknown>).map(
-        ([k, v]) => `${prefix}${key}.${k}="${v?.toString()}"`,
+      return Object.entries(value as Record<string, unknown>).flatMap(
+        ([k, v]) => objectToCliArgs({ [`${key}.${k}`]: v }),
       );
     }
 

--- a/packages/nx-plugin/src/executors/internal/cli.unit.test.ts
+++ b/packages/nx-plugin/src/executors/internal/cli.unit.test.ts
@@ -63,12 +63,13 @@ describe('objectToCliArgs', () => {
     expect(result).toStrictEqual(['--format.json="simple"']);
   });
 
-  it('should handle objects with array', () => {
-    const params = { persist: { format: ['json', 'md'] } };
+  it('should handle nested objects', () => {
+    const params = { persist: { format: ['json', 'md'], verbose: false } };
     const result = objectToCliArgs(params);
     expect(result).toEqual([
       '--persist.format="json"',
       '--persist.format="md"',
+      '--persist.no-verbose',
     ]);
   });
 

--- a/packages/nx-plugin/src/executors/internal/cli.unit.test.ts
+++ b/packages/nx-plugin/src/executors/internal/cli.unit.test.ts
@@ -69,7 +69,7 @@ describe('objectToCliArgs', () => {
     expect(result).toEqual([
       '--persist.format="json"',
       '--persist.format="md"',
-      '--persist.no-verbose',
+      '--no-persist.verbose',
     ]);
   });
 

--- a/packages/nx-plugin/src/executors/internal/cli.unit.test.ts
+++ b/packages/nx-plugin/src/executors/internal/cli.unit.test.ts
@@ -63,6 +63,15 @@ describe('objectToCliArgs', () => {
     expect(result).toStrictEqual(['--format.json="simple"']);
   });
 
+  it('should handle objects with array', () => {
+    const params = { persist: { format: ['json', 'md'] } };
+    const result = objectToCliArgs(params);
+    expect(result).toEqual([
+      '--persist.format="json"',
+      '--persist.format="md"',
+    ]);
+  });
+
   it('should handle objects with undefined', () => {
     const params = { format: undefined };
     const result = objectToCliArgs(params);

--- a/packages/utils/src/lib/transform.ts
+++ b/packages/utils/src/lib/transform.ts
@@ -91,6 +91,13 @@ export function objectToCliArgs<
       return value.map(v => `${prefix}${key}="${v}"`);
     }
 
+    if (typeof value === 'object') {
+      return Object.entries(value as Record<string, ArgumentValue>).flatMap(
+        // transform nested objects to the dot notation `key.subkey`
+        ([k, v]) => objectToCliArgs({ [`${key}.${k}`]: v }),
+      );
+    }
+
     if (typeof value === 'string') {
       return [`${prefix}${key}="${value}"`];
     }

--- a/packages/utils/src/lib/transform.unit.test.ts
+++ b/packages/utils/src/lib/transform.unit.test.ts
@@ -191,6 +191,15 @@ describe('objectToCliArgs', () => {
     expect(result).toEqual(['--format="json"', '--format="md"']);
   });
 
+  it('should handle nested objects as arguments', () => {
+    const params = { persist: { format: ['json', 'md'] } };
+    const result = objectToCliArgs(params);
+    expect(result).toEqual([
+      '--persist.format="json"',
+      '--persist.format="md"',
+    ]);
+  });
+
   it('should throw error for unsupported type', () => {
     const params = { unsupported: undefined as any };
     expect(() => objectToCliArgs(params)).toThrow('Unsupported type');

--- a/packages/utils/src/lib/transform.unit.test.ts
+++ b/packages/utils/src/lib/transform.unit.test.ts
@@ -197,7 +197,7 @@ describe('objectToCliArgs', () => {
     expect(result).toEqual([
       '--persist.format="json"',
       '--persist.format="md"',
-      '--persist.no-verbose',
+      '--no-persist.verbose',
     ]);
   });
 

--- a/packages/utils/src/lib/transform.unit.test.ts
+++ b/packages/utils/src/lib/transform.unit.test.ts
@@ -191,12 +191,13 @@ describe('objectToCliArgs', () => {
     expect(result).toEqual(['--format="json"', '--format="md"']);
   });
 
-  it('should handle nested objects as arguments', () => {
-    const params = { persist: { format: ['json', 'md'] } };
+  it('should handle nested objects', () => {
+    const params = { persist: { format: ['json', 'md'], verbose: false } };
     const result = objectToCliArgs(params);
     expect(result).toEqual([
       '--persist.format="json"',
       '--persist.format="md"',
+      '--persist.no-verbose',
     ]);
   });
 


### PR DESCRIPTION
Hotfix for #737 

**before:**
`parseObjToCliArgs({persist: {format: ['md', 'json']}})` => `--persist.format="md,json"`


**after:**
`parseObjToCliArgs({persist: {format: ['md', 'json']}})` => `--persist.format="md" --persist.format="json"`