### PR TITLE
feat: skip perfect scores in stdout summary

### DIFF
--- a/packages/core/src/lib/collect-and-persist.ts
+++ b/packages/core/src/lib/collect-and-persist.ts
@@ -3,7 +3,12 @@ import {
   type PersistConfig,
   pluginReportSchema,
 } from '@code-pushup/models';
-import { verboseUtils } from '@code-pushup/utils';
+import {
+  logStdoutSummary,
+  scoreReport,
+  sortReport,
+  verboseUtils,
+} from '@code-pushup/utils';
 import { collect } from './implementation/collect';
 import { logPersistedResults, persistReport } from './implementation/persist';
 import type { GlobalOptions } from './types';
@@ -18,7 +23,16 @@ export async function collectAndPersistReports(
   const { exec } = verboseUtils(options.verbose);
 
   const report = await collect(options);
-  const persistResults = await persistReport(report, options.persist);
+  const sortedScoredReport = sortReport(scoreReport(report));
+  const persistResults = await persistReport(
+    report,
+    sortedScoredReport,
+    options.persist,
+  );
+
+  // terminal output
+  logStdoutSummary(sortedScoredReport, options.verbose);
+
   exec(() => {
     logPersistedResults(persistResults);
   });

--- a/packages/core/src/lib/collect-and-persist.unit.test.ts
+++ b/packages/core/src/lib/collect-and-persist.unit.test.ts
@@ -1,4 +1,4 @@
-import { describe } from 'vitest';
+import { type MockInstance, describe } from 'vitest';
 import {
   ISO_STRING_REGEXP,
   MINIMAL_CONFIG_MOCK,
@@ -6,6 +6,7 @@ import {
   getLogMessages,
 } from '@code-pushup/test-utils';
 import {
+  type ScoredReport,
   logStdoutSummary,
   scoreReport,
   sortReport,
@@ -29,12 +30,17 @@ vi.mock('./implementation/persist', () => ({
 }));
 
 describe('collectAndPersistReports', () => {
+  let logStdoutSpy: MockInstance<
+    [report: ScoredReport, verbose?: boolean],
+    void
+  >;
+
   beforeEach(() => {
-    vi.spyOn(utils, 'logStdoutSummary');
+    logStdoutSpy = vi.spyOn(utils, 'logStdoutSummary');
   });
 
-  afterEach(() => {
-    vi.clearAllMocks();
+  afterAll(() => {
+    logStdoutSpy.mockRestore();
   });
 
   it('should call collect and persistReport with correct parameters in non-verbose mode', async () => {
@@ -105,19 +111,10 @@ describe('collectAndPersistReports', () => {
     expect(logPersistedResults).toHaveBeenCalled();
   });
 
-  it('should print a summary to stdout`', async () => {
-    const verboseConfig: CollectAndPersistReportsOptions = {
-      categories: [],
-      ...MINIMAL_CONFIG_MOCK,
-      persist: {
-        outputDir: 'output',
-        filename: 'report',
-        format: ['md'],
-      },
-      verbose: true,
-      progress: false,
-    };
-    await collectAndPersistReports(verboseConfig);
+  it('should print a summary to stdout', async () => {
+    await collectAndPersistReports(
+      MINIMAL_CONFIG_MOCK as CollectAndPersistReportsOptions,
+    );
     const logs = getLogMessages(ui().logger);
     expect(logs.at(-2)).toContain('Made with ❤ by code-pushup.dev');
   });

--- a/packages/core/src/lib/implementation/persist.ts
+++ b/packages/core/src/lib/implementation/persist.ts
@@ -3,12 +3,10 @@ import { join } from 'node:path';
 import type { PersistConfig, Report } from '@code-pushup/models';
 import {
   type MultipleFileResults,
+  type ScoredReport,
   directoryExists,
   generateMdReport,
   logMultipleFileResults,
-  logStdoutSummary,
-  scoreReport,
-  sortReport,
   ui,
 } from '@code-pushup/utils';
 
@@ -26,13 +24,10 @@ export class PersistError extends Error {
 
 export async function persistReport(
   report: Report,
+  sortedScoredReport: ScoredReport,
   options: Required<PersistConfig>,
 ): Promise<MultipleFileResults> {
   const { outputDir, filename, format } = options;
-
-  const sortedScoredReport = sortReport(scoreReport(report));
-  // terminal output
-  logStdoutSummary(sortedScoredReport);
 
   // collect physical format outputs
   const results = format.map(reportType => {

--- a/packages/core/src/lib/implementation/persist.unit.test.ts
+++ b/packages/core/src/lib/implementation/persist.unit.test.ts
@@ -9,7 +9,7 @@ import {
   REPORT_MOCK,
   getLogMessages,
 } from '@code-pushup/test-utils';
-import { ui } from '@code-pushup/utils';
+import { scoreReport, sortReport, ui } from '@code-pushup/utils';
 import { logPersistedResults, persistReport } from './persist';
 
 describe('persistReport', () => {
@@ -17,28 +17,9 @@ describe('persistReport', () => {
     vol.fromJSON({}, MEMFS_VOLUME);
   });
 
-  it('should print a summary to stdout when no format is specified`', async () => {
-    await persistReport(MINIMAL_REPORT_MOCK, {
-      outputDir: MEMFS_VOLUME,
-      filename: 'report',
-      format: [],
-    });
-    const logs = getLogMessages(ui().logger);
-    expect(logs.at(-2)).toContain('Made with ❤ by code-pushup.dev');
-  });
-
-  it('should print a summary to stdout when all formats are specified`', async () => {
-    await persistReport(MINIMAL_REPORT_MOCK, {
-      outputDir: MEMFS_VOLUME,
-      filename: 'report',
-      format: ['md', 'json'],
-    });
-    const logs = getLogMessages(ui().logger);
-    expect(logs.at(-2)).toContain('Made with ❤ by code-pushup.dev');
-  });
-
   it('should create a report in json format', async () => {
-    await persistReport(MINIMAL_REPORT_MOCK, {
+    const sortedScoredReport = sortReport(scoreReport(MINIMAL_REPORT_MOCK));
+    await persistReport(MINIMAL_REPORT_MOCK, sortedScoredReport, {
       outputDir: MEMFS_VOLUME,
       filename: 'report',
       format: ['json'],
@@ -60,7 +41,8 @@ describe('persistReport', () => {
   });
 
   it('should create a report in md format', async () => {
-    await persistReport(MINIMAL_REPORT_MOCK, {
+    const sortedScoredReport = sortReport(scoreReport(MINIMAL_REPORT_MOCK));
+    await persistReport(MINIMAL_REPORT_MOCK, sortedScoredReport, {
       outputDir: MEMFS_VOLUME,
       filename: 'report',
       format: ['md'],
@@ -75,7 +57,8 @@ describe('persistReport', () => {
   });
 
   it('should create a report with categories section in all formats', async () => {
-    await persistReport(REPORT_MOCK, {
+    const sortedScoredReport = sortReport(scoreReport(REPORT_MOCK));
+    await persistReport(REPORT_MOCK, sortedScoredReport, {
       outputDir: MEMFS_VOLUME,
       format: ['md', 'json'],
       filename: 'report',

--- a/packages/utils/src/lib/reports/__snapshots__/report-stdout-all-perfect-scores.txt
+++ b/packages/utils/src/lib/reports/__snapshots__/report-stdout-all-perfect-scores.txt
@@ -3,23 +3,7 @@ Code PushUp Report - @code-pushup/core@0.0.1
 
 ESLint audits
 
-● Disallow missing props validation in a React component    6 warnings
-  definition
-● Disallow variable declarations from shadowing variables   3 warnings
-  declared in the outer scope
-● Require or disallow method and property shorthand         3 warnings
-  syntax for object literals
-● verifies the list of dependencies for Hooks like          2 warnings
-  useEffect and similar
-● Disallow missing `key` props in iterators/collection      1 warning
-  literals
-● Disallow unused variables                                 1 warning
-● Enforce a maximum number of lines of code in a function   1 warning
-● Require `const` declarations for variables that are       1 warning
-  never reassigned after declared
-● Require braces around arrow function bodies               1 warning
-● Require the use of `===` and `!==`                        1 warning
-● ... 37 audits with perfect scores omitted for brevity ...
+● All audits have perfect scores
 
 
 Lighthouse audits
@@ -39,9 +23,9 @@ Categories
 ├─────────────────────────────────────────────────────────┼─────────┼──────────┤
 │  Performance                                            │     92  │       8  │
 ├─────────────────────────────────────────────────────────┼─────────┼──────────┤
-│  Bug prevention                                         │     68  │      16  │
+│  Bug prevention                                         │    100  │      16  │
 ├─────────────────────────────────────────────────────────┼─────────┼──────────┤
-│  Code style                                             │     54  │      13  │
+│  Code style                                             │    100  │      13  │
 └─────────────────────────────────────────────────────────┴─────────┴──────────┘
 
 Made with ❤ by code-pushup.dev

--- a/packages/utils/src/lib/reports/__snapshots__/report-stdout-all-perfect-scores.txt
+++ b/packages/utils/src/lib/reports/__snapshots__/report-stdout-all-perfect-scores.txt
@@ -3,7 +3,7 @@ Code PushUp Report - @code-pushup/core@0.0.1
 
 ESLint audits
 
-● All audits have perfect scores
+● ... All 47 audits have perfect scores ...
 
 
 Lighthouse audits

--- a/packages/utils/src/lib/reports/__snapshots__/report-stdout-no-categories.txt
+++ b/packages/utils/src/lib/reports/__snapshots__/report-stdout-no-categories.txt
@@ -19,59 +19,7 @@ ESLint audits
   never reassigned after declared
 ● Require braces around arrow function bodies               1 warning
 ● Require the use of `===` and `!==`                        1 warning
-● Disallow `target="_blank"` attribute without              passed
-  `rel="noreferrer"`
-● Disallow assignment operators in conditional              passed
-  expressions
-● Disallow comments from being inserted as text nodes       passed
-● Disallow direct mutation of this.state                    passed
-● Disallow duplicate properties in JSX                      passed
-● Disallow invalid regular expression strings in `RegExp`   passed
-  constructors
-● Disallow loops with a body that allows only one           passed
-  iteration
-● Disallow missing displayName in a React component         passed
-  definition
-● Disallow missing React when using JSX                     passed
-● Disallow negating the left operand of relational          passed
-  operators
-● Disallow passing of children as props                     passed
-● Disallow React to be incorrectly marked as unused         passed
-● Disallow reassigning `const` variables                    passed
-● Disallow the use of `debugger`                            passed
-● Disallow the use of undeclared variables unless           passed
-  mentioned in `/*global */` comments
-● Disallow undeclared variables in JSX                      passed
-● Disallow unescaped HTML entities from appearing in        passed
-  markup
-● Disallow usage of deprecated methods                      passed
-● Disallow usage of findDOMNode                             passed
-● Disallow usage of isMounted                               passed
-● Disallow usage of the return value of ReactDOM.render     passed
-● Disallow usage of unknown DOM property                    passed
-● Disallow use of optional chaining in contexts where the   passed
-  `undefined` value is not allowed
-● Disallow using Object.assign with an object literal as    passed
-  the first argument and prefer the use of object spread
-  instead
-● Disallow using string references                          passed
-● Disallow variables used in JSX to be incorrectly marked   passed
-  as unused
-● Disallow when a DOM element is using both children and    passed
-  dangerouslySetInnerHTML
-● Enforce a maximum number of lines per file                passed
-● Enforce camelcase naming convention                       passed
-● Enforce comparing `typeof` expressions against valid      passed
-  strings
-● Enforce consistent brace style for all control            passed
-  statements
-● Enforce ES5 or ES6 class for returning value in render    passed
-  function
-● enforces the Rules of Hooks                               passed
-● Require `let` or `const` instead of `var`                 passed
-● Require calls to `isNaN()` when checking for `NaN`        passed
-● Require or disallow "Yoda" conditions                     passed
-● Require using arrow functions for callbacks               passed
+● ... 37 audits with perfect scores omitted for brevity ...
 
 
 Lighthouse audits
@@ -82,7 +30,6 @@ Lighthouse audits
 ● First Contentful Paint                                    1.2 s
 ● Largest Contentful Paint                                  1.5 s
 ● Speed Index                                               1.2 s
-● Cumulative Layout Shift                                   0
-● Total Blocking Time                                       0 ms
+● ... 2 audits with perfect scores omitted for brevity ...
 
 Made with ❤ by code-pushup.dev

--- a/packages/utils/src/lib/reports/__snapshots__/report-stdout-verbose.txt
+++ b/packages/utils/src/lib/reports/__snapshots__/report-stdout-verbose.txt
@@ -19,7 +19,59 @@ ESLint audits
   never reassigned after declared
 ● Require braces around arrow function bodies               1 warning
 ● Require the use of `===` and `!==`                        1 warning
-● ... 37 audits with perfect scores omitted for brevity ...
+● Disallow `target="_blank"` attribute without              passed
+  `rel="noreferrer"`
+● Disallow assignment operators in conditional              passed
+  expressions
+● Disallow comments from being inserted as text nodes       passed
+● Disallow direct mutation of this.state                    passed
+● Disallow duplicate properties in JSX                      passed
+● Disallow invalid regular expression strings in `RegExp`   passed
+  constructors
+● Disallow loops with a body that allows only one           passed
+  iteration
+● Disallow missing displayName in a React component         passed
+  definition
+● Disallow missing React when using JSX                     passed
+● Disallow negating the left operand of relational          passed
+  operators
+● Disallow passing of children as props                     passed
+● Disallow React to be incorrectly marked as unused         passed
+● Disallow reassigning `const` variables                    passed
+● Disallow the use of `debugger`                            passed
+● Disallow the use of undeclared variables unless           passed
+  mentioned in `/*global */` comments
+● Disallow undeclared variables in JSX                      passed
+● Disallow unescaped HTML entities from appearing in        passed
+  markup
+● Disallow usage of deprecated methods                      passed
+● Disallow usage of findDOMNode                             passed
+● Disallow usage of isMounted                               passed
+● Disallow usage of the return value of ReactDOM.render     passed
+● Disallow usage of unknown DOM property                    passed
+● Disallow use of optional chaining in contexts where the   passed
+  `undefined` value is not allowed
+● Disallow using Object.assign with an object literal as    passed
+  the first argument and prefer the use of object spread
+  instead
+● Disallow using string references                          passed
+● Disallow variables used in JSX to be incorrectly marked   passed
+  as unused
+● Disallow when a DOM element is using both children and    passed
+  dangerouslySetInnerHTML
+● Enforce a maximum number of lines per file                passed
+● Enforce camelcase naming convention                       passed
+● Enforce comparing `typeof` expressions against valid      passed
+  strings
+● Enforce consistent brace style for all control            passed
+  statements
+● Enforce ES5 or ES6 class for returning value in render    passed
+  function
+● enforces the Rules of Hooks                               passed
+● Require `let` or `const` instead of `var`                 passed
+● Require calls to `isNaN()` when checking for `NaN`        passed
+● Require or disallow "Yoda" conditions                     passed
+● Require using arrow functions for callbacks               passed
 
 
 Lighthouse audits
@@ -30,7 +82,8 @@ Lighthouse audits
 ● First Contentful Paint                                    1.2 s
 ● Largest Contentful Paint                                  1.5 s
 ● Speed Index                                               1.2 s
-● ... 2 audits with perfect scores omitted for brevity ...
+● Cumulative Layout Shift                                   0
+● Total Blocking Time                                       0 ms
 
 Categories
 

--- a/packages/utils/src/lib/reports/log-stdout-summary.integration.test.ts
+++ b/packages/utils/src/lib/reports/log-stdout-summary.integration.test.ts
@@ -48,4 +48,37 @@ describe('logStdoutSummary', () => {
       '__snapshots__/report-stdout-no-categories.txt',
     );
   });
+
+  it('should include all audits when verbose is true', async () => {
+    logStdoutSummary(sortReport(scoreReport(reportMock())), true);
+
+    const output = logs.join('\n');
+
+    await expect(removeColorCodes(output)).toMatchFileSnapshot(
+      '__snapshots__/report-stdout-verbose.txt',
+    );
+  });
+
+  it('should indicate that all audits have perfect scores', async () => {
+    const report = reportMock();
+    const reportWithPerfectScores = {
+      ...report,
+      plugins: report.plugins.map((plugin, index) => ({
+        ...plugin,
+        audits: plugin.audits.map(audit => ({
+          ...audit,
+          score: index === 0 ? 1 : audit.score,
+        })),
+      })),
+    };
+
+    logStdoutSummary(sortReport(scoreReport(reportWithPerfectScores)));
+
+    const output = logs.join('\n');
+
+    expect(output).toContain('All audits have perfect scores');
+    await expect(removeColorCodes(output)).toMatchFileSnapshot(
+      '__snapshots__/report-stdout-all-perfect-scores.txt',
+    );
+  });
 });

--- a/packages/utils/src/lib/reports/log-stdout-summary.integration.test.ts
+++ b/packages/utils/src/lib/reports/log-stdout-summary.integration.test.ts
@@ -63,20 +63,21 @@ describe('logStdoutSummary', () => {
     const report = reportMock();
     const reportWithPerfectScores = {
       ...report,
-      plugins: report.plugins.map((plugin, index) => ({
-        ...plugin,
-        audits: plugin.audits.map(audit => ({
-          ...audit,
-          score: index === 0 ? 1 : audit.score,
-        })),
-      })),
+      plugins: report.plugins.map((plugin, index) =>
+        index > 0
+          ? plugin
+          : {
+              ...plugin,
+              audits: plugin.audits.map(audit => ({ ...audit, score: 1 })),
+            },
+      ),
     };
 
     logStdoutSummary(sortReport(scoreReport(reportWithPerfectScores)));
 
     const output = logs.join('\n');
 
-    expect(output).toContain('All audits have perfect scores');
+    expect(output).toContain('All 47 audits have perfect scores');
     await expect(removeColorCodes(output)).toMatchFileSnapshot(
       '__snapshots__/report-stdout-all-perfect-scores.txt',
     );

--- a/packages/utils/src/lib/reports/log-stdout-summary.ts
+++ b/packages/utils/src/lib/reports/log-stdout-summary.ts
@@ -44,48 +44,51 @@ export function logPlugins(
       : audits.filter(({ score }) => score !== 1);
     const diff = audits.length - filteredAudits.length;
 
-    logAuditRows(title, filteredAudits);
+    logAudits(title, filteredAudits);
 
     if (diff > 0) {
-      const message =
+      const notice =
         filteredAudits.length === 0
-          ? 'All audits have perfect scores'
+          ? `... All ${diff} audits have perfect scores ...`
           : `... ${diff} audits with perfect scores omitted for brevity ...`;
-
-      ui().row([
-        { text: '●', width: 2, padding: [0, 1, 0, 0] },
-        // eslint-disable-next-line no-magic-numbers
-        { text: message, padding: [0, 3, 0, 0] },
-      ]);
+      logRow(1, notice);
     }
     log();
   });
 }
 
-function logAuditRows(title: string, audits: AuditReport[]): void {
+function logAudits(pluginTitle: string, audits: AuditReport[]): void {
   log();
-  log(bold.magentaBright(`${title} audits`));
+  log(bold.magentaBright(`${pluginTitle} audits`));
   log();
-  audits.forEach((audit: AuditReport) => {
-    ui().row([
-      {
-        text: applyScoreColor({ score: audit.score, text: '●' }),
-        width: 2,
-        padding: [0, 1, 0, 0],
-      },
-      {
-        text: audit.title,
-        // eslint-disable-next-line no-magic-numbers
-        padding: [0, 3, 0, 0],
-      },
-      {
-        text: cyanBright(audit.displayValue || `${audit.value}`),
-        // eslint-disable-next-line no-magic-numbers
-        width: 20,
-        padding: [0, 0, 0, 0],
-      },
-    ]);
+  audits.forEach(({ score, title, displayValue, value }) => {
+    logRow(score, title, displayValue || `${value}`);
   });
+}
+
+function logRow(score: number, title: string, value?: string): void {
+  ui().row([
+    {
+      text: applyScoreColor({ score, text: '●' }),
+      width: 2,
+      padding: [0, 1, 0, 0],
+    },
+    {
+      text: title,
+      // eslint-disable-next-line no-magic-numbers
+      padding: [0, 3, 0, 0],
+    },
+    ...(value
+      ? [
+          {
+            text: cyanBright(value),
+            // eslint-disable-next-line no-magic-numbers
+            width: 20,
+            padding: [0, 0, 0, 0],
+          },
+        ]
+      : []),
+  ]);
 }
 
 export function logCategories({ categories, plugins }: ScoredReport): void {

--- a/packages/utils/src/lib/reports/log-stdout-summary.unit.test.ts
+++ b/packages/utils/src/lib/reports/log-stdout-summary.unit.test.ts
@@ -1,7 +1,11 @@
 import { beforeAll, describe, expect, vi } from 'vitest';
 import { removeColorCodes } from '@code-pushup/test-utils';
 import { ui } from '../logging';
-import { binaryIconPrefix, logCategories } from './log-stdout-summary';
+import {
+  binaryIconPrefix,
+  logCategories,
+  logPlugins,
+} from './log-stdout-summary';
 import type { ScoredReport } from './types';
 
 describe('logCategories', () => {
@@ -157,6 +161,102 @@ describe('logCategories', () => {
   });
 });
 
+describe('logPlugins', () => {
+  let logs: string[];
+
+  beforeAll(() => {
+    logs = [];
+    vi.spyOn(console, 'log').mockImplementation(msg => {
+      logs = [...logs, msg];
+    });
+    ui().switchMode('normal');
+  });
+
+  afterEach(() => {
+    logs = [];
+  });
+
+  afterAll(() => {
+    ui().switchMode('raw');
+  });
+
+  it('should log only audits with scores other than 1 when verbose is false', () => {
+    logPlugins(
+      [
+        {
+          title: 'Best Practices',
+          slug: 'best-practices',
+          audits: [
+            { title: 'Audit 1', score: 0.75, value: 75 },
+            { title: 'Audit 2', score: 1, value: 100 },
+          ],
+        },
+      ] as ScoredReport['plugins'],
+      false,
+    );
+    const output = logs.join('\n');
+    expect(output).toContain('Audit 1');
+    expect(output).not.toContain('Audit 2');
+    expect(output).toContain('audits with perfect scores omitted for brevity');
+  });
+
+  it('should log all audits when verbose is true', () => {
+    logPlugins(
+      [
+        {
+          title: 'Best Practices',
+          slug: 'best-practices',
+          audits: [
+            { title: 'Audit 1', score: 0.5, value: 50 },
+            { title: 'Audit 2', score: 1, value: 100 },
+          ],
+        },
+      ] as ScoredReport['plugins'],
+      true,
+    );
+    const output = logs.join('\n');
+    expect(output).toContain('Audit 1');
+    expect(output).toContain('Audit 2');
+  });
+
+  it('should indicate all audits have perfect scores', () => {
+    logPlugins(
+      [
+        {
+          title: 'Best Practices',
+          slug: 'best-practices',
+          audits: [
+            { title: 'Audit 1', score: 1, value: 100 },
+            { title: 'Audit 2', score: 1, value: 100 },
+          ],
+        },
+      ] as ScoredReport['plugins'],
+      false,
+    );
+    const output = logs.join('\n');
+    expect(output).toContain('All audits have perfect scores');
+  });
+
+  it('should log original audits when verbose is false and no audits have perfect scores', () => {
+    logPlugins(
+      [
+        {
+          title: 'Best Practices',
+          slug: 'best-practices',
+          audits: [
+            { title: 'Audit 1', score: 0.5, value: 100 },
+            { title: 'Audit 2', score: 0.5, value: 100 },
+          ],
+        },
+      ] as ScoredReport['plugins'],
+      false,
+    );
+    const output = logs.join('\n');
+    expect(output).toContain('Audit 1');
+    expect(output).toContain('Audit 2');
+  });
+});
+
 describe('binaryIconPrefix', () => {
   it('should return passing binaryPrefix if score is 1 and isBinary is true', () => {
     expect(removeColorCodes(binaryIconPrefix(1, true))).toBe('✓ ');
@@ -168,5 +268,9 @@ describe('binaryIconPrefix', () => {
 
   it('should return NO binaryPrefix if score is 1 and isBinary is false', () => {
     expect(binaryIconPrefix(1, false)).toBe('');
+  });
+
+  it('should return NO binaryPrefix when isBinary is undefined', () => {
+    expect(binaryIconPrefix(1, undefined)).toBe('');
   });
 });

--- a/packages/utils/src/lib/reports/log-stdout-summary.unit.test.ts
+++ b/packages/utils/src/lib/reports/log-stdout-summary.unit.test.ts
@@ -234,7 +234,7 @@ describe('logPlugins', () => {
       false,
     );
     const output = logs.join('\n');
-    expect(output).toContain('All audits have perfect scores');
+    expect(output).toContain('All 2 audits have perfect scores');
   });
 
   it('should log original audits when verbose is false and no audits have perfect scores', () => {


### PR DESCRIPTION
Closes #830 

This pull request focuses on improving the terminal output by skipping audits with perfect scores and refactoring the code.

### Changes:

- `verbose` option is now passed to `logStdoutSummary`
- stdout logging is moved from `persistReport` to `collectAndPersistReports`
- `logPlugins` is refactored to skip audits with perfect scores
- test coverage is added