### PR TITLE
refactor: add code-pushup.preset.ts

### DIFF
--- a/code-pushup.config.ts
+++ b/code-pushup.config.ts
@@ -2,6 +2,15 @@ import { DEFAULT_FLAGS } from 'chrome-launcher/dist/flags.js';
 import 'dotenv/config';
 import { z } from 'zod';
 import {
+  coverageCategories,
+  eslintCategories,
+  eslintCoreConfigNx,
+  jsPackagesCategories,
+  jsPackagesCoreConfig,
+  lighthouseCategories,
+  lighthouseCoreConfig,
+} from './code-pushup.preset';
+import {
   fileSizePlugin,
   fileSizeRecommendedRefs,
   packageJsonDocumentationGroupRef,
@@ -19,6 +28,7 @@ import {
   lighthouseGroupRef,
   lighthousePlugin,
 } from './dist/packages/plugin-lighthouse';
+import { mergeConfigs } from './dist/packages/utils';
 import type { CoreConfig } from './packages/models/src';
 
 // load upload configuration from environment
@@ -41,8 +51,6 @@ const config: CoreConfig = {
   }),
 
   plugins: [
-    await eslintPlugin(await eslintConfigFromAllNxProjects()),
-
     await coveragePlugin({
       coverageToolCommand: {
         command: 'npx',
@@ -59,8 +67,6 @@ const config: CoreConfig = {
       reports: await getNxCoveragePaths(['unit-test', 'integration-test']),
     }),
 
-    await jsPackagesPlugin({ packageManager: 'npm' }),
-
     fileSizePlugin({
       directory: './dist/examples/react-todos-app',
       pattern: /\.js$/,
@@ -72,88 +78,10 @@ const config: CoreConfig = {
       license: 'MIT',
       type: 'module',
     }),
-
-    await lighthousePlugin(
-      'https://github.com/code-pushup/cli?tab=readme-ov-file#code-pushup-cli/',
-      { chromeFlags: DEFAULT_FLAGS.concat(['--headless']) },
-    ),
   ],
 
   categories: [
-    {
-      slug: 'performance',
-      title: 'Performance',
-      refs: [lighthouseGroupRef('performance')],
-    },
-    {
-      slug: 'a11y',
-      title: 'Accessibility',
-      refs: [lighthouseGroupRef('accessibility')],
-    },
-    {
-      slug: 'best-practices',
-      title: 'Best Practices',
-      refs: [lighthouseGroupRef('best-practices')],
-    },
-    {
-      slug: 'seo',
-      title: 'SEO',
-      refs: [lighthouseGroupRef('seo')],
-    },
-    {
-      slug: 'bug-prevention',
-      title: 'Bug prevention',
-      description: 'Lint rules that find **potential bugs** in your code.',
-      refs: [{ type: 'group', plugin: 'eslint', slug: 'problems', weight: 1 }],
-    },
-    {
-      slug: 'code-style',
-      title: 'Code style',
-      description:
-        'Lint rules that promote **good practices** and consistency in your code.',
-      refs: [
-        { type: 'group', plugin: 'eslint', slug: 'suggestions', weight: 1 },
-      ],
-    },
-    {
-      slug: 'code-coverage',
-      title: 'Code coverage',
-      description: 'Measures how much of your code is **covered by tests**.',
-      refs: [
-        {
-          type: 'group',
-          plugin: 'coverage',
-          slug: 'coverage',
-          weight: 1,
-        },
-      ],
-    },
-    {
-      slug: 'security',
-      title: 'Security',
-      description: 'Finds known **vulnerabilities** in 3rd-party packages.',
-      refs: [
-        {
-          type: 'group',
-          plugin: 'js-packages',
-          slug: 'npm-audit',
-          weight: 1,
-        },
-      ],
-    },
-    {
-      slug: 'updates',
-      title: 'Updates',
-      description: 'Finds **outdated** 3rd-party packages.',
-      refs: [
-        {
-          type: 'group',
-          plugin: 'js-packages',
-          slug: 'npm-outdated',
-          weight: 1,
-        },
-      ],
-    },
+    ...coverageCategories(),
     {
       slug: 'custom-checks',
       title: 'Custom checks',
@@ -166,4 +94,11 @@ const config: CoreConfig = {
   ],
 };
 
-export default config;
+export default mergeConfigs(
+  config,
+  jsPackagesCoreConfig(),
+  lighthouseCoreConfig(
+    'https://github.com/code-pushup/cli?tab=readme-ov-file#code-pushup-cli/',
+  ),
+  eslintCoreConfigNx(),
+);

--- a/code-pushup.config.ts
+++ b/code-pushup.config.ts
@@ -1,5 +1,5 @@
 import 'dotenv/config';
-import {z} from 'zod';
+import { z } from 'zod';
 import {
   coverageCategories,
   eslintCoreConfigNx,
@@ -13,9 +13,11 @@ import {
   packageJsonPerformanceGroupRef,
   packageJsonPlugin,
 } from './dist/examples/plugins';
-import coveragePlugin, {getNxCoveragePaths,} from './dist/packages/plugin-coverage';
-import {mergeConfigs} from './dist/packages/utils';
-import type {CoreConfig} from './packages/models/src';
+import coveragePlugin, {
+  getNxCoveragePaths,
+} from './dist/packages/plugin-coverage';
+import { mergeConfigs } from './dist/packages/utils';
+import type { CoreConfig } from './packages/models/src';
 
 // load upload configuration from environment
 const envSchema = z.object({

--- a/code-pushup.config.ts
+++ b/code-pushup.config.ts
@@ -81,7 +81,7 @@ const config: CoreConfig = {
   ],
 
   categories: [
-    ...coverageCategories(),
+    ...coverageCategories,
     {
       slug: 'custom-checks',
       title: 'Custom checks',

--- a/code-pushup.config.ts
+++ b/code-pushup.config.ts
@@ -1,13 +1,9 @@
-import { DEFAULT_FLAGS } from 'chrome-launcher/dist/flags.js';
 import 'dotenv/config';
-import { z } from 'zod';
+import {z} from 'zod';
 import {
   coverageCategories,
-  eslintCategories,
   eslintCoreConfigNx,
-  jsPackagesCategories,
   jsPackagesCoreConfig,
-  lighthouseCategories,
   lighthouseCoreConfig,
 } from './code-pushup.preset';
 import {
@@ -17,19 +13,9 @@ import {
   packageJsonPerformanceGroupRef,
   packageJsonPlugin,
 } from './dist/examples/plugins';
-import coveragePlugin, {
-  getNxCoveragePaths,
-} from './dist/packages/plugin-coverage';
-import eslintPlugin, {
-  eslintConfigFromAllNxProjects,
-} from './dist/packages/plugin-eslint';
-import jsPackagesPlugin from './dist/packages/plugin-js-packages';
-import {
-  lighthouseGroupRef,
-  lighthousePlugin,
-} from './dist/packages/plugin-lighthouse';
-import { mergeConfigs } from './dist/packages/utils';
-import type { CoreConfig } from './packages/models/src';
+import coveragePlugin, {getNxCoveragePaths,} from './dist/packages/plugin-coverage';
+import {mergeConfigs} from './dist/packages/utils';
+import type {CoreConfig} from './packages/models/src';
 
 // load upload configuration from environment
 const envSchema = z.object({
@@ -96,9 +82,9 @@ const config: CoreConfig = {
 
 export default mergeConfigs(
   config,
-  jsPackagesCoreConfig(),
-  lighthouseCoreConfig(
+  await jsPackagesCoreConfig(),
+  await lighthouseCoreConfig(
     'https://github.com/code-pushup/cli?tab=readme-ov-file#code-pushup-cli/',
   ),
-  eslintCoreConfigNx(),
+  await eslintCoreConfigNx(),
 );

--- a/code-pushup.config.ts
+++ b/code-pushup.config.ts
@@ -1,7 +1,7 @@
 import 'dotenv/config';
 import { z } from 'zod';
 import {
-  coverageCategories,
+  coverageCoreConfigNx,
   eslintCoreConfigNx,
   jsPackagesCoreConfig,
   lighthouseCoreConfig,
@@ -13,9 +13,6 @@ import {
   packageJsonPerformanceGroupRef,
   packageJsonPlugin,
 } from './dist/examples/plugins';
-import coveragePlugin, {
-  getNxCoveragePaths,
-} from './dist/packages/plugin-coverage';
 import { mergeConfigs } from './dist/packages/utils';
 import type { CoreConfig } from './packages/models/src';
 
@@ -39,22 +36,6 @@ const config: CoreConfig = {
   }),
 
   plugins: [
-    await coveragePlugin({
-      coverageToolCommand: {
-        command: 'npx',
-        args: [
-          'nx',
-          'run-many',
-          '-t',
-          'unit-test',
-          'integration-test',
-          '--coverage.enabled',
-          '--skipNxCache',
-        ],
-      },
-      reports: await getNxCoveragePaths(['unit-test', 'integration-test']),
-    }),
-
     fileSizePlugin({
       directory: './dist/examples/react-todos-app',
       pattern: /\.js$/,
@@ -69,7 +50,6 @@ const config: CoreConfig = {
   ],
 
   categories: [
-    ...coverageCategories,
     {
       slug: 'custom-checks',
       title: 'Custom checks',
@@ -84,6 +64,7 @@ const config: CoreConfig = {
 
 export default mergeConfigs(
   config,
+  await coverageCoreConfigNx(),
   await jsPackagesCoreConfig(),
   await lighthouseCoreConfig(
     'https://github.com/code-pushup/cli?tab=readme-ov-file#code-pushup-cli/',

--- a/code-pushup.preset.ts
+++ b/code-pushup.preset.ts
@@ -134,6 +134,9 @@ export const eslintCoreConfigNx = async (
 export const coverageCoreConfigNx = async (
   projectName?: string,
 ): Promise<CoreConfig> => {
+  if (projectName) {
+    throw new Error('coverageCoreConfigNx for single projects not implemented');
+  }
   const targetNames = ['unit-test', 'integration-test'];
   const targetArgs = [
     '-t',
@@ -142,7 +145,6 @@ export const coverageCoreConfigNx = async (
     '--coverage.enabled',
     '--skipNxCache',
   ];
-  const rootArgs = ['nx', 'run-many'];
   return {
     plugins: [
       await coveragePlugin({
@@ -157,6 +159,6 @@ export const coverageCoreConfigNx = async (
         reports: await getNxCoveragePaths(targetNames),
       }),
     ],
-    categories: eslintCategories,
+    categories: coverageCategories,
   };
 };

--- a/code-pushup.preset.ts
+++ b/code-pushup.preset.ts
@@ -1,9 +1,16 @@
-import {DEFAULT_FLAGS} from 'chrome-launcher/dist/flags.js';
-import coveragePlugin, {getNxCoveragePaths,} from './dist/packages/plugin-coverage';
-import eslintPlugin, {eslintConfigFromAllNxProjects, eslintConfigFromNxProject,} from './dist/packages/plugin-eslint';
+import { DEFAULT_FLAGS } from 'chrome-launcher/dist/flags.js';
+import coveragePlugin, {
+  getNxCoveragePaths,
+} from './dist/packages/plugin-coverage';
+import eslintPlugin, {
+  eslintConfigFromAllNxProjects,
+  eslintConfigFromNxProject,
+} from './dist/packages/plugin-eslint';
 import jsPackagesPlugin from './dist/packages/plugin-js-packages';
-import lighthousePlugin, {lighthouseGroupRef,} from './dist/packages/plugin-lighthouse';
-import type {CategoryConfig, CoreConfig} from './packages/models/src';
+import lighthousePlugin, {
+  lighthouseGroupRef,
+} from './dist/packages/plugin-lighthouse';
+import type { CategoryConfig, CoreConfig } from './packages/models/src';
 
 export const jsPackagesCategories: CategoryConfig[] = [
   {

--- a/code-pushup.preset.ts
+++ b/code-pushup.preset.ts
@@ -95,7 +95,7 @@ export const coverageCategories = [
 
 export const jsPackagesCoreConfig = async (): Promise<CoreConfig> => ({
   plugins: [await jsPackagesPlugin({ packageManager: 'npm' })],
-  categories: jsPackagesCategories(),
+  categories: jsPackagesCategories,
 });
 
 export const lighthouseCoreConfig = async (
@@ -106,7 +106,7 @@ export const lighthouseCoreConfig = async (
       chromeFlags: DEFAULT_FLAGS.concat(['--headless']),
     }),
   ],
-  categories: lighthouseCategories(),
+  categories: lighthouseCategories,
 });
 
 export const eslintCoreConfigNx = async (
@@ -119,5 +119,5 @@ export const eslintCoreConfigNx = async (
         : eslintConfigFromAllNxProjects()),
     ),
   ],
-  categories: eslintCategories(),
+  categories: eslintCategories,
 });

--- a/code-pushup.preset.ts
+++ b/code-pushup.preset.ts
@@ -1,0 +1,123 @@
+import { DEFAULT_FLAGS } from 'chrome-launcher/dist/flags.js';
+import eslintPlugin, {
+  eslintConfigFromAllNxProjects,
+  eslintConfigFromNxProject,
+} from './dist/packages/plugin-eslint';
+import jsPackagesPlugin from './dist/packages/plugin-js-packages';
+import lighthousePlugin, {
+  lighthouseGroupRef,
+} from './dist/packages/plugin-lighthouse';
+import type { CoreConfig } from './packages/models/src';
+
+export const jsPackagesCategories = [
+  {
+    slug: 'security',
+    title: 'Security',
+    description: 'Finds known **vulnerabilities** in 3rd-party packages.',
+    refs: [
+      {
+        type: 'group',
+        plugin: 'js-packages',
+        slug: 'npm-audit',
+        weight: 1,
+      },
+    ],
+  },
+  {
+    slug: 'updates',
+    title: 'Updates',
+    description: 'Finds **outdated** 3rd-party packages.',
+    refs: [
+      {
+        type: 'group',
+        plugin: 'js-packages',
+        slug: 'npm-outdated',
+        weight: 1,
+      },
+    ],
+  },
+];
+
+export const lighthouseCategories = [
+  {
+    slug: 'performance',
+    title: 'Performance',
+    refs: [lighthouseGroupRef('performance')],
+  },
+  {
+    slug: 'a11y',
+    title: 'Accessibility',
+    refs: [lighthouseGroupRef('accessibility')],
+  },
+  {
+    slug: 'best-practices',
+    title: 'Best Practices',
+    refs: [lighthouseGroupRef('best-practices')],
+  },
+  {
+    slug: 'seo',
+    title: 'SEO',
+    refs: [lighthouseGroupRef('seo')],
+  },
+];
+
+export const eslintCategories = [
+  {
+    slug: 'bug-prevention',
+    title: 'Bug prevention',
+    description: 'Lint rules that find **potential bugs** in your code.',
+    refs: [{ type: 'group', plugin: 'eslint', slug: 'problems', weight: 1 }],
+  },
+  {
+    slug: 'code-style',
+    title: 'Code style',
+    description:
+      'Lint rules that promote **good practices** and consistency in your code.',
+    refs: [{ type: 'group', plugin: 'eslint', slug: 'suggestions', weight: 1 }],
+  },
+];
+
+export const coverageCategories = [
+  {
+    slug: 'code-coverage',
+    title: 'Code coverage',
+    description: 'Measures how much of your code is **covered by tests**.',
+    refs: [
+      {
+        type: 'group',
+        plugin: 'coverage',
+        slug: 'coverage',
+        weight: 1,
+      },
+    ],
+  },
+];
+
+export const jsPackagesCoreConfig = async (): Promise<CoreConfig> => ({
+  plugins: [await jsPackagesPlugin({ packageManager: 'npm' })],
+  categories: jsPackagesCategories(),
+});
+
+export const lighthouseCoreConfig = async (
+  url: string,
+): Promise<CoreConfig> => ({
+  plugins: [
+    await lighthousePlugin(url, {
+      chromeFlags: DEFAULT_FLAGS.concat(['--headless']),
+    }),
+  ],
+  categories: lighthouseCategories(),
+});
+
+export const eslintCoreConfigNx = async (
+  projectName?: string,
+): Promise<CoreConfig> => ({
+  plugins: [
+    await eslintPlugin(
+      await (projectName
+        ? eslintConfigFromNxProject(projectName)
+        : eslintConfigFromAllNxProjects()),
+    ),
+  ],
+  categories: eslintCategories(),
+});

--- a/packages/utils/src/lib/merge-configs.unit.test.ts
+++ b/packages/utils/src/lib/merge-configs.unit.test.ts
@@ -172,7 +172,7 @@ describe('mergeObjects', () => {
     });
   });
 
-  it('should merge add upload to config', () => {
+  it('should merge upload config properties', () => {
     expect(
       mergeConfigs(
         MOCK_CONFIG_PERSIST,


### PR DESCRIPTION
This PR adds a `code-pushup.preset.ts` and uses the preset in `code-pushup.config.ts`

Notice: 
Coverage helper still unfinished.