### PR TITLE
fix(utils): format reports with unchanged score

### DIFF
--- a/packages/utils/src/lib/reports/__snapshots__/report-diff-changed.md
+++ b/packages/utils/src/lib/reports/__snapshots__/report-diff-changed.md
@@ -1,0 +1,28 @@
+# Code PushUp
+
+🤨 Code PushUp report has both **improvements and regressions** – compared target commit 0123456789abcdef0123456789abcdef01234567 with source commit abcdef0123456789abcdef0123456789abcdef01.
+
+## 🏷️ Categories
+
+| 🏷️ Category   | ⭐ Score |
+| :------------- | :-----: |
+| Performance    |  🟢 92  |
+| Bug prevention |  🟡 68  |
+| Code style     |  🟡 54  |
+
+<details>
+<summary><strong>1</strong> audit changed without impacting score</summary>
+
+## 🗃️ Groups
+
+All of 2 groups are unchanged.
+
+## 🛡️ Audits
+
+| 🔌 Plugin                                                          | 🛡️ Audit                                                                        | 📏 Previous value |  📏 Current value  |                                    🔄 Value change                                    |
+| :----------------------------------------------------------------- | :------------------------------------------------------------------------------- | :---------------: | :----------------: | :-----------------------------------------------------------------------------------: |
+| [ESLint](https://www.npmjs.com/package/@code-pushup/eslint-plugin) | [Disallow unused variables](https://eslint.org/docs/latest/rules/no-unused-vars) |  🟥 12 warnings   | 🟥 **10 warnings** | ![↓ −16.7 %](https://img.shields.io/badge/%E2%86%93%20%E2%88%9216.7%E2%80%89%25-gray) |
+
+53 other audits are unchanged.
+
+</details>

--- a/packages/utils/src/lib/reports/__snapshots__/report-diff-monorepo-changed.md
+++ b/packages/utils/src/lib/reports/__snapshots__/report-diff-monorepo-changed.md
@@ -1,0 +1,26 @@
+# Code PushUp
+
+🤨 Code PushUp report has both **improvements and regressions** – compared target commit 0123456789abcdef0123456789abcdef01234567 with source commit abcdef0123456789abcdef0123456789abcdef01.
+
+## 💼 Project `web`
+
+🤨 Code PushUp report has both **improvements and regressions**.
+
+All of 3 categories are unchanged.
+
+<details>
+<summary><strong>1</strong> audit changed without impacting score</summary>
+
+### 🗃️ Groups
+
+All of 2 groups are unchanged.
+
+### 🛡️ Audits
+
+| 🔌 Plugin                                                          | 🛡️ Audit                                                                        | 📏 Previous value |  📏 Current value  |                                    🔄 Value change                                    |
+| :----------------------------------------------------------------- | :------------------------------------------------------------------------------- | :---------------: | :----------------: | :-----------------------------------------------------------------------------------: |
+| [ESLint](https://www.npmjs.com/package/@code-pushup/eslint-plugin) | [Disallow unused variables](https://eslint.org/docs/latest/rules/no-unused-vars) |  🟥 12 warnings   | 🟥 **10 warnings** | ![↓ −16.7 %](https://img.shields.io/badge/%E2%86%93%20%E2%88%9216.7%E2%80%89%25-gray) |
+
+53 other audits are unchanged.
+
+</details>

--- a/packages/utils/src/lib/reports/generate-md-reports-diff.integration.test.ts
+++ b/packages/utils/src/lib/reports/generate-md-reports-diff.integration.test.ts
@@ -3,6 +3,7 @@ import {
   COMMIT_MOCK,
   reportsDiffAddedPluginMock,
   reportsDiffAltMock,
+  reportsDiffChangedMock,
   reportsDiffMock,
   reportsDiffUnchangedMock,
 } from '@code-pushup/test-utils';
@@ -56,6 +57,12 @@ describe('generateMdReportsDiff', () => {
     await expect(
       generateMdReportsDiff(reportsDiffUnchangedMock()),
     ).toMatchFileSnapshot('__snapshots__/report-diff-unchanged.md');
+  });
+
+  it('should format Markdown comment for reports diff with changes that do not impact score', async () => {
+    await expect(
+      generateMdReportsDiff(reportsDiffChangedMock()),
+    ).toMatchFileSnapshot('__snapshots__/report-diff-changed.md');
   });
 
   it('should format Markdown comment for reports diff with added plugin', async () => {
@@ -137,5 +144,13 @@ describe('generateMdReportsDiffForMonorepo', () => {
         { ...reportsDiffUnchangedMock(), label: 'backoffice' },
       ]),
     ).toMatchFileSnapshot('__snapshots__/report-diff-monorepo-unchanged.md');
+  });
+
+  it('should format Markdown comment with changes that do not impact score', async () => {
+    await expect(
+      generateMdReportsDiffForMonorepo([
+        { ...reportsDiffChangedMock(), label: 'web' },
+      ]),
+    ).toMatchFileSnapshot('__snapshots__/report-diff-monorepo-changed.md');
   });
 });

--- a/packages/utils/src/lib/reports/generate-md-reports-diff.ts
+++ b/packages/utils/src/lib/reports/generate-md-reports-diff.ts
@@ -142,16 +142,6 @@ function createCategoriesTable(
   const { changed, unchanged, added } = diff.categories;
   const { hasChanges, skipUnchanged } = options;
 
-  const columns: TableColumnObject[] = [
-    { heading: '🏷️ Category', alignment: 'left' },
-    {
-      heading: hasChanges ? '⭐ Previous score' : '⭐ Score',
-      alignment: 'center',
-    },
-    { heading: '⭐ Current score', alignment: 'center' },
-    { heading: '🔄 Score change', alignment: 'center' },
-  ];
-
   const rows: TableRow[] = [
     ...sortChanges(changed).map(category => [
       formatTitle(category),
@@ -175,6 +165,20 @@ function createCategoriesTable(
           formatScoreWithColor(category.score),
           '–',
         ])),
+  ];
+
+  if (rows.length === 0) {
+    return [[], []];
+  }
+
+  const columns: TableColumnObject[] = [
+    { heading: '🏷️ Category', alignment: 'left' },
+    {
+      heading: hasChanges ? '⭐ Previous score' : '⭐ Score',
+      alignment: 'center',
+    },
+    { heading: '⭐ Current score', alignment: 'center' },
+    { heading: '🔄 Score change', alignment: 'center' },
   ];
 
   return [

--- a/testing/test-utils/src/lib/utils/dynamic-mocks/report-diff.mock.ts
+++ b/testing/test-utils/src/lib/utils/dynamic-mocks/report-diff.mock.ts
@@ -336,6 +336,31 @@ export function reportsDiffUnchangedMock(): ReportsDiff {
   };
 }
 
+export function reportsDiffChangedMock(): ReportsDiff {
+  const originalDiff = reportsDiffUnchangedMock();
+  return {
+    ...originalDiff,
+    audits: {
+      ...originalDiff.audits,
+      changed: [
+        {
+          slug: 'no-unused-vars' satisfies ESLintAuditSlug,
+          title: ESLINT_AUDITS_MAP['no-unused-vars'].title,
+          docsUrl: ESLINT_AUDITS_MAP['no-unused-vars'].docsUrl,
+          plugin: {
+            slug: ESLINT_PLUGIN_META.slug,
+            title: ESLINT_PLUGIN_META.title,
+            docsUrl: ESLINT_PLUGIN_META.docsUrl,
+          },
+          scores: { before: 0, after: 0, diff: 0 },
+          values: { before: 12, after: 10, diff: -2 },
+          displayValues: { before: '12 warnings', after: '10 warnings' },
+        },
+      ],
+    },
+  };
+}
+
 export function reportsDiffAddedPluginMock(): ReportsDiff {
   const originalDiff = reportsDiffAltMock();
   return {


### PR DESCRIPTION
This PR resolves an issue with the report formatting logic where changes that did not affect the score were not being handled correctly. Specifically, it ensures that a categories table is excluded from the monorepo report when none of the category scores have been affected.

Closes #819 