### PR TITLE
test(utils): extend unit tests

### DIFF
--- a/packages/utils/src/lib/formatting.unit.test.ts
+++ b/packages/utils/src/lib/formatting.unit.test.ts
@@ -44,6 +44,7 @@ describe('pluralize', () => {
 describe('formatBytes', () => {
   it.each([
     [0, '0 B'],
+    [-1, '0 B'],
     [1000, '1000 B'],
     [10_000, '9.77 kB'],
     [10_000_000, '9.54 MB'],
@@ -80,6 +81,10 @@ describe('formatDuration', () => {
     [1200, '1.20 s'],
   ])('should log correctly formatted duration for %s', (ms, displayValue) => {
     expect(formatDuration(ms)).toBe(displayValue);
+  });
+
+  it('should log formatted duration with 1 digit after the decimal point', () => {
+    expect(formatDuration(120.255_555, 1)).toBe('120.3 ms');
   });
 });
 

--- a/packages/utils/src/lib/reports/utils.unit.test.ts
+++ b/packages/utils/src/lib/reports/utils.unit.test.ts
@@ -289,7 +289,7 @@ describe('sortAudits', () => {
 });
 
 describe('getPluginNameFromSlug', () => {
-  it('should return plugin tiitle', () => {
+  it('should return plugin title', () => {
     const plugins = [
       { slug: 'plugin-a', title: 'Plugin A' },
       { slug: 'plugin-b', title: 'Plugin B' },

--- a/packages/utils/src/lib/transform.unit.test.ts
+++ b/packages/utils/src/lib/transform.unit.test.ts
@@ -25,6 +25,13 @@ describe('toArray', () => {
   it('should leave array value unchanged', () => {
     expect(toArray(['*.ts', '*.js'])).toEqual(['*.ts', '*.js']);
   });
+
+  it('should handle nested arrays', () => {
+    expect(toArray([['*.ts', '*.js'], ['*.json']])).toEqual([
+      ['*.ts', '*.js'],
+      ['*.json'],
+    ]);
+  });
 });
 
 describe('objectToKeys', () => {
@@ -36,6 +43,14 @@ describe('objectToKeys', () => {
   it('should transform empty object into empty array', () => {
     const keys: never[] = objectToKeys({});
     expect(keys).toEqual([]);
+  });
+
+  it('should transform nested object into array of keys', () => {
+    const keys = objectToKeys({
+      prop1: 1,
+      nestedProp1: { nestedKey1: 1 },
+    });
+    expect(keys).toEqual(['prop1', 'nestedProp1']);
   });
 });
 
@@ -72,6 +87,17 @@ describe('objectToEntries', () => {
   it('should transform empty object into empty array', () => {
     const keys: [never, never][] = objectToEntries({});
     expect(keys).toEqual([]);
+  });
+
+  it('should transform nested object into array of entries', () => {
+    const keys = objectToEntries({
+      prop1: 1,
+      nestedProp1: { nestedKey1: 1 },
+    });
+    expect(keys).toEqual([
+      ['prop1', 1],
+      ['nestedProp1', { nestedKey1: 1 }],
+    ]);
   });
 });
 


### PR DESCRIPTION
Closes #272 

- [x] Add tests covering `countCategoryAudits`
- [x] Add nested value examples for `toArray`, `objectToKeys` and `objectToEntries`
- [x] Extend existing suites for `formatBytes`, `formatDuration`, `formatScoreWithColor`, `countWeightedRefs`, `getPluginNameFromSlug`, `sortAuditIssues`

> [!NOTE]  
> - `formatDuration` already had some coverage. It was slightly extended
> - `getSeverityIcon` mentioned in the issue doesn't exist anymore 
> - `tableHtml` has been renamed to `table` and tested since the issue was created
> - `loadReport` has also been tested