### PR TITLE
fix(plugin-lighthouse): process empty array flags

### DIFF
--- a/packages/plugin-lighthouse/src/lib/lighthouse-plugin.ts
+++ b/packages/plugin-lighthouse/src/lib/lighthouse-plugin.ts
@@ -14,12 +14,8 @@ export function lighthousePlugin(
   url: string,
   flags?: LighthouseOptions,
 ): PluginConfig {
-  const {
-    skipAudits = [],
-    onlyAudits = [],
-    onlyCategories = [],
-    ...unparsedFlags
-  } = normalizeFlags(flags ?? {});
+  const { skipAudits, onlyAudits, onlyCategories, ...unparsedFlags } =
+    normalizeFlags(flags ?? {});
 
   const { audits, groups } = filterAuditsAndGroupsByOnlyOptions(
     LIGHTHOUSE_NAVIGATION_AUDITS,

--- a/packages/plugin-lighthouse/src/lib/normalize-flags.ts
+++ b/packages/plugin-lighthouse/src/lib/normalize-flags.ts
@@ -50,6 +50,8 @@ export function normalizeFlags(flags?: LighthouseOptions): LighthouseCliFlags {
       )
       // in code-pushup lighthouse categories are mapped as groups, therefor we had to rename "onlyCategories" to "onlyGroups" for the user of the plugin as it was confusing
       .map(([key, v]) => [key === 'onlyGroups' ? 'onlyCategories' : key, v])
+      // onlyAudits and onlyCategories cannot be empty arrays, otherwise skipAudits is ignored by lighthouse
+      .filter(([_, v]) => !(Array.isArray(v) && v.length === 0))
       // undefined | string | string[] => string[] (empty for undefined)
       .map(([key, v]) => {
         if (!REFINED_STRING_OR_STRING_ARRAY.has(key as never)) {

--- a/packages/plugin-lighthouse/src/lib/normalize-flags.unit.test.ts
+++ b/packages/plugin-lighthouse/src/lib/normalize-flags.unit.test.ts
@@ -54,9 +54,6 @@ describe('normalizeFlags', () => {
     channel: 'cli',
     // custom overwrites in favour of the plugin
     quiet: true,
-    onlyAudits: [],
-    skipAudits: [],
-    onlyCategories: [],
     output: ['json'],
     outputPath: join(LIGHTHOUSE_OUTPUT_PATH, LIGHTHOUSE_REPORT_NAME),
   };
@@ -121,5 +118,17 @@ describe('normalizeFlags', () => {
       } as unknown as LighthouseOptions),
     ).toEqual(expect.not.objectContaining({ 'list-all-audits': true }));
     expect(getLogMessages(ui().logger)).toHaveLength(1);
+  });
+
+  it('should remove any flag with an empty array as a value', () => {
+    const flags = {
+      onlyAudits: [],
+      skipAudits: [],
+      onlyCategories: [],
+    };
+    const result = normalizeFlags(flags);
+    expect(result).not.toHaveProperty(['onlyAudits']);
+    expect(result).not.toHaveProperty('skipAudits');
+    expect(result).not.toHaveProperty('onlyCategories');
   });
 });

--- a/packages/plugin-lighthouse/src/lib/normalize-flags.unit.test.ts
+++ b/packages/plugin-lighthouse/src/lib/normalize-flags.unit.test.ts
@@ -127,7 +127,7 @@ describe('normalizeFlags', () => {
       onlyCategories: [],
     };
     const result = normalizeFlags(flags);
-    expect(result).not.toHaveProperty(['onlyAudits']);
+    expect(result).not.toHaveProperty('onlyAudits');
     expect(result).not.toHaveProperty('skipAudits');
     expect(result).not.toHaveProperty('onlyCategories');
   });

--- a/packages/plugin-lighthouse/src/lib/runner/utils.ts
+++ b/packages/plugin-lighthouse/src/lib/runner/utils.ts
@@ -17,25 +17,12 @@ import type { LighthouseOptions } from '../types';
 import { logUnsupportedDetails, toAuditDetails } from './details/details';
 import { LighthouseCliFlags } from './types';
 
-// @TODO fix https://github.com/code-pushup/cli/issues/612
 export function normalizeAuditOutputs(
   auditOutputs: AuditOutputs,
   flags: LighthouseOptions = { skipAudits: [] },
 ): AuditOutputs {
   const toSkip = new Set(flags.skipAudits ?? []);
-  return auditOutputs.filter(({ slug }) => {
-    const doSkip = toSkip.has(slug);
-    if (doSkip) {
-      ui().logger.info(
-        `Audit ${bold(
-          slug,
-        )} was included in audit outputs of lighthouse but listed under ${bold(
-          'skipAudits',
-        )}.`,
-      );
-    }
-    return !doSkip;
-  });
+  return auditOutputs.filter(({ slug }) => !toSkip.has(slug));
 }
 
 export class LighthouseAuditParsingError extends Error {


### PR DESCRIPTION
Closes #612 

This PR addresses an issue where the `skipAudits` flag was being ignored if `onlyAudits` or `onlyCategories` were present as empty arrays in the Lighthouse plugin configuration. The `normalizeFlags` function has been updated to remove any flags with empty array values, ensuring that `skipAudits` operates correctly.

### Context

In Lighthouse, the `onlyAudits`, `onlyCategories`, and `skipAudits` flags are used to determine which audits to include in the report. However, a bug occurred when `onlyAudits` or `onlyCategories` were provided as empty arrays. This caused the `skipAudits` flag to be ignored, leading to all audits being included in the report, even those that were supposed to be skipped.

Source: [https://github.com/GoogleChrome/lighthouse/blob/main/core/config/filters.js#L269-L276](https://github.com/GoogleChrome/lighthouse/blob/main/core/config/filters.js#L269-L276)