### PR TITLE
fix(plugin-js-packages): filter out warnings

### DIFF
--- a/packages/plugin-js-packages/src/lib/package-managers/pnpm/audit-result.ts
+++ b/packages/plugin-js-packages/src/lib/package-managers/pnpm/audit-result.ts
@@ -1,9 +1,10 @@
 import type { AuditResult, Vulnerability } from '../../runner/audit/types';
 import { getVulnerabilitiesTotal } from '../../runner/audit/utils';
 import type { PnpmAuditResultJson } from './types';
+import { filterWarnings } from './utils';
 
 export function pnpmToAuditResult(output: string): AuditResult {
-  const pnpmResult = JSON.parse(output) as PnpmAuditResultJson;
+  const pnpmResult = JSON.parse(filterWarnings(output)) as PnpmAuditResultJson;
 
   const vulnerabilities = Object.values(pnpmResult.advisories).map(
     ({

--- a/packages/plugin-js-packages/src/lib/package-managers/pnpm/audit-result.unit.test.ts
+++ b/packages/plugin-js-packages/src/lib/package-managers/pnpm/audit-result.unit.test.ts
@@ -76,6 +76,62 @@ describe('pnpmToAuditResult', () => {
       summary: { critical: 0, high: 0, moderate: 0, low: 0, info: 0, total: 0 },
     });
   });
+
+  it('should filter out warnings from the input', () => {
+    /* eslint-disable no-irregular-whitespace */
+    const inputWithWarnings = `
+       WARN  Unsupported engine
+       WARN  Issue while reading file
+      {
+        "advisories": {
+          "123": {
+            "module_name": "@cypress/request",
+            "id": 123,
+            "severity": "high",
+            "vulnerable_versions": "<2.88.12",
+            "recommendation": "Upgrade to version 2.88.12 or later",
+            "title": "SSR forgery",
+            "url": "https://github.com/advisories",
+            "findings": [
+              { "paths": [". > @cypress/request@2.88.5"] }
+            ]
+          }
+        },
+        "metadata": {
+          "vulnerabilities": {
+            "critical": 0,
+            "high": 1,
+            "moderate": 0,
+            "low": 0,
+            "info": 0
+          }
+        }
+      }
+    `;
+    /* eslint-enable no-irregular-whitespace */
+    expect(pnpmToAuditResult(inputWithWarnings)).toEqual<AuditResult>({
+      vulnerabilities: [
+        {
+          name: '@cypress/request',
+          id: 123,
+          severity: 'high',
+          versionRange: '<2.88.12',
+          fixInformation: 'Upgrade to version 2.88.12 or later',
+          directDependency: true,
+          title: 'SSR forgery',
+          url: 'https://github.com/advisories',
+        },
+      ],
+      summary: {
+        critical: 0,
+        high: 1,
+        moderate: 0,
+        low: 0,
+        info: 0,
+        total: 1,
+      },
+    });
+  });
 });
 
 describe('pnpmToDirectDependency', () => {

--- a/packages/plugin-js-packages/src/lib/package-managers/pnpm/outdated-result.ts
+++ b/packages/plugin-js-packages/src/lib/package-managers/pnpm/outdated-result.ts
@@ -1,9 +1,12 @@
 import { objectToEntries } from '@code-pushup/utils';
 import type { OutdatedResult } from '../../runner/outdated/types';
 import type { PnpmOutdatedResultJson } from './types';
+import { filterWarnings } from './utils';
 
 export function pnpmToOutdatedResult(output: string): OutdatedResult {
-  const pnpmOutdated = JSON.parse(output) as PnpmOutdatedResultJson;
+  const pnpmOutdated = JSON.parse(
+    filterWarnings(output),
+  ) as PnpmOutdatedResultJson;
 
   return objectToEntries(pnpmOutdated).map(
     ([name, { current, latest, dependencyType: type }]) => ({

--- a/packages/plugin-js-packages/src/lib/package-managers/pnpm/outdated-result.unit.test.ts
+++ b/packages/plugin-js-packages/src/lib/package-managers/pnpm/outdated-result.unit.test.ts
@@ -39,4 +39,39 @@ describe('pnpmToOutdatedResult', () => {
   it('should transform no dependencies to empty array', () => {
     expect(pnpmToOutdatedResult('{}')).toEqual([]);
   });
+
+  it('should filter out warnings from the input', () => {
+    /* eslint-disable no-irregular-whitespace */
+    const inputWithWarnings = `
+       WARN  Unsupported engine
+       WARN  Issue while reading file
+      {
+        "cypress": {
+          "current": "8.5.0",
+          "latest": "13.6.0",
+          "dependencyType": "devDependencies"
+        },
+        "@cypress/request": {
+          "current": "2.88.10",
+          "latest": "3.0.0",
+          "dependencyType": "devDependencies"
+        }
+      }
+    `;
+    /* eslint-enable no-irregular-whitespace */
+    expect(pnpmToOutdatedResult(inputWithWarnings)).toEqual<OutdatedResult>([
+      {
+        name: 'cypress',
+        current: '8.5.0',
+        latest: '13.6.0',
+        type: 'devDependencies',
+      },
+      {
+        name: '@cypress/request',
+        current: '2.88.10',
+        latest: '3.0.0',
+        type: 'devDependencies',
+      },
+    ]);
+  });
 });

--- a/packages/plugin-js-packages/src/lib/package-managers/pnpm/utils.ts
+++ b/packages/plugin-js-packages/src/lib/package-managers/pnpm/utils.ts
@@ -1,0 +1,5 @@
+export const filterWarnings = (output: string): string =>
+  output
+    .split('\n')
+    .filter(line => !line.includes('WARN'))
+    .join('\n');


### PR DESCRIPTION
Fixes #787 

- Create a `filterOutWarnings` function to remove warnings from the output before passing it to `JSON.parse`.
- Add unit tests to verify that warnings are filtered out and valid JSON is correctly parsed.

Additionally, the updated functionality was manually tested in a real project using pnpm by directly editing the plugin's source code in the `node_modules` directory and executing the command. The command ran successfully, confirming that the functionality works as expected.