### PR TITLE
feat: make portal-client dependency optional

### DIFF
--- a/e2e/plugin-lighthouse-e2e/tests/collect.e2e.test.ts
+++ b/e2e/plugin-lighthouse-e2e/tests/collect.e2e.test.ts
@@ -30,7 +30,8 @@ describe('collect report with lighthouse-plugin NPM package', () => {
 
     const { code, stdout } = await executeProcess({
       command: 'npx',
-      args: ['@code-pushup/cli', 'collect', '--no-progress'],
+      // verbose exposes audits with perfect scores that are hidden in the default stdout
+      args: ['@code-pushup/cli', 'collect', '--no-progress', '--verbose'],
       cwd,
     });
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -118,7 +118,26 @@ _If you're looking for programmatic usage, then refer to the underlying [@code-p
 
 ## Portal integration
 
-If you have access to the Code PushUp portal, provide credentials in order to upload reports.
+If you have access to the Code PushUp portal, you can enable report uploads by installing the `@code-pushup/portal-client` package.
+
+<details>
+<summary>Installation command for <code>npm</code>, <code>yarn</code> and <code>pnpm</code></summary>
+
+```sh
+npm install --save-dev @code-pushup/portal-client
+```
+
+```sh
+yarn add --dev @code-pushup/portal-client
+```
+
+```sh
+pnpm add --save-dev @code-pushup/portal-client
+```
+
+</details>
+
+Once the package is installed, update your configuration file to include your portal credentials:
 
 ```ts
 const config: CoreConfig = {

--- a/packages/cli/src/lib/autorun/autorun-command.ts
+++ b/packages/cli/src/lib/autorun/autorun-command.ts
@@ -46,8 +46,10 @@ export function yargsAutorunCommandObject() {
       }
 
       if (options.upload) {
-        const { url } = await upload(options);
-        uploadSuccessfulLog(url);
+        const report = await upload(options);
+        if (report?.url) {
+          uploadSuccessfulLog(report.url);
+        }
       } else {
         ui().logger.warning('Upload skipped because configuration is not set.');
         renderIntegratePortalHint();

--- a/packages/cli/src/lib/upload/upload-command.ts
+++ b/packages/cli/src/lib/upload/upload-command.ts
@@ -22,8 +22,10 @@ export function yargsUploadCommandObject() {
         renderIntegratePortalHint();
         throw new Error('Upload configuration not set');
       }
-      const { url } = await upload(options);
-      uploadSuccessfulLog(url);
+      const report = await upload(options);
+      if (report?.url) {
+        uploadSuccessfulLog(report.url);
+      }
     },
   } satisfies CommandModule;
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -6,7 +6,14 @@
   "dependencies": {
     "@code-pushup/models": "0.51.0",
     "@code-pushup/utils": "0.51.0",
-    "@code-pushup/portal-client": "^0.9.0",
     "ansis": "^3.3.0"
+  },
+  "peerDependencies": {
+    "@code-pushup/portal-client": "^0.9.0"
+  },
+  "peerDependenciesMeta": {
+    "@code-pushup/portal-client": {
+      "optional": true
+    }
   }
 }

--- a/packages/core/src/lib/compare.ts
+++ b/packages/core/src/lib/compare.ts
@@ -1,10 +1,6 @@
 import { writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import {
-  PortalOperationError,
-  getPortalComparisonLink,
-} from '@code-pushup/portal-client';
-import {
   type Format,
   type PersistConfig,
   type Report,
@@ -28,6 +24,7 @@ import {
   compareCategories,
   compareGroups,
 } from './implementation/compare-scorables';
+import { loadPortalClient } from './load-portal-client';
 
 export async function compareReportFiles(
   inputPaths: Diff<string>,
@@ -119,6 +116,11 @@ async function fetchPortalComparisonLink(
   commits: NonNullable<ReportsDiff['commits']>,
 ): Promise<string | undefined> {
   const { server, apiKey, organization, project } = uploadConfig;
+  const portalClient = await loadPortalClient();
+  if (!portalClient) {
+    return;
+  }
+  const { PortalOperationError, getPortalComparisonLink } = portalClient;
   try {
     return await getPortalComparisonLink({
       server,

--- a/packages/core/src/lib/load-portal-client.ts
+++ b/packages/core/src/lib/load-portal-client.ts
@@ -1,0 +1,14 @@
+import { ui } from '@code-pushup/utils';
+
+export async function loadPortalClient(): Promise<
+  typeof import('@code-pushup/portal-client') | null
+> {
+  try {
+    return await import('@code-pushup/portal-client');
+  } catch {
+    ui().logger.error(
+      'Optional peer dependency @code-pushup/portal-client is not available. Make sure it is installed to enable upload functionality.',
+    );
+    return null;
+  }
+}

--- a/packages/core/src/lib/upload.ts
+++ b/packages/core/src/lib/upload.ts
@@ -1,10 +1,8 @@
-import {
-  type SaveReportMutationVariables,
-  uploadToPortal,
-} from '@code-pushup/portal-client';
+import type { SaveReportMutationVariables } from '@code-pushup/portal-client';
 import type { PersistConfig, Report, UploadConfig } from '@code-pushup/models';
 import { loadReport } from '@code-pushup/utils';
 import { reportToGQL } from './implementation/report-to-gql';
+import { loadPortalClient } from './load-portal-client';
 import type { GlobalOptions } from './types';
 
 export type UploadOptions = { upload?: UploadConfig } & {
@@ -16,13 +14,15 @@ export type UploadOptions = { upload?: UploadConfig } & {
  * @param options
  * @param uploadFn
  */
-export async function upload(
-  options: UploadOptions,
-  uploadFn: typeof uploadToPortal = uploadToPortal,
-) {
+export async function upload(options: UploadOptions) {
   if (options.upload == null) {
     throw new Error('Upload configuration is not set.');
   }
+  const portalClient = await loadPortalClient();
+  if (!portalClient) {
+    return;
+  }
+  const { uploadToPortal } = portalClient;
   const { apiKey, server, organization, project, timeout } = options.upload;
   const report: Report = await loadReport({
     ...options.persist,
@@ -39,5 +39,5 @@ export async function upload(
     ...reportToGQL(report),
   };
 
-  return uploadFn({ apiKey, server, data, timeout });
+  return uploadToPortal({ apiKey, server, data, timeout });
 }


### PR DESCRIPTION
Closes #474 

- Make `@code-pushup/portal-client` an optional peer dependency in the `@code-pushup/core` package.
- Update the core package to use dynamic imports for `@code-pushup/portal-client`.
- Add a utility function to handle the loading of the portal client.
- Update the installation instructions to guide users on omitting optional dependencies, including details for `npm`, `pnpm`, and `yarn` setups.