### PR TITLE
refactor(utils): prioritize score in sort order

### DIFF
--- a/packages/utils/src/lib/reports/__snapshots__/report.md
+++ b/packages/utils/src/lib/reports/__snapshots__/report.md
@@ -14,16 +14,16 @@ Performance metrics [📖 Docs](https://developers.google.com/web/fundamentals/p
 
 🟢 Score: **92**
 
-- 🟢 Performance (_Lighthouse_)
-  - 🟩 [Total Blocking Time](#total-blocking-time-lighthouse) - **0 ms**
-  - 🟨 [Largest Contentful Paint](#largest-contentful-paint-lighthouse) - **1.5 s**
-  - 🟩 [Cumulative Layout Shift](#cumulative-layout-shift-lighthouse) - **0**
-  - 🟨 [First Contentful Paint](#first-contentful-paint-lighthouse) - **1.2 s**
-  - 🟩 [Speed Index](#speed-index-lighthouse) - **1.2 s**
 - 🟥 [Disallow missing `key` props in iterators/collection literals](#disallow-missing-key-props-in-iterators-collection-literals-eslint) (_ESLint_) - **1 warning**
 - 🟡 Maximum lines limitation (_ESLint_)
   - 🟥 [Enforce a maximum number of lines of code in a function](#enforce-a-maximum-number-of-lines-of-code-in-a-function-eslint) - **1 warning**
   - 🟩 [Enforce a maximum number of lines per file](#enforce-a-maximum-number-of-lines-per-file-eslint) - **passed**
+- 🟢 Performance (_Lighthouse_)
+  - 🟨 [First Contentful Paint](#first-contentful-paint-lighthouse) - **1.2 s**
+  - 🟨 [Largest Contentful Paint](#largest-contentful-paint-lighthouse) - **1.5 s**
+  - 🟩 [Speed Index](#speed-index-lighthouse) - **1.2 s**
+  - 🟩 [Total Blocking Time](#total-blocking-time-lighthouse) - **0 ms**
+  - 🟩 [Cumulative Layout Shift](#cumulative-layout-shift-lighthouse) - **0**
 
 ### Bug prevention
 
@@ -31,9 +31,9 @@ Performance metrics [📖 Docs](https://developers.google.com/web/fundamentals/p
 
 - 🟥 [verifies the list of dependencies for Hooks like useEffect and similar](#verifies-the-list-of-dependencies-for-hooks-like-useeffect-and-similar-eslint) (_ESLint_) - **2 warnings**
 - 🟥 [Disallow missing `key` props in iterators/collection literals](#disallow-missing-key-props-in-iterators-collection-literals-eslint) (_ESLint_) - **1 warning**
-- 🟩 [enforces the Rules of Hooks](#enforces-the-rules-of-hooks-eslint) (_ESLint_) - **passed**
 - 🟥 [Disallow missing props validation in a React component definition](#disallow-missing-props-validation-in-a-react-component-definition-eslint) (_ESLint_) - **6 warnings**
 - 🟥 [Require the use of `===` and `!==`](#require-the-use-of--and--eslint) (_ESLint_) - **1 warning**
+- 🟩 [enforces the Rules of Hooks](#enforces-the-rules-of-hooks-eslint) (_ESLint_) - **passed**
 - 🟩 [Disallow assignment operators in conditional expressions](#disallow-assignment-operators-in-conditional-expressions-eslint) (_ESLint_) - **passed**
 - 🟩 [Disallow invalid regular expression strings in `RegExp` constructors](#disallow-invalid-regular-expression-strings-in-regexp-constructors-eslint) (_ESLint_) - **passed**
 - 🟩 [Disallow loops with a body that allows only one iteration](#disallow-loops-with-a-body-that-allows-only-one-iteration-eslint) (_ESLint_) - **passed**

--- a/packages/utils/src/lib/reports/__snapshots__/sorting.integration.test.ts.snap
+++ b/packages/utils/src/lib/reports/__snapshots__/sorting.integration.test.ts.snap
@@ -26,19 +26,7 @@ exports[`sortReport > should sort the audits and audit groups in categories, plu
       "refs": [
         {
           "plugin": "eslint",
-          "slug": "typescript-eslint",
-          "type": "group",
-          "weight": 8,
-        },
-        {
-          "plugin": "eslint",
           "slug": "eslint-functional",
-          "type": "audit",
-          "weight": 1,
-        },
-        {
-          "plugin": "eslint",
-          "slug": "eslint-jest-consistent-naming",
           "type": "audit",
           "weight": 1,
         },
@@ -47,6 +35,18 @@ exports[`sortReport > should sort the audits and audit groups in categories, plu
           "slug": "typescript-eslint-extra",
           "type": "group",
           "weight": 0,
+        },
+        {
+          "plugin": "eslint",
+          "slug": "typescript-eslint",
+          "type": "group",
+          "weight": 8,
+        },
+        {
+          "plugin": "eslint",
+          "slug": "eslint-jest-consistent-naming",
+          "type": "audit",
+          "weight": 1,
         },
         {
           "plugin": "eslint",

--- a/packages/utils/src/lib/reports/sorting.unit.test.ts
+++ b/packages/utils/src/lib/reports/sorting.unit.test.ts
@@ -78,7 +78,7 @@ describe('getSortableAuditByRef', () => {
 });
 
 describe('getSortableGroupByRef', () => {
-  it('should return a sortable group with sorted references', () => {
+  it('should return a sortable group with references sorted based on score > weight > value > title', () => {
     expect(
       getSortableGroupByRef(
         {
@@ -134,12 +134,12 @@ describe('getSortableGroupByRef', () => {
       score: 0.66,
       refs: [
         {
-          slug: 'function-coverage',
-          weight: 2,
-        },
-        {
           slug: 'branch-coverage',
           weight: 1,
+        },
+        {
+          slug: 'function-coverage',
+          weight: 2,
         },
       ],
       weight: 2,
@@ -180,7 +180,7 @@ describe('getSortableGroupByRef', () => {
 });
 
 describe('getSortedGroupAudits', () => {
-  it('should return sorted group audits based on weight > score > value > title', () => {
+  it('should return sorted group audits based on score > weight > value > title', () => {
     expect(
       getSortedGroupAudits(
         {
@@ -226,10 +226,6 @@ describe('getSortedGroupAudits', () => {
       ),
     ).toStrictEqual([
       expect.objectContaining({
-        weight: 6,
-        slug: 'function-coverage',
-      }),
-      expect.objectContaining({
         weight: 3,
         score: 0.5,
         slug: 'line-coverage',
@@ -238,6 +234,10 @@ describe('getSortedGroupAudits', () => {
         weight: 3,
         score: 0.75,
         slug: 'branch-coverage',
+      }),
+      expect.objectContaining({
+        weight: 6,
+        slug: 'function-coverage',
       }),
     ]);
   });

--- a/packages/utils/src/lib/reports/utils.ts
+++ b/packages/utils/src/lib/reports/utils.ts
@@ -164,12 +164,12 @@ export function compareCategoryAuditsAndGroups(
   a: SortableAuditReport | SortableGroup,
   b: SortableAuditReport | SortableGroup,
 ): number {
-  if (a.weight !== b.weight) {
-    return b.weight - a.weight;
-  }
-
   if (a.score !== b.score) {
     return a.score - b.score;
+  }
+
+  if (a.weight !== b.weight) {
+    return b.weight - a.weight;
   }
 
   if ('value' in a && 'value' in b && a.value !== b.value) {

--- a/packages/utils/src/lib/reports/utils.unit.test.ts
+++ b/packages/utils/src/lib/reports/utils.unit.test.ts
@@ -128,7 +128,7 @@ describe('compareIssueSeverity', () => {
 });
 
 describe('compareCategoryAuditsAndGroups', () => {
-  it('should sort audits by weight and score', () => {
+  it('should sort audits by score and weight', () => {
     const mockAudits = [
       { weight: 0, score: 0.1 },
       { weight: 5, score: 1 },
@@ -136,10 +136,10 @@ describe('compareCategoryAuditsAndGroups', () => {
       { weight: 10, score: 1 },
     ] as SortableAuditReport[];
     expect([...mockAudits].sort(compareCategoryAuditsAndGroups)).toEqual([
-      { weight: 10, score: 1 },
-      { weight: 5, score: 1 },
       { weight: 0, score: 0.1 },
       { weight: 0, score: 0.7 },
+      { weight: 10, score: 1 },
+      { weight: 5, score: 1 },
     ]);
   });
 
@@ -187,9 +187,9 @@ describe('compareCategoryAuditsAndGroups', () => {
     expect(
       [...mockAudits, ...mockGroups].sort(compareCategoryAuditsAndGroups),
     ).toEqual([
-      { weight: 2, score: 1, title: 'group A' },
       { weight: 1, score: 0, value: 5, title: 'audit C' },
       { weight: 1, score: 0, value: 0, title: 'audit B' },
+      { weight: 2, score: 1, title: 'group A' },
       { weight: 1, score: 1, value: 100, title: 'audit A' },
       { weight: 1, score: 1, title: 'group B' },
     ]);


### PR DESCRIPTION
Closes #571 

This PR updates the order of checks from `weight > score > value > title` to `score > weight > value > title` to prioritize sorting by score. This change ensures that failed audits appear before passed ones in the report.