### PR TITLE
feat(utils): increase audit value column width

### DIFF
--- a/packages/utils/src/lib/reports/__snapshots__/report-diff-added.md
+++ b/packages/utils/src/lib/reports/__snapshots__/report-diff-added.md
@@ -25,6 +25,6 @@ All of 1 group is unchanged.
 | :----------------------------------------------------------------- | :------------------------------------------------------------------------------- | :---------------: | :--------------: | :------------------------------------------------------------------------------: |
 | [ESLint](https://www.npmjs.com/package/@code-pushup/eslint-plugin) | [Disallow unused variables](https://eslint.org/docs/latest/rules/no-unused-vars) |     🟩 passed     |  🟥 **1 error**  | ![↑ +∞ %](https://img.shields.io/badge/%E2%86%91%20%2B%E2%88%9E%E2%80%89%25-red) |
 
-48 other audits are unchanged.
+49 other audits are unchanged.
 
 </details>

--- a/packages/utils/src/lib/reports/__snapshots__/report-diff-improved.md
+++ b/packages/utils/src/lib/reports/__snapshots__/report-diff-improved.md
@@ -42,6 +42,6 @@
 | Lighthouse                                                         | [First Contentful Paint](https://developer.chrome.com/docs/lighthouse/performance/first-contentful-paint/)                                           |     🟨 1.2 s      |   🟨 **1.1 s**   |   ![↓ −4 %](https://img.shields.io/badge/%E2%86%93%20%E2%88%924%E2%80%89%25-green)   |
 | Lighthouse                                                         | [Speed Index](https://developer.chrome.com/docs/lighthouse/performance/speed-index/)                                                                 |     🟩 1.2 s      |   🟩 **1.1 s**   |   ![↓ −4 %](https://img.shields.io/badge/%E2%86%93%20%E2%88%924%E2%80%89%25-green)   |
 
-40 other audits are unchanged.
+41 other audits are unchanged.
 
 </details>

--- a/packages/utils/src/lib/reports/__snapshots__/report-diff-mixed.md
+++ b/packages/utils/src/lib/reports/__snapshots__/report-diff-mixed.md
@@ -35,6 +35,6 @@
 | Lighthouse                                                         | [First Contentful Paint](https://developer.chrome.com/docs/lighthouse/performance/first-contentful-paint/)     |     🟨 1.2 s      |   🟨 **1.1 s**   | ![↓ −4 %](https://img.shields.io/badge/%E2%86%93%20%E2%88%924%E2%80%89%25-green) |
 | Lighthouse                                                         | [Speed Index](https://developer.chrome.com/docs/lighthouse/performance/speed-index/)                           |     🟩 1.2 s      |   🟩 **1.1 s**   | ![↓ −4 %](https://img.shields.io/badge/%E2%86%93%20%E2%88%924%E2%80%89%25-green) |
 
-48 other audits are unchanged.
+49 other audits are unchanged.
 
 </details>

--- a/packages/utils/src/lib/reports/__snapshots__/report-diff-unchanged.md
+++ b/packages/utils/src/lib/reports/__snapshots__/report-diff-unchanged.md
@@ -16,4 +16,4 @@ All of 2 groups are unchanged.
 
 ## 🛡️ Audits
 
-All of 52 audits are unchanged.
+All of 53 audits are unchanged.

--- a/packages/utils/src/lib/reports/__snapshots__/report-diff-with-portal-link.md
+++ b/packages/utils/src/lib/reports/__snapshots__/report-diff-with-portal-link.md
@@ -37,6 +37,6 @@
 | Lighthouse                                                         | [First Contentful Paint](https://developer.chrome.com/docs/lighthouse/performance/first-contentful-paint/)     |     🟨 1.2 s      |   🟨 **1.1 s**   | ![↓ −4 %](https://img.shields.io/badge/%E2%86%93%20%E2%88%924%E2%80%89%25-green) |
 | Lighthouse                                                         | [Speed Index](https://developer.chrome.com/docs/lighthouse/performance/speed-index/)                           |     🟩 1.2 s      |   🟩 **1.1 s**   | ![↓ −4 %](https://img.shields.io/badge/%E2%86%93%20%E2%88%924%E2%80%89%25-green) |
 
-48 other audits are unchanged.
+49 other audits are unchanged.
 
 </details>

--- a/packages/utils/src/lib/reports/__snapshots__/report-stdout-no-categories.txt
+++ b/packages/utils/src/lib/reports/__snapshots__/report-stdout-no-categories.txt
@@ -3,70 +3,86 @@ Code PushUp Report - @code-pushup/core@0.0.1
 
 ESLint audits
 
-● Disallow missing props validation in a React component definition   6 warnings
-● Disallow variable declarations from shadowing variables declared    3 warnings
-  in the outer scope
-● Require or disallow method and property shorthand syntax for        3 warnings
-  object literals
-● verifies the list of dependencies for Hooks like useEffect and      2 warnings
-  similar
-● Disallow missing `key` props in iterators/collection literals       1 warning
-● Disallow unused variables                                           1 warning
-● Enforce a maximum number of lines of code in a function             1 warning
-● Require `const` declarations for variables that are never           1 warning
-  reassigned after declared
-● Require braces around arrow function bodies                         1 warning
-● Require the use of `===` and `!==`                                  1 warning
-● Disallow `target="_blank"` attribute without `rel="noreferrer"`     passed
-● Disallow assignment operators in conditional expressions            passed
-● Disallow comments from being inserted as text nodes                 passed
-● Disallow direct mutation of this.state                              passed
-● Disallow duplicate properties in JSX                                passed
-● Disallow invalid regular expression strings in `RegExp`             passed
+● Disallow missing props validation in a React component    6 warnings
+  definition
+● Disallow variable declarations from shadowing variables   3 warnings
+  declared in the outer scope
+● Require or disallow method and property shorthand         3 warnings
+  syntax for object literals
+● verifies the list of dependencies for Hooks like          2 warnings
+  useEffect and similar
+● Disallow missing `key` props in iterators/collection      1 warning
+  literals
+● Disallow unused variables                                 1 warning
+● Enforce a maximum number of lines of code in a function   1 warning
+● Require `const` declarations for variables that are       1 warning
+  never reassigned after declared
+● Require braces around arrow function bodies               1 warning
+● Require the use of `===` and `!==`                        1 warning
+● Disallow `target="_blank"` attribute without              passed
+  `rel="noreferrer"`
+● Disallow assignment operators in conditional              passed
+  expressions
+● Disallow comments from being inserted as text nodes       passed
+● Disallow direct mutation of this.state                    passed
+● Disallow duplicate properties in JSX                      passed
+● Disallow invalid regular expression strings in `RegExp`   passed
   constructors
-● Disallow loops with a body that allows only one iteration           passed
-● Disallow missing displayName in a React component definition        passed
-● Disallow missing React when using JSX                               passed
-● Disallow negating the left operand of relational operators          passed
-● Disallow passing of children as props                               passed
-● Disallow React to be incorrectly marked as unused                   passed
-● Disallow reassigning `const` variables                              passed
-● Disallow the use of `debugger`                                      passed
-● Disallow the use of undeclared variables unless mentioned in        passed
-  `/*global */` comments
-● Disallow undeclared variables in JSX                                passed
-● Disallow unescaped HTML entities from appearing in markup           passed
-● Disallow usage of deprecated methods                                passed
-● Disallow usage of findDOMNode                                       passed
-● Disallow usage of isMounted                                         passed
-● Disallow usage of the return value of ReactDOM.render               passed
-● Disallow usage of unknown DOM property                              passed
-● Disallow use of optional chaining in contexts where the             passed
+● Disallow loops with a body that allows only one           passed
+  iteration
+● Disallow missing displayName in a React component         passed
+  definition
+● Disallow missing React when using JSX                     passed
+● Disallow negating the left operand of relational          passed
+  operators
+● Disallow passing of children as props                     passed
+● Disallow React to be incorrectly marked as unused         passed
+● Disallow reassigning `const` variables                    passed
+● Disallow the use of `debugger`                            passed
+● Disallow the use of undeclared variables unless           passed
+  mentioned in `/*global */` comments
+● Disallow undeclared variables in JSX                      passed
+● Disallow unescaped HTML entities from appearing in        passed
+  markup
+● Disallow usage of deprecated methods                      passed
+● Disallow usage of findDOMNode                             passed
+● Disallow usage of isMounted                               passed
+● Disallow usage of the return value of ReactDOM.render     passed
+● Disallow usage of unknown DOM property                    passed
+● Disallow use of optional chaining in contexts where the   passed
   `undefined` value is not allowed
-● Disallow using Object.assign with an object literal as the first    passed
-  argument and prefer the use of object spread instead
-● Disallow using string references                                    passed
-● Disallow variables used in JSX to be incorrectly marked as unused   passed
-● Disallow when a DOM element is using both children and              passed
+● Disallow using Object.assign with an object literal as    passed
+  the first argument and prefer the use of object spread
+  instead
+● Disallow using string references                          passed
+● Disallow variables used in JSX to be incorrectly marked   passed
+  as unused
+● Disallow when a DOM element is using both children and    passed
   dangerouslySetInnerHTML
-● Enforce a maximum number of lines per file                          passed
-● Enforce camelcase naming convention                                 passed
-● Enforce comparing `typeof` expressions against valid strings        passed
-● Enforce consistent brace style for all control statements           passed
-● Enforce ES5 or ES6 class for returning value in render function     passed
-● enforces the Rules of Hooks                                         passed
-● Require `let` or `const` instead of `var`                           passed
-● Require calls to `isNaN()` when checking for `NaN`                  passed
-● Require or disallow "Yoda" conditions                               passed
-● Require using arrow functions for callbacks                         passed
+● Enforce a maximum number of lines per file                passed
+● Enforce camelcase naming convention                       passed
+● Enforce comparing `typeof` expressions against valid      passed
+  strings
+● Enforce consistent brace style for all control            passed
+  statements
+● Enforce ES5 or ES6 class for returning value in render    passed
+  function
+● enforces the Rules of Hooks                               passed
+● Require `let` or `const` instead of `var`                 passed
+● Require calls to `isNaN()` when checking for `NaN`        passed
+● Require or disallow "Yoda" conditions                     passed
+● Require using arrow functions for callbacks               passed
 
 
 Lighthouse audits
 
-● First Contentful Paint                                              1.2 s
-● Largest Contentful Paint                                            1.5 s
-● Speed Index                                                         1.2 s
-● Cumulative Layout Shift                                             0
-● Total Blocking Time                                                 0 ms
+● Minimize third-party usage                                Third-party code
+                                                            blocked the main
+                                                            thread for 6,850 ms
+● First Contentful Paint                                    1.2 s
+● Largest Contentful Paint                                  1.5 s
+● Speed Index                                               1.2 s
+● Cumulative Layout Shift                                   0
+● Total Blocking Time                                       0 ms
 
 Made with ❤ by code-pushup.dev

--- a/packages/utils/src/lib/reports/__snapshots__/report-stdout.txt
+++ b/packages/utils/src/lib/reports/__snapshots__/report-stdout.txt
@@ -3,71 +3,87 @@ Code PushUp Report - @code-pushup/core@0.0.1
 
 ESLint audits
 
-● Disallow missing props validation in a React component definition   6 warnings
-● Disallow variable declarations from shadowing variables declared    3 warnings
-  in the outer scope
-● Require or disallow method and property shorthand syntax for        3 warnings
-  object literals
-● verifies the list of dependencies for Hooks like useEffect and      2 warnings
-  similar
-● Disallow missing `key` props in iterators/collection literals       1 warning
-● Disallow unused variables                                           1 warning
-● Enforce a maximum number of lines of code in a function             1 warning
-● Require `const` declarations for variables that are never           1 warning
-  reassigned after declared
-● Require braces around arrow function bodies                         1 warning
-● Require the use of `===` and `!==`                                  1 warning
-● Disallow `target="_blank"` attribute without `rel="noreferrer"`     passed
-● Disallow assignment operators in conditional expressions            passed
-● Disallow comments from being inserted as text nodes                 passed
-● Disallow direct mutation of this.state                              passed
-● Disallow duplicate properties in JSX                                passed
-● Disallow invalid regular expression strings in `RegExp`             passed
+● Disallow missing props validation in a React component    6 warnings
+  definition
+● Disallow variable declarations from shadowing variables   3 warnings
+  declared in the outer scope
+● Require or disallow method and property shorthand         3 warnings
+  syntax for object literals
+● verifies the list of dependencies for Hooks like          2 warnings
+  useEffect and similar
+● Disallow missing `key` props in iterators/collection      1 warning
+  literals
+● Disallow unused variables                                 1 warning
+● Enforce a maximum number of lines of code in a function   1 warning
+● Require `const` declarations for variables that are       1 warning
+  never reassigned after declared
+● Require braces around arrow function bodies               1 warning
+● Require the use of `===` and `!==`                        1 warning
+● Disallow `target="_blank"` attribute without              passed
+  `rel="noreferrer"`
+● Disallow assignment operators in conditional              passed
+  expressions
+● Disallow comments from being inserted as text nodes       passed
+● Disallow direct mutation of this.state                    passed
+● Disallow duplicate properties in JSX                      passed
+● Disallow invalid regular expression strings in `RegExp`   passed
   constructors
-● Disallow loops with a body that allows only one iteration           passed
-● Disallow missing displayName in a React component definition        passed
-● Disallow missing React when using JSX                               passed
-● Disallow negating the left operand of relational operators          passed
-● Disallow passing of children as props                               passed
-● Disallow React to be incorrectly marked as unused                   passed
-● Disallow reassigning `const` variables                              passed
-● Disallow the use of `debugger`                                      passed
-● Disallow the use of undeclared variables unless mentioned in        passed
-  `/*global */` comments
-● Disallow undeclared variables in JSX                                passed
-● Disallow unescaped HTML entities from appearing in markup           passed
-● Disallow usage of deprecated methods                                passed
-● Disallow usage of findDOMNode                                       passed
-● Disallow usage of isMounted                                         passed
-● Disallow usage of the return value of ReactDOM.render               passed
-● Disallow usage of unknown DOM property                              passed
-● Disallow use of optional chaining in contexts where the             passed
+● Disallow loops with a body that allows only one           passed
+  iteration
+● Disallow missing displayName in a React component         passed
+  definition
+● Disallow missing React when using JSX                     passed
+● Disallow negating the left operand of relational          passed
+  operators
+● Disallow passing of children as props                     passed
+● Disallow React to be incorrectly marked as unused         passed
+● Disallow reassigning `const` variables                    passed
+● Disallow the use of `debugger`                            passed
+● Disallow the use of undeclared variables unless           passed
+  mentioned in `/*global */` comments
+● Disallow undeclared variables in JSX                      passed
+● Disallow unescaped HTML entities from appearing in        passed
+  markup
+● Disallow usage of deprecated methods                      passed
+● Disallow usage of findDOMNode                             passed
+● Disallow usage of isMounted                               passed
+● Disallow usage of the return value of ReactDOM.render     passed
+● Disallow usage of unknown DOM property                    passed
+● Disallow use of optional chaining in contexts where the   passed
   `undefined` value is not allowed
-● Disallow using Object.assign with an object literal as the first    passed
-  argument and prefer the use of object spread instead
-● Disallow using string references                                    passed
-● Disallow variables used in JSX to be incorrectly marked as unused   passed
-● Disallow when a DOM element is using both children and              passed
+● Disallow using Object.assign with an object literal as    passed
+  the first argument and prefer the use of object spread
+  instead
+● Disallow using string references                          passed
+● Disallow variables used in JSX to be incorrectly marked   passed
+  as unused
+● Disallow when a DOM element is using both children and    passed
   dangerouslySetInnerHTML
-● Enforce a maximum number of lines per file                          passed
-● Enforce camelcase naming convention                                 passed
-● Enforce comparing `typeof` expressions against valid strings        passed
-● Enforce consistent brace style for all control statements           passed
-● Enforce ES5 or ES6 class for returning value in render function     passed
-● enforces the Rules of Hooks                                         passed
-● Require `let` or `const` instead of `var`                           passed
-● Require calls to `isNaN()` when checking for `NaN`                  passed
-● Require or disallow "Yoda" conditions                               passed
-● Require using arrow functions for callbacks                         passed
+● Enforce a maximum number of lines per file                passed
+● Enforce camelcase naming convention                       passed
+● Enforce comparing `typeof` expressions against valid      passed
+  strings
+● Enforce consistent brace style for all control            passed
+  statements
+● Enforce ES5 or ES6 class for returning value in render    passed
+  function
+● enforces the Rules of Hooks                               passed
+● Require `let` or `const` instead of `var`                 passed
+● Require calls to `isNaN()` when checking for `NaN`        passed
+● Require or disallow "Yoda" conditions                     passed
+● Require using arrow functions for callbacks               passed
 
 
 Lighthouse audits
 
-● First Contentful Paint                                              1.2 s
-● Largest Contentful Paint                                            1.5 s
-● Speed Index                                                         1.2 s
-● Cumulative Layout Shift                                             0
-● Total Blocking Time                                                 0 ms
+● Minimize third-party usage                                Third-party code
+                                                            blocked the main
+                                                            thread for 6,850 ms
+● First Contentful Paint                                    1.2 s
+● Largest Contentful Paint                                  1.5 s
+● Speed Index                                               1.2 s
+● Cumulative Layout Shift                                   0
+● Total Blocking Time                                       0 ms
 
 Categories
 

--- a/packages/utils/src/lib/reports/__snapshots__/report.md
+++ b/packages/utils/src/lib/reports/__snapshots__/report.md
@@ -448,6 +448,12 @@ ESLint rule **yoda**. [📖 Docs](https://eslint.org/docs/latest/rules/yoda)
 
 ESLint rule **prefer-arrow-callback**. [📖 Docs](https://eslint.org/docs/latest/rules/prefer-arrow-callback)
 
+### Minimize third-party usage (Lighthouse)
+
+🟥 **Third-party code blocked the main thread for 6,850 ms** (score: 0)
+
+Third-party code can significantly impact load performance. Limit the number of redundant third-party providers and try to load third-party code after your page has primarily finished loading. [Learn how to minimize third-party impact](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/).
+
 ### First Contentful Paint (Lighthouse)
 
 🟨 **1.2 s** (score: 76)
@@ -485,11 +491,11 @@ Report was created by [Code PushUp](https://github.com/code-pushup/cli#readme) o
 | Plugin     | Audits | Version | Duration |
 | :--------- | :----: | :-----: | -------: |
 | ESLint     |   47   | `0.1.0` |   368 ms |
-| Lighthouse |   5    | `0.1.0` |   1.23 s |
+| Lighthouse |   6    | `0.1.0` |   1.23 s |
 
 | Commit                                                 | Version | Duration | Plugins | Categories | Audits |
 | :----------------------------------------------------- | :-----: | -------: | :-----: | :--------: | :----: |
-| Minor fixes (abcdef0123456789abcdef0123456789abcdef01) | `0.0.1` |   1.65 s |    2    |     3      |   52   |
+| Minor fixes (abcdef0123456789abcdef0123456789abcdef01) | `0.0.1` |   1.65 s |    2    |     3      |   53   |
 
 ---
 

--- a/packages/utils/src/lib/reports/log-stdout-summary.ts
+++ b/packages/utils/src/lib/reports/log-stdout-summary.ts
@@ -55,7 +55,8 @@ function logPlugins(report: ScoredReport): void {
         },
         {
           text: cyanBright(audit.displayValue || `${audit.value}`),
-          width: 10,
+          // eslint-disable-next-line no-magic-numbers
+          width: 20,
           padding: [0, 0, 0, 0],
         },
       ]);

--- a/testing/test-utils/src/lib/utils/dynamic-mocks/lighthouse-audits.mock.ts
+++ b/testing/test-utils/src/lib/utils/dynamic-mocks/lighthouse-audits.mock.ts
@@ -78,6 +78,16 @@ export const LIGHTHOUSE_AUDITS_MAP = {
     value: 1189,
     displayValue: '1.2 s',
   },
+  'third-party-summary': {
+    slug: 'third-party-summary',
+    title: 'Minimize third-party usage',
+    description:
+      'Third-party code can significantly impact load performance. Limit the number of redundant third-party providers and try to load third-party code after your page has primarily finished loading. [Learn how to minimize third-party impact](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/).',
+    docsUrl: undefined,
+    displayValue: 'Third-party code blocked the main thread for 6,850 ms',
+    value: 0,
+    score: 0,
+  },
 } satisfies Record<string, AuditReport>;
 
 export const LIGHTHOUSE_AUDIT_SLUGS = Object.keys(


### PR DESCRIPTION
Closes #665 

- [x] Increase a column width from 10 to 20
- [x] Add a new audit in Lighthouse audit mocks to test how an audit value column wraps a long `displayValue`
- [x] Update snapshots

<details>
  <summary>Screenshots</summary>
<p></p>
<p>Before:</p>
<img width="500" alt="Screenshot 2024-08-13 at 6 48 56 PM" src="https://github.com/user-attachments/assets/c31fe1e8-1fa4-4746-8e23-788f4a9c24d5">
<p></p>
<p>After:</p>
<img width="500" alt="Screenshot 2024-08-13 at 6 32 37 PM" src="https://github.com/user-attachments/assets/165f9577-f02b-4f8e-8cac-a012f7e7de57">
<p></p>
<p>Before:</p>
<img width="500" alt="Screenshot 2024-08-13 at 6 48 00 PM" src="https://github.com/user-attachments/assets/9b52130a-5bc9-437b-8524-63ccef235719">
<p></p>
<p>After:</p>
<img width="500" alt="Screenshot 2024-08-13 at 6 31 55 PM" src="https://github.com/user-attachments/assets/7c8479fd-057a-454d-bac5-e5960cda0134">
</details>