### PR TITLE
feat(cli): handle invalid plugin filter options

### DIFF
--- a/packages/cli/src/lib/implementation/filter-plugins.middleware.ts
+++ b/packages/cli/src/lib/implementation/filter-plugins.middleware.ts
@@ -1,7 +1,10 @@
 import { filterItemRefsBy } from '@code-pushup/utils';
 import type { OnlyPluginsOptions } from './only-plugins.model';
 import type { SkipPluginsOptions } from './skip-plugins.model';
-import { validatePluginFilterOption } from './validate-plugin-filter-options.utils';
+import {
+  handleConflictingPlugins,
+  validatePluginFilterOption,
+} from './validate-plugin-filter-options.utils';
 
 export function filterPluginsMiddleware<
   T extends SkipPluginsOptions & OnlyPluginsOptions,
@@ -17,6 +20,8 @@ export function filterPluginsMiddleware<
   if (skipPlugins.length === 0 && onlyPlugins.length === 0) {
     return { ...originalProcessArgs, categories };
   }
+
+  handleConflictingPlugins(onlyPlugins, skipPlugins);
 
   validatePluginFilterOption(
     'skipPlugins',

--- a/packages/cli/src/lib/implementation/global.utils.ts
+++ b/packages/cli/src/lib/implementation/global.utils.ts
@@ -22,8 +22,10 @@ export function filterKebabCaseKeys<T extends Record<string, unknown>>(
     ) as T;
 }
 
-// log error and flush stdout so that Yargs doesn't suppress it
-// related issue: https://github.com/yargs/yargs/issues/2118
+// Log error and flush stdout to ensure all logs are printed
+// before Yargs exits or rethrows the error.
+// This prevents log suppression, especially in async execution.
+// Related issue: https://github.com/yargs/yargs/issues/2118
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function logErrorBeforeThrow<T extends (...args: any[]) => any>(
   fn: T,
@@ -38,10 +40,11 @@ export function logErrorBeforeThrow<T extends (...args: any[]) => any>(
         ui().logger.error(error.message);
         await new Promise(resolve => process.stdout.write('', resolve));
         yargs().exit(1, error);
+      } else {
+        console.error(error);
+        await new Promise(resolve => process.stdout.write('', resolve));
+        throw error;
       }
-      console.error(error);
-      await new Promise(resolve => process.stdout.write('', resolve));
-      throw error;
     }
   }) as T;
 }

--- a/packages/cli/src/lib/implementation/global.utils.ts
+++ b/packages/cli/src/lib/implementation/global.utils.ts
@@ -1,4 +1,6 @@
-import { toArray } from '@code-pushup/utils';
+import yargs from 'yargs';
+import { toArray, ui } from '@code-pushup/utils';
+import { OptionValidationError } from './validate-plugin-filter-options.utils';
 
 export function filterKebabCaseKeys<T extends Record<string, unknown>>(
   obj: T,
@@ -32,6 +34,11 @@ export function logErrorBeforeThrow<T extends (...args: any[]) => any>(
       // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-argument
       return await fn(...args);
     } catch (error) {
+      if (error instanceof OptionValidationError) {
+        ui().logger.error(error.message);
+        await new Promise(resolve => process.stdout.write('', resolve));
+        yargs().exit(1, error);
+      }
       console.error(error);
       await new Promise(resolve => process.stdout.write('', resolve));
       throw error;

--- a/packages/cli/src/lib/implementation/global.utils.unit.test.ts
+++ b/packages/cli/src/lib/implementation/global.utils.unit.test.ts
@@ -1,5 +1,7 @@
-import { expect } from 'vitest';
-import { filterKebabCaseKeys } from './global.utils';
+import { describe, expect, it, vi } from 'vitest';
+import { ui } from '@code-pushup/utils';
+import { filterKebabCaseKeys, logErrorBeforeThrow } from './global.utils';
+import { OptionValidationError } from './validate-plugin-filter-options.utils';
 
 describe('filterKebabCaseKeys', () => {
   it('should filter root level kebab-case keys', () => {
@@ -36,5 +38,44 @@ describe('filterKebabCaseKeys', () => {
     expect(filterKebabCaseKeys(obj)).toEqual({
       camelCase: ['kebab-case', { 'kebab-case': 'value' }],
     });
+  });
+});
+
+describe('logErrorBeforeThrow', () => {
+  it('should exit when OptionValidationError is thrown', async () => {
+    const errorFn = vi.fn().mockRejectedValue(new OptionValidationError());
+    const logFn = logErrorBeforeThrow(errorFn);
+
+    await expect(logFn()).rejects.toThrow(
+      'process.exit unexpectedly called with "1"',
+    );
+    await expect(logFn()).rejects.not.toThrow(
+      expect.any(OptionValidationError),
+    );
+  });
+
+  it('should log a custom error when OptionValidationError is thrown', async () => {
+    const loggerSpy = vi.spyOn(ui().logger, 'error').mockImplementation(() => {
+      /* empty */
+    });
+
+    const errorFn = vi
+      .fn()
+      .mockRejectedValue(new OptionValidationError('Option validation failed'));
+
+    try {
+      await logErrorBeforeThrow(errorFn)();
+    } catch {
+      /* suppress */
+    }
+
+    expect(loggerSpy).toHaveBeenCalledWith('Option validation failed');
+  });
+
+  it('should rethrow errors other than OptionValidationError', async () => {
+    const errorFn = vi.fn().mockRejectedValue(new Error('Some other error'));
+    await expect(logErrorBeforeThrow(errorFn)()).rejects.toThrow(
+      'Some other error',
+    );
   });
 });

--- a/packages/cli/src/lib/implementation/validate-plugin-filter-options.utils.ts
+++ b/packages/cli/src/lib/implementation/validate-plugin-filter-options.utils.ts
@@ -1,11 +1,7 @@
 import type { CategoryConfig, PluginConfig } from '@code-pushup/models';
 import { filterItemRefsBy, ui } from '@code-pushup/utils';
 
-export class OptionValidationError extends Error {
-  constructor(message: string) {
-    super(`${message}`);
-  }
-}
+export class OptionValidationError extends Error {}
 
 export function validatePluginFilterOption(
   option: 'onlyPlugins' | 'skipPlugins',

--- a/packages/cli/src/lib/implementation/validate-plugin-filter-options.utils.ts
+++ b/packages/cli/src/lib/implementation/validate-plugin-filter-options.utils.ts
@@ -1,8 +1,14 @@
 import type { CategoryConfig, PluginConfig } from '@code-pushup/models';
 import { filterItemRefsBy, ui } from '@code-pushup/utils';
 
+export class OptionValidationError extends Error {
+  constructor(message: string) {
+    super(`${message}`);
+  }
+}
+
 export function validatePluginFilterOption(
-  filterOption: 'onlyPlugins' | 'skipPlugins',
+  option: 'onlyPlugins' | 'skipPlugins',
   {
     plugins,
     categories,
@@ -16,35 +22,75 @@ export function validatePluginFilterOption(
   }: { pluginsToFilter?: string[]; verbose?: boolean } = {},
 ): void {
   const pluginsToFilterSet = new Set(pluginsToFilter);
-  const missingPlugins = pluginsToFilter.filter(
+  const invalidPlugins = pluginsToFilter.filter(
     plugin => !plugins.some(({ slug }) => slug === plugin),
   );
+  const message = createValidationMessage(option, invalidPlugins, plugins);
 
-  const isSkipOption = filterOption === 'skipPlugins';
-
-  const filterFunction = (plugin: string) =>
-    isSkipOption
+  const filterFn = (plugin: string) =>
+    option === 'skipPlugins'
       ? pluginsToFilterSet.has(plugin)
       : !pluginsToFilterSet.has(plugin);
 
-  if (missingPlugins.length > 0) {
-    ui().logger.warning(
-      `The --${filterOption} argument references ${
-        missingPlugins.length === 1 ? 'a plugin that does' : 'plugins that do'
-      } not exist: ${missingPlugins.join(', ')}. The valid plugin ${
-        plugins.length === 1 ? 'slug is' : 'slugs are'
-      } ${plugins.map(({ slug }) => slug).join(', ')}.`,
-    );
+  if (
+    option === 'onlyPlugins' &&
+    pluginsToFilterSet.size > 0 &&
+    pluginsToFilterSet.size === invalidPlugins.length
+  ) {
+    throw new OptionValidationError(message);
+  }
+
+  if (invalidPlugins.length > 0) {
+    ui().logger.warning(message);
   }
 
   if (categories.length > 0 && verbose) {
     const removedCategorySlugs = filterItemRefsBy(categories, ({ plugin }) =>
-      filterFunction(plugin),
+      filterFn(plugin),
     ).map(({ slug }) => slug);
     ui().logger.info(
-      `The --${filterOption} argument removed the following categories: ${removedCategorySlugs.join(
+      `The --${option} argument removed the following categories: ${removedCategorySlugs.join(
         ', ',
       )}.`,
+    );
+  }
+}
+
+export function createValidationMessage(
+  option: 'onlyPlugins' | 'skipPlugins',
+  invalidPlugins: string[],
+  validPlugins: Pick<PluginConfig, 'slug'>[],
+): string {
+  const invalidPluginText =
+    invalidPlugins.length === 1
+      ? 'a plugin that does not exist:'
+      : 'plugins that do not exist:';
+  const invalidSlugs = invalidPlugins.join(', ');
+
+  const validPluginText =
+    validPlugins.length === 1
+      ? 'The only valid plugin is'
+      : 'Valid plugins are';
+  const validSlugs = validPlugins.map(({ slug }) => slug).join(', ');
+
+  return `The --${option} argument references ${invalidPluginText} ${invalidSlugs}. ${validPluginText} ${validSlugs}.`;
+}
+
+export function handleConflictingPlugins(
+  onlyPlugins: string[],
+  skipPlugins: string[],
+): void {
+  const conflictingPlugins = onlyPlugins.filter(plugin =>
+    skipPlugins.includes(plugin),
+  );
+
+  if (conflictingPlugins.length > 0) {
+    const conflictSubject =
+      conflictingPlugins.length > 1 ? 'plugins are' : 'plugin is';
+    const conflictingSlugs = conflictingPlugins.join(', ');
+
+    throw new OptionValidationError(
+      `The following ${conflictSubject} specified in both --onlyPlugins and --skipPlugins: ${conflictingSlugs}. Please choose one option.`,
     );
   }
 }

--- a/packages/cli/src/lib/implementation/validate-plugin-filter-options.utils.unit.test.ts
+++ b/packages/cli/src/lib/implementation/validate-plugin-filter-options.utils.unit.test.ts
@@ -2,11 +2,16 @@ import { describe, expect } from 'vitest';
 import type { CategoryConfig, PluginConfig } from '@code-pushup/models';
 import { getLogMessages } from '@code-pushup/test-utils';
 import { ui } from '@code-pushup/utils';
-import { validatePluginFilterOption } from './validate-plugin-filter-options.utils';
+import {
+  OptionValidationError,
+  createValidationMessage,
+  handleConflictingPlugins,
+  validatePluginFilterOption,
+} from './validate-plugin-filter-options.utils';
 
 describe('validatePluginFilterOption', () => {
   describe('onlyPlugins', () => {
-    it('should log a warning if the onlyPlugins argument contains multiple nonexistent plugins', () => {
+    it('should log a warning if the onlyPlugins argument contains multiple nonexistent plugins along with a valid one', () => {
       validatePluginFilterOption(
         'onlyPlugins',
         {
@@ -21,7 +26,7 @@ describe('validatePluginFilterOption', () => {
       );
     });
 
-    it('should log a warning if the onlyPlugins argument contains one nonexistent plugin', () => {
+    it('should log a warning if the onlyPlugins argument contains one nonexistent plugin along with a valid one', () => {
       validatePluginFilterOption(
         'onlyPlugins',
         {
@@ -38,22 +43,24 @@ describe('validatePluginFilterOption', () => {
       );
     });
 
-    it('should include all valid plugin slugs in a warning', () => {
-      validatePluginFilterOption(
-        'onlyPlugins',
-        {
-          plugins: [
-            { slug: 'plugin1', audits: [{ slug: 'a1-p1' }] },
-            { slug: 'plugin2', audits: [{ slug: 'a1-p2' }] },
-            { slug: 'plugin3', audits: [{ slug: 'a1-p3' }] },
-          ] as PluginConfig[],
-          categories: [],
-        },
-        { pluginsToFilter: ['plugin4'] },
-      );
-      const logs = getLogMessages(ui().logger);
-      expect(logs[0]).toContain(
-        'The valid plugin slugs are plugin1, plugin2, plugin3.',
+    it('should throw OptionValidationError when none of the provided slugs are present in plugins', () => {
+      expect(() => {
+        validatePluginFilterOption(
+          'onlyPlugins',
+          {
+            plugins: [
+              { slug: 'plugin1', audits: [{ slug: 'a1-p1' }] },
+              { slug: 'plugin2', audits: [{ slug: 'a1-p2' }] },
+              { slug: 'plugin3', audits: [{ slug: 'a1-p3' }] },
+            ] as PluginConfig[],
+            categories: [],
+          },
+          { pluginsToFilter: ['plugin4', 'plugin5'] },
+        );
+      }).toThrow(
+        new OptionValidationError(
+          'The --onlyPlugins argument references plugins that do not exist: plugin4, plugin5. Valid plugins are plugin1, plugin2, plugin3.',
+        ),
       );
     });
 
@@ -175,5 +182,105 @@ describe('validatePluginFilterOption', () => {
         'The --skipPlugins argument removed the following categories: c1, c3.',
       );
     });
+  });
+
+  describe('onlyPlugins and skipPlugins', () => {
+    it('should throw OptionValidationError when none of the onlyPlugins are valid', () => {
+      const allPlugins = [
+        { slug: 'plugin1', audits: [{ slug: 'a1-p1' }] },
+        { slug: 'plugin2', audits: [{ slug: 'a1-p2' }] },
+      ] as PluginConfig[];
+
+      expect(() => {
+        validatePluginFilterOption(
+          'skipPlugins',
+          { plugins: allPlugins, categories: [] },
+          { pluginsToFilter: ['plugin1'] },
+        );
+        validatePluginFilterOption(
+          'onlyPlugins',
+          { plugins: allPlugins, categories: [] },
+          { pluginsToFilter: ['plugin3'] },
+        );
+      }).toThrow(
+        new OptionValidationError(
+          'The --onlyPlugins argument references a plugin that does not exist: plugin3. Valid plugins are plugin1, plugin2.',
+        ),
+      );
+    });
+  });
+});
+
+describe('createValidationMessage', () => {
+  it.each([
+    [
+      'onlyPlugins',
+      ['wrong-slug'],
+      ['plugin1', 'plugin2', 'plugin3'],
+      'The --onlyPlugins argument references a plugin that does not exist: wrong-slug. Valid plugins are plugin1, plugin2, plugin3.',
+    ],
+    [
+      'skipPlugins',
+      ['wrong-slug1', 'wrong-slug2'],
+      ['plugin1', 'plugin2', 'plugin3'],
+      'The --skipPlugins argument references plugins that do not exist: wrong-slug1, wrong-slug2. Valid plugins are plugin1, plugin2, plugin3.',
+    ],
+    [
+      'onlyPlugins',
+      ['wrong-slug'],
+      ['plugin1'],
+      'The --onlyPlugins argument references a plugin that does not exist: wrong-slug. The only valid plugin is plugin1.',
+    ],
+    [
+      'skipPlugins',
+      ['wrong-slug1', 'wrong-slug2'],
+      ['plugin1'],
+      'The --skipPlugins argument references plugins that do not exist: wrong-slug1, wrong-slug2. The only valid plugin is plugin1.',
+    ],
+  ])(
+    'should create a validation message for %s with invalid plugins %o and valid plugins %o',
+    (option, invalidPlugins, validPlugins, expected) => {
+      expect(
+        createValidationMessage(
+          option as 'skipPlugins' | 'onlyPlugins',
+          invalidPlugins,
+          validPlugins.map(slug => ({ slug })),
+        ),
+      ).toBe(expected);
+    },
+  );
+});
+
+describe('handleConflictingPlugins', () => {
+  it.each([
+    [
+      ['plugin1'],
+      ['plugin1'],
+      'The following plugin is specified in both --onlyPlugins and --skipPlugins: plugin1. Please choose one option.',
+    ],
+    [
+      ['plugin1', 'plugin2'],
+      ['plugin1', 'plugin2'],
+      'The following plugins are specified in both --onlyPlugins and --skipPlugins: plugin1, plugin2. Please choose one option.',
+    ],
+  ])(
+    'should throw OptionValidationError for conflicting onlyPlugins %o and skipPlugins %o',
+    (onlyPlugins, skipPlugins, message) => {
+      expect(() => {
+        handleConflictingPlugins(onlyPlugins, skipPlugins);
+      }).toThrow(new OptionValidationError(message));
+    },
+  );
+
+  it('should check for conflicts without throwing an error when there is none', () => {
+    expect(() => {
+      handleConflictingPlugins(['plugin2'], ['plugin1']);
+    }).not.toThrow();
+  });
+
+  it('should check for conflicts without throwing an error when both options are empty', () => {
+    expect(() => {
+      handleConflictingPlugins([], []);
+    }).not.toThrow();
   });
 });


### PR DESCRIPTION
Closes #823 

This PR improves error handling for `--onlyPlugins` and `--skipPlugins`, ensuring the command aborts when no valid plugins are provided to `--onlyPlugins`. Invalid plugins are ignored with warnings, and conflicts between the two options are handled with clear error messages.