### PR TITLE
feat(plugin-lighthouse): omit audit details table title

### DIFF
--- a/packages/plugin-lighthouse/src/lib/runner/details/details.unit.test.ts
+++ b/packages/plugin-lighthouse/src/lib/runner/details/details.unit.test.ts
@@ -89,7 +89,6 @@ describe('toAuditDetails', () => {
 
     expect(outputs).toStrictEqual({
       table: {
-        title: 'Table',
         columns: [
           {
             key: 'name',

--- a/packages/plugin-lighthouse/src/lib/runner/details/table.type.ts
+++ b/packages/plugin-lighthouse/src/lib/runner/details/table.type.ts
@@ -19,7 +19,6 @@ export function parseTableToAuditDetailsTable(
 
   try {
     return tableSchema().parse({
-      title: 'Table',
       columns: parseTableColumns(rawHeadings),
       rows: items.map(row => parseTableRow(row, rawHeadings)),
     });

--- a/packages/plugin-lighthouse/src/lib/runner/details/table.type.unit.test.ts
+++ b/packages/plugin-lighthouse/src/lib/runner/details/table.type.unit.test.ts
@@ -93,7 +93,6 @@ describe('parseTableToAuditDetails', () => {
     } satisfies Details.Table);
 
     expect(outputs).toStrictEqual({
-      title: 'Table',
       columns: [
         {
           key: 'statistic',
@@ -219,7 +218,6 @@ describe('parseTableToAuditDetails', () => {
     } as Details.Table);
 
     expect(outputs).toEqual({
-      title: 'Table',
       columns: [
         {
           align: 'left',

--- a/packages/plugin-lighthouse/src/lib/runner/utils.unit.test.ts
+++ b/packages/plugin-lighthouse/src/lib/runner/utils.unit.test.ts
@@ -150,7 +150,6 @@ describe('toAuditOutputs', () => {
       table: {
         columns: [{ key: 'number', align: 'left' }],
         rows: [{ number: 42 }],
-        title: 'Table',
       },
     });
   });


### PR DESCRIPTION
Closes #775 

- [x] Update the `parseTableToAuditDetailsTable` function that parses audit details of type `table` to return only table columns and rows, omitting the title.
- [x] Tweak the tests accordingly.