### PR TITLE
ci: prevent duplicate CI runs when pushing to open PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   push:
+    branches: [main]
   pull_request:
     branches: [main]
 


### PR DESCRIPTION
Fixes unintended consequence from:
- #743

The CI is triggered on `push` _and_ on `pull_request` (was only `on: push` before, but that didn't work for forks). This means that the workflow and all its jobs _run twice_ on every push to an open PR, or when pushing to branch and then opening a new PR. 

Simplest solution was to restrict `push` trigger to `main` branch. This means CI won't be triggered by push to any branch anymore, there needs to be an open PR (can be a draft). 

![image](https://github.com/user-attachments/assets/f005575a-ed3a-46d2-8e8c-c1b9f411ba40)

