### PR TITLE
feat(cli): implement `merge-diffs` command

### DIFF
--- a/e2e/cli-e2e/tests/__snapshots__/help.e2e.test.ts.snap
+++ b/e2e/cli-e2e/tests/__snapshots__/help.e2e.test.ts.snap
@@ -14,7 +14,7 @@ Commands:
   code-pushup compare       Compare 2 report files and create a diff file
 
   code-pushup print-config  Print config
-  code-pushup merge-diffs   Combine many report diffs into single report-diff.md
+  code-pushup merge-diffs   Combine many report diffs into a single diff file
 
 
 Global Options:

--- a/e2e/cli-e2e/tests/__snapshots__/help.e2e.test.ts.snap
+++ b/e2e/cli-e2e/tests/__snapshots__/help.e2e.test.ts.snap
@@ -14,6 +14,8 @@ Commands:
   code-pushup compare       Compare 2 report files and create a diff file
 
   code-pushup print-config  Print config
+  code-pushup merge-diffs   Combine many report diffs into single report-diff.md
+
 
 Global Options:
       --progress     Show progress bar in stdout.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -268,12 +268,13 @@ Usage:
 Description:
 Compare 2 reports and produce a report diff file.
 
-In addition to the [Common Command Options](#common-command-options), the following options are required:
+In addition to the [Common Command Options](#common-command-options), the following options are recognized by the `compare` command:
 
-| Option         | Type     | Description                   |
-| -------------- | -------- | ----------------------------- |
-| **`--before`** | `string` | Path to source `report.json`. |
-| **`--after`**  | `string` | Path to target `report.json`. |
+| Option         | Required | Type     | Description                         |
+| -------------- | :------: | -------- | ----------------------------------- |
+| **`--before`** |   yes    | `string` | Path to source `report.json`.       |
+| **`--after`**  |   yes    | `string` | Path to target `report.json`.       |
+| **`--label`**  |    no    | `string` | Label for diff (e.g. project name). |
 
 #### `print-config` command
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -285,3 +285,17 @@ Description:
 Print the resolved configuration.
 
 Refer to the [Common Command Options](#common-command-options) for the list of available options.
+
+### `merge-diffs` command
+
+Usage:
+`code-pushup merge-diffs --files PATH_1 PATH_2 ... [options]`
+
+Description:
+Combine multiple report diffs into a single `report-diff.md`.
+
+In addition to the [Common Command Options](#common-command-options), the following options are recognized by the `merge-diffs` command:
+
+| Option        | Required | Type       | Description                       |
+| ------------- | :------: | ---------- | --------------------------------- |
+| **`--files`** |   yes    | `string[]` | List of `report-diff.json` paths. |

--- a/packages/cli/src/lib/commands.ts
+++ b/packages/cli/src/lib/commands.ts
@@ -3,6 +3,7 @@ import { yargsAutorunCommandObject } from './autorun/autorun-command';
 import { yargsCollectCommandObject } from './collect/collect-command';
 import { yargsCompareCommandObject } from './compare/compare-command';
 import { yargsHistoryCommandObject } from './history/history-command';
+import { yargsMergeDiffsCommandObject } from './merge-diffs/merge-diffs-command';
 import { yargsConfigCommandObject } from './print-config/print-config-command';
 import { yargsUploadCommandObject } from './upload/upload-command';
 
@@ -17,4 +18,5 @@ export const commands: CommandModule[] = [
   yargsHistoryCommandObject(),
   yargsCompareCommandObject(),
   yargsConfigCommandObject(),
+  yargsMergeDiffsCommandObject(),
 ];

--- a/packages/cli/src/lib/compare/compare-command.ts
+++ b/packages/cli/src/lib/compare/compare-command.ts
@@ -22,12 +22,13 @@ export function yargsCompareCommandObject() {
         upload?: UploadConfig;
       };
 
-      const { before, after, persist, upload } = options;
+      const { before, after, label, persist, upload } = options;
 
       const outputPaths = await compareReportFiles(
         { before, after },
         persist,
         upload,
+        label,
       );
 
       ui().logger.info(

--- a/packages/cli/src/lib/compare/compare-command.unit.test.ts
+++ b/packages/cli/src/lib/compare/compare-command.unit.test.ts
@@ -44,6 +44,28 @@ describe('compare-command', () => {
         format: DEFAULT_PERSIST_FORMAT,
       },
       expect.any(Object),
+      undefined,
+    );
+  });
+
+  it('should forward label from command line', async () => {
+    await yargsCli(
+      [
+        'compare',
+        '--before=source-report.json',
+        '--after=target-report.json',
+        '--label=core',
+      ],
+      { ...DEFAULT_CLI_CONFIGURATION, commands: [yargsCompareCommandObject()] },
+    ).parseAsync();
+
+    expect(compareReportFiles).toHaveBeenCalledWith<
+      Parameters<typeof compareReportFiles>
+    >(
+      { before: 'source-report.json', after: 'target-report.json' },
+      expect.any(Object),
+      expect.any(Object),
+      'core',
     );
   });
 

--- a/packages/cli/src/lib/implementation/compare.model.ts
+++ b/packages/cli/src/lib/implementation/compare.model.ts
@@ -1,3 +1,3 @@
 import { Diff } from '@code-pushup/utils';
 
-export type CompareOptions = Diff<string>;
+export type CompareOptions = Diff<string> & { label?: string };

--- a/packages/cli/src/lib/implementation/compare.options.ts
+++ b/packages/cli/src/lib/implementation/compare.options.ts
@@ -16,5 +16,9 @@ export function yargsCompareOptionsDefinition(): Record<
       type: 'string',
       demandOption: true,
     },
+    label: {
+      describe: 'Label for diff (e.g. project name)',
+      type: 'string',
+    },
   };
 }

--- a/packages/cli/src/lib/implementation/merge-diffs.model.ts
+++ b/packages/cli/src/lib/implementation/merge-diffs.model.ts
@@ -1,0 +1,3 @@
+export type MergeDiffsOptions = {
+  files: string[];
+};

--- a/packages/cli/src/lib/implementation/merge-diffs.options.ts
+++ b/packages/cli/src/lib/implementation/merge-diffs.options.ts
@@ -1,0 +1,15 @@
+import { Options } from 'yargs';
+import type { MergeDiffsOptions } from './merge-diffs.model';
+
+export function yargsMergeDiffsOptionsDefinition(): Record<
+  keyof MergeDiffsOptions,
+  Options
+> {
+  return {
+    files: {
+      describe: 'List of report-diff.json paths',
+      type: 'array',
+      demandOption: true,
+    },
+  };
+}

--- a/packages/cli/src/lib/merge-diffs/merge-diffs-command.ts
+++ b/packages/cli/src/lib/merge-diffs/merge-diffs-command.ts
@@ -11,7 +11,7 @@ export function yargsMergeDiffsCommandObject() {
   const command = 'merge-diffs';
   return {
     command,
-    describe: 'Combine many report diffs into single report-diff.md',
+    describe: 'Combine many report diffs into a single diff file',
     builder: yargsMergeDiffsOptionsDefinition(),
     handler: async (args: unknown) => {
       ui().logger.log(bold(CLI_NAME));

--- a/packages/cli/src/lib/merge-diffs/merge-diffs-command.ts
+++ b/packages/cli/src/lib/merge-diffs/merge-diffs-command.ts
@@ -1,0 +1,30 @@
+import { bold, gray } from 'ansis';
+import { CommandModule } from 'yargs';
+import { mergeDiffs } from '@code-pushup/core';
+import { PersistConfig } from '@code-pushup/models';
+import { ui } from '@code-pushup/utils';
+import { CLI_NAME } from '../constants';
+import { MergeDiffsOptions } from '../implementation/merge-diffs.model';
+import { yargsMergeDiffsOptionsDefinition } from '../implementation/merge-diffs.options';
+
+export function yargsMergeDiffsCommandObject() {
+  const command = 'merge-diffs';
+  return {
+    command,
+    describe: 'Combine many report diffs into single report-diff.md',
+    builder: yargsMergeDiffsOptionsDefinition(),
+    handler: async (args: unknown) => {
+      ui().logger.log(bold(CLI_NAME));
+      ui().logger.info(gray(`Run ${command}...`));
+
+      const options = args as MergeDiffsOptions & {
+        persist: Required<PersistConfig>;
+      };
+      const { files, persist } = options;
+
+      const outputPath = await mergeDiffs(files, persist);
+
+      ui().logger.info(`Reports diff written to ${bold(outputPath)}`);
+    },
+  } satisfies CommandModule;
+}

--- a/packages/cli/src/lib/merge-diffs/merge-diffs-command.unit.test.ts
+++ b/packages/cli/src/lib/merge-diffs/merge-diffs-command.unit.test.ts
@@ -1,0 +1,72 @@
+import { bold } from 'ansis';
+import { mergeDiffs } from '@code-pushup/core';
+import {
+  DEFAULT_PERSIST_FILENAME,
+  DEFAULT_PERSIST_FORMAT,
+  DEFAULT_PERSIST_OUTPUT_DIR,
+} from '@code-pushup/models';
+import { getLogMessages } from '@code-pushup/test-utils';
+import { ui } from '@code-pushup/utils';
+import { DEFAULT_CLI_CONFIGURATION } from '../../../mocks/constants';
+import { yargsCli } from '../yargs-cli';
+import { yargsMergeDiffsCommandObject } from './merge-diffs-command';
+
+vi.mock('@code-pushup/core', async () => {
+  const core: object = await vi.importActual('@code-pushup/core');
+  const { CORE_CONFIG_MOCK }: typeof import('@code-pushup/test-utils') =
+    await vi.importActual('@code-pushup/test-utils');
+  return {
+    ...core,
+    autoloadRc: vi.fn().mockResolvedValue(CORE_CONFIG_MOCK),
+    mergeDiffs: vi.fn().mockResolvedValue('.code-pushup/report-diff.md'),
+  };
+});
+
+describe('merge-diffs-command', () => {
+  it('should parse input paths from command line and output path from persist config', async () => {
+    await yargsCli(
+      [
+        'merge-diffs',
+        '--files',
+        'frontoffice/report-diff.json',
+        'backoffice/report-diff.json',
+        'api/report-diff.json',
+      ],
+      {
+        ...DEFAULT_CLI_CONFIGURATION,
+        commands: [yargsMergeDiffsCommandObject()],
+      },
+    ).parseAsync();
+
+    expect(mergeDiffs).toHaveBeenCalledWith<Parameters<typeof mergeDiffs>>(
+      [
+        'frontoffice/report-diff.json',
+        'backoffice/report-diff.json',
+        'api/report-diff.json',
+      ],
+      {
+        outputDir: DEFAULT_PERSIST_OUTPUT_DIR,
+        filename: DEFAULT_PERSIST_FILENAME,
+        format: DEFAULT_PERSIST_FORMAT,
+      },
+    );
+  });
+
+  it('should log output path to stdout', async () => {
+    await yargsCli(
+      [
+        'merge-diffs',
+        '--files=frontoffice/report-diff.json',
+        '--files=backoffice/report-diff.json',
+      ],
+      {
+        ...DEFAULT_CLI_CONFIGURATION,
+        commands: [yargsMergeDiffsCommandObject()],
+      },
+    ).parseAsync();
+
+    expect(getLogMessages(ui().logger).at(-1)).toContain(
+      `Reports diff written to ${bold('.code-pushup/report-diff.md')}`,
+    );
+  });
+});

--- a/packages/cli/src/lib/yargs-cli.integration.test.ts
+++ b/packages/cli/src/lib/yargs-cli.integration.test.ts
@@ -8,6 +8,8 @@ import {
   UploadConfigCliOptions,
 } from './implementation/core-config.model';
 import { GeneralCliOptions } from './implementation/global.model';
+import { MergeDiffsOptions } from './implementation/merge-diffs.model';
+import { yargsMergeDiffsOptionsDefinition } from './implementation/merge-diffs.options';
 import { OnlyPluginsOptions } from './implementation/only-plugins.model';
 import { yargsOnlyPluginsOptionsDefinition } from './implementation/only-plugins.options';
 import { SkipPluginsOptions } from './implementation/skip-plugins.model';
@@ -173,6 +175,30 @@ describe('yargsCli', () => {
         noExitProcess: true,
       }).parse(),
     ).toThrow('Missing required arguments: before, after');
+  });
+
+  it('should parse merge-diffs options', async () => {
+    const parsedArgv = await yargsCli<GeneralCliOptions & MergeDiffsOptions>(
+      [
+        '--files',
+        '.code-pushup/frontend/report-diff.json',
+        '.code-pushup/backend/report-diff.json',
+      ],
+      { options: { ...options, ...yargsMergeDiffsOptionsDefinition() } },
+    ).parseAsync();
+    expect(parsedArgv.files).toEqual([
+      '.code-pushup/frontend/report-diff.json',
+      '.code-pushup/backend/report-diff.json',
+    ]);
+  });
+
+  it('should error if required merge-diffs option is missing', () => {
+    expect(() =>
+      yargsCli<GeneralCliOptions & CompareOptions>([], {
+        options: { ...options, ...yargsMergeDiffsOptionsDefinition() },
+        noExitProcess: true,
+      }).parse(),
+    ).toThrow('Missing required argument: files');
   });
 
   it('should provide default arguments for history command', async () => {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -23,3 +23,4 @@ export {
 } from './lib/implementation/read-rc-file';
 export { GlobalOptions } from './lib/types';
 export { UploadOptions, upload } from './lib/upload';
+export { mergeDiffs } from './lib/merge-diffs';

--- a/packages/core/src/lib/merge-diffs.ts
+++ b/packages/core/src/lib/merge-diffs.ts
@@ -1,0 +1,13 @@
+import { PersistConfig, reportsDiffSchema } from '@code-pushup/models';
+import { readJsonFile } from '@code-pushup/utils';
+
+export async function mergeDiffs(
+  files: string[],
+  persistConfig: Required<PersistConfig>,
+): Promise<string> {
+  const diffs = await Promise.all(
+    files.map(file => readJsonFile(file).then(reportsDiffSchema.parseAsync)),
+  );
+  // TODO: implement
+  return '<path>';
+}

--- a/packages/core/src/lib/merge-diffs.ts
+++ b/packages/core/src/lib/merge-diffs.ts
@@ -1,13 +1,44 @@
+import { writeFile } from 'node:fs/promises';
+import { basename, dirname, join } from 'node:path';
 import { PersistConfig, reportsDiffSchema } from '@code-pushup/models';
-import { readJsonFile } from '@code-pushup/utils';
+import {
+  ensureDirectoryExists,
+  generateMdReportsDiffForMonorepo,
+  isPromiseFulfilledResult,
+  isPromiseRejectedResult,
+  readJsonFile,
+  ui,
+} from '@code-pushup/utils';
 
 export async function mergeDiffs(
   files: string[],
   persistConfig: Required<PersistConfig>,
 ): Promise<string> {
-  const diffs = await Promise.all(
-    files.map(file => readJsonFile(file).then(reportsDiffSchema.parseAsync)),
+  const results = await Promise.allSettled(
+    files.map(async file => {
+      const json = await readJsonFile(file);
+      const diff = await reportsDiffSchema.parseAsync(json);
+      return { ...diff, file };
+    }),
   );
-  // TODO: implement
-  return '<path>';
+  results.filter(isPromiseRejectedResult).forEach(({ reason }) => {
+    ui().logger.warning(`Failed to parse report diff file - ${reason}`);
+  });
+  const diffs = results
+    .filter(isPromiseFulfilledResult)
+    .map(({ value }) => value);
+
+  const labeledDiffs = diffs.map(diff => ({
+    ...diff,
+    label: diff.label || basename(dirname(diff.file)), // fallback is parent folder name
+  }));
+
+  const markdown = generateMdReportsDiffForMonorepo(labeledDiffs);
+
+  const { outputDir, filename } = persistConfig;
+  const outputPath = join(outputDir, `${filename}-diff.md`);
+  await ensureDirectoryExists(outputDir);
+  await writeFile(outputPath, markdown);
+
+  return outputPath;
 }

--- a/packages/core/src/lib/merge-diffs.unit.test.ts
+++ b/packages/core/src/lib/merge-diffs.unit.test.ts
@@ -66,10 +66,10 @@ describe('mergeDiffs', () => {
 
     expect(getLogMessages(ui().logger)).toEqual([
       expect.stringContaining(
-        'Failed to parse report diff file - Error: ENOENT: no such file or directory',
+        'Skipped invalid report diff - Failed to read JSON file missing-report-diff.json',
       ),
-      expect.stringMatching(
-        /Failed to parse report diff file - .*invalid_type.*Required/s,
+      expect.stringContaining(
+        'Skipped invalid report diff - Invalid reports diff in invalid-report-diff.json',
       ),
     ]);
   });

--- a/packages/core/src/lib/merge-diffs.unit.test.ts
+++ b/packages/core/src/lib/merge-diffs.unit.test.ts
@@ -1,0 +1,76 @@
+import { vol } from 'memfs';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { PersistConfig } from '@code-pushup/models';
+import {
+  MEMFS_VOLUME,
+  getLogMessages,
+  reportsDiffAddedPluginMock,
+  reportsDiffAltMock,
+  reportsDiffMock,
+  reportsDiffUnchangedMock,
+} from '@code-pushup/test-utils';
+import { fileExists, ui } from '@code-pushup/utils';
+import { mergeDiffs } from './merge-diffs';
+
+describe('mergeDiffs', () => {
+  const diffPaths = {
+    'console/report-diff.json': JSON.stringify(reportsDiffMock()),
+    'admin/report-diff.json': JSON.stringify(reportsDiffAltMock()),
+    'website/report-diff.json': JSON.stringify(reportsDiffUnchangedMock()),
+    'docs/report-diff.json': JSON.stringify(reportsDiffAddedPluginMock()),
+  };
+  const files = Object.keys(diffPaths);
+  const persistConfig: Required<PersistConfig> = {
+    outputDir: MEMFS_VOLUME,
+    filename: 'report',
+    format: ['json', 'md'],
+  };
+
+  beforeEach(() => {
+    vol.fromJSON(diffPaths, MEMFS_VOLUME);
+  });
+
+  it('should create Markdown file', async () => {
+    const outputPath = await mergeDiffs(files, persistConfig);
+
+    expect(outputPath).toBe(join(MEMFS_VOLUME, 'report-diff.md'));
+    await expect(fileExists(outputPath)).resolves.toBe(true);
+    await expect(readFile(outputPath, 'utf8')).resolves.toContain(
+      '# Code PushUp',
+    );
+  });
+
+  it('should use parent folder as project name in Markdown output if label missing in diff', async () => {
+    const outputPath = await mergeDiffs(files, persistConfig);
+
+    const markdown = await readFile(outputPath, 'utf8');
+    // `website` is unchanged, therefore not mentioned by name
+    expect(markdown).toContain('## 💼 Project `console`');
+    expect(markdown).toContain('## 💼 Project `admin`');
+    expect(markdown).toContain('## 💼 Project `docs`');
+  });
+
+  it('should log warnings if file parsing failed', async () => {
+    vol.fromJSON(
+      { ...diffPaths, 'invalid-report-diff.json': '{}' },
+      MEMFS_VOLUME,
+    );
+
+    await expect(
+      mergeDiffs(
+        [...files, 'missing-report-diff.json', 'invalid-report-diff.json'],
+        persistConfig,
+      ),
+    ).resolves.toBe(join(MEMFS_VOLUME, 'report-diff.md'));
+
+    expect(getLogMessages(ui().logger)).toEqual([
+      expect.stringContaining(
+        'Failed to parse report diff file - Error: ENOENT: no such file or directory',
+      ),
+      expect.stringMatching(
+        /Failed to parse report diff file - .*invalid_type.*Required/s,
+      ),
+    ]);
+  });
+});

--- a/packages/models/docs/models-reference.md
+++ b/packages/models/docs/models-reference.md
@@ -1193,13 +1193,6 @@ _Object containing the following properties:_
 
 _(\*) Required._
 
-## PrimitiveValue
-
-_Union of the following possible types:_
-
-- `string`
-- `number`
-
 ## Report
 
 _Object containing the following properties:_
@@ -1223,6 +1216,8 @@ _Object containing the following properties:_
 | Property               | Description                                     | Type                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
 | :--------------------- | :---------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **`commits`** (\*)     | Commits identifying compared reports            | _Object with properties:_<ul><li>`before`: _Object with properties:_<ul><li>`hash`: `string` (_regex: `/^[\da-f]{40}$/`_) - Commit SHA (full)</li><li>`message`: `string` - Commit message</li><li>`date`: `Date` (_nullable_) - Date and time when commit was authored</li><li>`author`: `string` - Commit author name</li></ul> - Git commit (source commit)</li><li>`after`: _Object with properties:_<ul><li>`hash`: `string` (_regex: `/^[\da-f]{40}$/`_) - Commit SHA (full)</li><li>`message`: `string` - Commit message</li><li>`date`: `Date` (_nullable_) - Date and time when commit was authored</li><li>`author`: `string` - Commit author name</li></ul> - Git commit (target commit)</li></ul> (_nullable_) |
+| `portalUrl`            | Link to comparison page in Code PushUp portal   | `string` (_url_)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| `label`                | Label (e.g. project name)                       | `string`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
 | **`categories`** (\*)  | Changes affecting categories                    | _Object with properties:_<ul><li>`changed`: _Array of [CategoryDiff](#categorydiff) items_</li><li>`unchanged`: _Array of [CategoryResult](#categoryresult) items_</li><li>`added`: _Array of [CategoryResult](#categoryresult) items_</li><li>`removed`: _Array of [CategoryResult](#categoryresult) items_</li></ul>                                                                                                                                                                                                                                                                                                                                                                                                     |
 | **`groups`** (\*)      | Changes affecting groups                        | _Object with properties:_<ul><li>`changed`: _Array of [GroupDiff](#groupdiff) items_</li><li>`unchanged`: _Array of [GroupResult](#groupresult) items_</li><li>`added`: _Array of [GroupResult](#groupresult) items_</li><li>`removed`: _Array of [GroupResult](#groupresult) items_</li></ul>                                                                                                                                                                                                                                                                                                                                                                                                                             |
 | **`audits`** (\*)      | Changes affecting audits                        | _Object with properties:_<ul><li>`changed`: _Array of [AuditDiff](#auditdiff) items_</li><li>`unchanged`: _Array of [AuditResult](#auditresult) items_</li><li>`added`: _Array of [AuditResult](#auditresult) items_</li><li>`removed`: _Array of [AuditResult](#auditresult) items_</li></ul>                                                                                                                                                                                                                                                                                                                                                                                                                             |
@@ -1270,6 +1265,18 @@ _Enum string, one of the following possible values:_
 - `'center'`
 - `'right'`
 
+## TableCellValue
+
+_Union of the following possible types:_
+
+- `string`
+- `number`
+- `boolean`
+- `null` (_nullable_)
+  (_optional & nullable_)
+
+_Default value:_ `null`
+
 ## TableColumnObject
 
 _Object containing the following properties:_
@@ -1299,13 +1306,13 @@ Object row
 _Object record with dynamic keys:_
 
 - _keys of type_ `string`
-- _values of type_ [PrimitiveValue](#primitivevalue)
+- _values of type_ [TableCellValue](#tablecellvalue) (_optional & nullable_)
 
 ## TableRowPrimitive
 
 Primitive row
 
-_Array of [PrimitiveValue](#primitivevalue) items._
+_Array of [TableCellValue](#tablecellvalue) (\_optional & nullable_) items.\_
 
 ## UploadConfig
 

--- a/packages/models/src/lib/reports-diff.ts
+++ b/packages/models/src/lib/reports-diff.ts
@@ -12,6 +12,7 @@ import {
   scoreSchema,
   slugSchema,
   titleSchema,
+  urlSchema,
 } from './implementation/schemas';
 import { pluginMetaSchema } from './plugin-config';
 
@@ -112,6 +113,10 @@ export const reportsDiffSchema = z
     commits: makeComparisonSchema(commitSchema)
       .nullable()
       .describe('Commits identifying compared reports'),
+    portalUrl: urlSchema
+      .optional()
+      .describe('Link to comparison page in Code PushUp portal'),
+    label: z.string().optional().describe('Label (e.g. project name)'),
     categories: makeArraysComparisonSchema(
       categoryDiffSchema,
       categoryResultSchema,

--- a/packages/models/src/lib/reports-diff.unit.test.ts
+++ b/packages/models/src/lib/reports-diff.unit.test.ts
@@ -18,6 +18,9 @@ describe('reportsDiffSchema', () => {
             date: new Date(),
           },
         },
+        portalUrl:
+          'https://code-pushup.example.com/portal/example/website/comparison/abcdef0123456789abcdef0123456789abcdef01/0123456789abcdef0123456789abcdef01234567',
+        label: 'website',
         date: new Date().toISOString(),
         duration: 42,
         packageName: '@code-pushup/core',

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,5 +1,6 @@
 export { exists } from '@code-pushup/models';
 export { Diff, comparePairs, matchArrayItemsByKey } from './lib/diff';
+export { stringifyError } from './lib/errors';
 export {
   ProcessConfig,
   ProcessError,

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -71,7 +71,10 @@ export {
   listGroupsFromAllPlugins,
 } from './lib/reports/flatten-plugins';
 export { generateMdReport } from './lib/reports/generate-md-report';
-export { generateMdReportsDiff } from './lib/reports/generate-md-reports-diff';
+export {
+  generateMdReportsDiff,
+  generateMdReportsDiffForMonorepo,
+} from './lib/reports/generate-md-reports-diff';
 export { loadReport } from './lib/reports/load-report';
 export { logStdoutSummary } from './lib/reports/log-stdout-summary';
 export { scoreReport } from './lib/reports/scoring';
@@ -108,10 +111,10 @@ export {
 } from './lib/transform';
 export {
   ExcludeNullFromPropertyTypes,
-  ExtractArrays,
   ExtractArray,
+  ExtractArrays,
   ItemOrArray,
-  WithRequired,
   Prettify,
+  WithRequired,
 } from './lib/types';
 export { verboseUtils } from './lib/verbose-utils';

--- a/packages/utils/src/lib/errors.ts
+++ b/packages/utils/src/lib/errors.ts
@@ -1,0 +1,13 @@
+export function stringifyError(error: unknown): string {
+  // TODO: special handling for ZodError instances
+  if (error instanceof Error) {
+    if (error.name === 'Error' || error.message.startsWith(error.name)) {
+      return error.message;
+    }
+    return `${error.name}: ${error.message}`;
+  }
+  if (typeof error === 'string') {
+    return error;
+  }
+  return JSON.stringify(error);
+}

--- a/packages/utils/src/lib/errors.unit.test.ts
+++ b/packages/utils/src/lib/errors.unit.test.ts
@@ -1,0 +1,25 @@
+import { stringifyError } from './errors';
+
+describe('stringifyError', () => {
+  it('should use only message from plain Error instance', () => {
+    expect(stringifyError(new Error('something went wrong'))).toBe(
+      'something went wrong',
+    );
+  });
+
+  it('should use class name and message from Error extensions', () => {
+    expect(stringifyError(new TypeError('invalid value'))).toBe(
+      'TypeError: invalid value',
+    );
+  });
+
+  it('should keep strings "as is"', () => {
+    expect(stringifyError('something went wrong')).toBe('something went wrong');
+  });
+
+  it('should format objects as JSON', () => {
+    expect(stringifyError({ status: 400, statusText: 'Bad Request' })).toBe(
+      '{"status":400,"statusText":"Bad Request"}',
+    );
+  });
+});

--- a/packages/utils/src/lib/reports/generate-md-reports-diff.integration.test.ts
+++ b/packages/utils/src/lib/reports/generate-md-reports-diff.integration.test.ts
@@ -65,12 +65,12 @@ describe('generateMdReportsDiff', () => {
   });
 
   it('should format Markdown comment with link to portal', async () => {
-    const report = reportsDiffAltMock();
-    const portalUrl = `https://app.code-pushup.dev/portal/dunder-mifflin/website/comparison/${COMMIT_MOCK.hash}/${COMMIT_ALT_MOCK.hash}`;
-
-    await expect(generateMdReportsDiff(report, portalUrl)).toMatchFileSnapshot(
-      '__snapshots__/report-diff-with-portal.md',
-    );
+    await expect(
+      generateMdReportsDiff({
+        ...reportsDiffAltMock(),
+        portalUrl: `https://app.code-pushup.dev/portal/dunder-mifflin/website/comparison/${COMMIT_MOCK.hash}/${COMMIT_ALT_MOCK.hash}`,
+      }),
+    ).toMatchFileSnapshot('__snapshots__/report-diff-with-portal.md');
   });
 
   it('should format Markdown comment with truncated audits table', async () => {
@@ -105,10 +105,10 @@ describe('generateMdReportsDiffForMonorepo', () => {
   it('should format Markdown comment with multiple projects', async () => {
     await expect(
       generateMdReportsDiffForMonorepo([
-        { name: 'console', diff: reportsDiffMock() },
-        { name: 'admin', diff: reportsDiffAltMock() },
-        { name: 'marketing', diff: reportsDiffUnchangedMock() },
-        { name: 'docs', diff: reportsDiffAddedPluginMock() },
+        { ...reportsDiffMock(), label: 'console' },
+        { ...reportsDiffAltMock(), label: 'admin' },
+        { ...reportsDiffUnchangedMock(), label: 'marketing' },
+        { ...reportsDiffAddedPluginMock(), label: 'docs' },
       ]),
     ).toMatchFileSnapshot('__snapshots__/report-diff-monorepo.md');
   });
@@ -117,13 +117,13 @@ describe('generateMdReportsDiffForMonorepo', () => {
     await expect(
       generateMdReportsDiffForMonorepo([
         {
-          name: 'frontoffice',
-          diff: reportsDiffMock(),
+          ...reportsDiffMock(),
+          label: 'frontoffice',
           portalUrl: `https://app.code-pushup.dev/portal/dunder-mifflin/frontoffice/comparison/${COMMIT_MOCK.hash}/${COMMIT_ALT_MOCK.hash}`,
         },
         {
-          name: 'backoffice',
-          diff: reportsDiffUnchangedMock(),
+          ...reportsDiffUnchangedMock(),
+          label: 'backoffice',
           portalUrl: `https://app.code-pushup.dev/portal/dunder-mifflin/backoffice/comparison/${COMMIT_MOCK.hash}/${COMMIT_ALT_MOCK.hash}`,
         },
       ]),
@@ -133,8 +133,8 @@ describe('generateMdReportsDiffForMonorepo', () => {
   it('should format Markdown comment with all projects unchanged', async () => {
     await expect(
       generateMdReportsDiffForMonorepo([
-        { name: 'frontoffice', diff: reportsDiffUnchangedMock() },
-        { name: 'backoffice', diff: reportsDiffUnchangedMock() },
+        { ...reportsDiffUnchangedMock(), label: 'frontoffice' },
+        { ...reportsDiffUnchangedMock(), label: 'backoffice' },
       ]),
     ).toMatchFileSnapshot('__snapshots__/report-diff-monorepo-unchanged.md');
   });


### PR DESCRIPTION
Part of #731 (CLI)

New `merge-diffs` command implemented, which parses list of `report-diff.json` paths from required `--files` option and uses Markdown formatter from #793 to generate single `report-diff.md`.

Also added a `--label` option to `compare` command, which can be used to set project names for the JSON diffs (parent directory used as fallback).