### PR TITLE
feat(cli): add command option aliases

### DIFF
--- a/e2e/cli-e2e/tests/__snapshots__/help.e2e.test.ts.snap
+++ b/e2e/cli-e2e/tests/__snapshots__/help.e2e.test.ts.snap
@@ -26,9 +26,9 @@ Global Options:
                      .(ts|mjs|js).                       [string]
       --tsconfig     Path to a TypeScript config, to be used when loading config
                       file.                              [string]
-      --onlyPlugins  List of plugins to run. If not set all plugins are run.
+  -p, --onlyPlugins  List of plugins to run. If not set all plugins are run.
                                                  [array] [default: []]
-      --skipPlugins  List of plugins to skip. If not set all plugins are run.
+  -P, --skipPlugins  List of plugins to skip. If not set all plugins are run.
                                                  [array] [default: []]
 
 Persist Options:

--- a/packages/cli/src/lib/implementation/only-plugins.options.ts
+++ b/packages/cli/src/lib/implementation/only-plugins.options.ts
@@ -7,6 +7,7 @@ export const onlyPluginsOption: Options = {
   type: 'array',
   default: [],
   coerce: coerceArray,
+  alias: 'p',
 };
 
 export function yargsOnlyPluginsOptionsDefinition(): Record<

--- a/packages/cli/src/lib/implementation/skip-plugins.options.ts
+++ b/packages/cli/src/lib/implementation/skip-plugins.options.ts
@@ -7,6 +7,7 @@ export const skipPluginsOption: Options = {
   type: 'array',
   default: [],
   coerce: coerceArray,
+  alias: 'P',
 };
 
 export function yargsSkipPluginsOptionsDefinition(): Record<


### PR DESCRIPTION
Closes #672 

This PR adds aliases for `--onlyPlugins` and `--skipPlugins`.