### PR TITLE
refactor: move metadata into each of the sub-package `package.json` and add keywords

### DIFF
--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -44,7 +44,7 @@ module.exports = {
 
           try {
             await promisify(exec)(
-              `tsc --emitDeclarationOnly --project ${tsConfig} --outDir dist`,
+              `npx tsc --emitDeclarationOnly --project ${tsConfig} --outDir dist`,
             );
           } catch (err) {
             console.error(err);

--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -1,4 +1,3 @@
-const { readFile, writeFile, stat } = require('node:fs/promises');
 const { exec } = require('node:child_process');
 const { promisify } = require('node:util');
 
@@ -51,72 +50,6 @@ module.exports = {
             console.error(err);
             throw err;
           }
-        });
-      },
-    },
-    {
-      name: 'PackageJSON',
-      setup(build) {
-        build.onEnd(async result => {
-          if (result.errors.length > 0) return;
-
-          const project = await getNxProject();
-          const { outputPath } = getESBuildExecutorOptions(project);
-
-          const sourcePackageJsonPath = `${project.data.root}/package.json`;
-          const outputPackageJsonPath = `${outputPath}/package.json`;
-
-          const isPublishable = await stat(sourcePackageJsonPath)
-            .then(stats => stats.isFile())
-            .catch(() => false);
-
-          if (!isPublishable) {
-            /** @type {import('nx/src/utils/package-json').PackageJson} */
-            const newPackageJson = {
-              name: `@code-pushup/${project.name}`,
-              private: true,
-              type: 'module',
-              main: 'index.js',
-              types: 'src/index.d.ts',
-            };
-            await writeFile(
-              outputPackageJsonPath,
-              JSON.stringify(newPackageJson, null, 2),
-            );
-            return;
-          }
-
-          /** @type {import('nx/src/utils/package-json').PackageJson} */
-          const packageJson = JSON.parse(
-            await readFile(sourcePackageJsonPath, 'utf8'),
-          );
-
-          /** @type {import('nx/src/utils/package-json').PackageJson} */
-          const rootPackageJson = JSON.parse(
-            await readFile('package.json', 'utf8'),
-          );
-
-          packageJson.license = rootPackageJson.license;
-          if (project.name === 'cli') {
-            packageJson.homepage = rootPackageJson.homepage;
-          } else {
-            packageJson.homepage = `https://github.com/code-pushup/cli/tree/main/packages/${project.name}#readme`;
-          }
-          packageJson.bugs = rootPackageJson.bugs;
-          packageJson.repository = {
-            ...rootPackageJson.repository,
-            directory: project.data.root,
-          };
-          packageJson.contributors = rootPackageJson.contributors;
-          packageJson.publishConfig = { access: 'public' };
-          packageJson.type = 'module';
-          packageJson.main = './index.js';
-          packageJson.types = './src/index.d.ts';
-
-          await writeFile(
-            outputPackageJsonPath,
-            JSON.stringify(packageJson, null, 2),
-          );
         });
       },
     },

--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "0.0.0",
   "license": "MIT",
   "description": "A CLI to run all kinds of code quality measurements to align your team with company goals",
-  "homepage": "code-pushup.dev",
+  "homepage": "https://code-pushup.dev",
   "bugs": {
-    "url": "https://github.com/code-pushup/cli/issues"
+    "url": "https://github.com/code-pushup/cli/issues?q=is%3Aissue%20state%3Aopen%20type%3ABug"
   },
   "repository": {
     "type": "git",
@@ -126,6 +126,28 @@
     "@nx/nx-darwin-x64": "^16.10.0",
     "@nx/nx-linux-x64-gnu": "16.7.4"
   },
+  "keywords": [
+    "CLI",
+    "Code PushUp",
+    "automation",
+    "developer tools",
+    "code quality",
+    "conformance",
+    "build tools",
+    "KPI tracking",
+    "tech debt",
+    "automated feedback",
+    "regression guard",
+    "CI integration",
+    "code management",
+    "actionable feedback",
+    "trend analysis",
+    "static analysis",
+    "linting",
+    "audit",
+    "performance",
+    "score monitoring"
+  ],
   "config": {
     "commitizen": {
       "path": "@commitlint/cz-commitlint"

--- a/packages/ci/package.json
+++ b/packages/ci/package.json
@@ -2,6 +2,31 @@
   "name": "@code-pushup/ci",
   "version": "0.53.0",
   "description": "CI automation logic for Code PushUp (provider-agnostic)",
+  "license": "MIT",
+  "homepage": "https://github.com/code-pushup/cli/tree/main/packages/ci#readme",
+  "bugs": {
+    "url": "https://github.com/code-pushup/cli/issues?q=is%3Aissue%20state%3Aopen%20type%3ABug%20label%3A\"🧩%20ci\""
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/code-pushup/cli.git",
+    "directory": "packages/ci"
+  },
+  "keywords": [
+    "Code PushUp",
+    "CI integration",
+    "automation",
+    "KPI tracking",
+    "tech debt",
+    "automated feedback",
+    "regression guard"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "type": "module",
+  "main": "./index.js",
+  "types": "./src/index.d.ts",
   "dependencies": {
     "@code-pushup/models": "0.53.0",
     "@code-pushup/utils": "0.53.0",

--- a/packages/cli/docs/custom-plugins.md
+++ b/packages/cli/docs/custom-plugins.md
@@ -622,7 +622,7 @@ Assign weights based on what influence each audit and group should have on the o
 
 ```typescript
 // code-pushup.config.ts
-import { CoreConfig } from '@code-pushup/core';
+import type { CoreConfig } from '@code-pushup/core';
 
 export default {
   // ...

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -3,6 +3,43 @@
   "version": "0.53.0",
   "license": "MIT",
   "description": "A CLI to run all kinds of code quality measurements to align your team with company goals",
+  "homepage": "https://code-pushup.dev",
+  "bugs": {
+    "url": "https://github.com/code-pushup/cli/issues?q=is%3Aissue%20state%3Aopen%20type%3ABug%20label%3A\"🧩%20cli\""
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/code-pushup/cli.git",
+    "directory": "packages/cli"
+  },
+  "keywords": [
+    "CLI",
+    "Code PushUp",
+    "automation",
+    "developer tools",
+    "code quality",
+    "conformance",
+    "build tools",
+    "KPI tracking",
+    "tech debt",
+    "automated feedback",
+    "regression guard",
+    "CI integration",
+    "code management",
+    "actionable feedback",
+    "trend analysis",
+    "static analysis",
+    "linting",
+    "audit",
+    "performance",
+    "score monitoring"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "type": "module",
+  "main": "./index.js",
+  "types": "./src/index.d.ts",
   "bin": {
     "code-pushup": "index.js"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,6 +3,43 @@
   "version": "0.53.0",
   "license": "MIT",
   "description": "Core business logic for the used by the Code PushUp CLI",
+  "homepage": "https://github.com/code-pushup/cli/tree/main/packages/core#readme",
+  "bugs": {
+    "url": "https://github.com/code-pushup/cli/issues?q=is%3Aissue%20state%3Aopen%20type%3ABug%20label%3A\"🧩%20core\""
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/code-pushup/cli.git",
+    "directory": "packages/core"
+  },
+  "keywords": [
+    "CLI",
+    "Code PushUp",
+    "automation",
+    "developer tools",
+    "code quality",
+    "conformance",
+    "build tools",
+    "KPI tracking",
+    "tech debt",
+    "automated feedback",
+    "regression guard",
+    "CI integration",
+    "code management",
+    "actionable feedback",
+    "trend analysis",
+    "static analysis",
+    "linting",
+    "audit",
+    "performance",
+    "score monitoring"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "type": "module",
+  "main": "./index.js",
+  "types": "./src/index.d.ts",
   "dependencies": {
     "@code-pushup/models": "0.53.0",
     "@code-pushup/utils": "0.53.0",

--- a/packages/create-cli/package.json
+++ b/packages/create-cli/package.json
@@ -3,6 +3,30 @@
   "version": "0.53.0",
   "license": "MIT",
   "bin": "index.js",
+  "homepage": "https://github.com/code-pushup/cli/tree/main/packages/create-cli#readme",
+  "bugs": {
+    "url": "https://github.com/code-pushup/cli/issues?q=is%3Aissue%20state%3Aopen%20type%3ABug%20label%3A\"🧩%20create-cli\""
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/code-pushup/cli.git",
+    "directory": "packages/create-cli"
+  },
+  "keywords": [
+    "CLI",
+    "Code PushUp",
+    "automation",
+    "developer tools",
+    "code quality",
+    "conformance",
+    "build tools"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "type": "module",
+  "main": "./index.js",
+  "types": "./src/index.d.ts",
   "dependencies": {
     "@code-pushup/nx-plugin": "0.53.0",
     "@code-pushup/utils": "0.53.0"

--- a/packages/models/package.json
+++ b/packages/models/package.json
@@ -3,6 +3,31 @@
   "version": "0.53.0",
   "license": "MIT",
   "description": "Model definitions and validators for the Code PushUp CLI",
+  "homepage": "https://github.com/code-pushup/cli/tree/main/packages/models#readme",
+  "bugs": {
+    "url": "https://github.com/code-pushup/cli/issues?q=is%3Aissue%20state%3Aopen%20type%3ABug%20label%3A\"🧩%20models\""
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/code-pushup/cli.git",
+    "directory": "packages/models"
+  },
+  "keywords": [
+    "CLI",
+    "Code PushUp",
+    "developer tools",
+    "code quality",
+    "conformance",
+    "type definition",
+    "validators",
+    "models"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "type": "module",
+  "main": "./index.js",
+  "types": "./src/index.d.ts",
   "dependencies": {
     "zod": "^3.22.1",
     "vscode-material-icons": "^0.1.0"

--- a/packages/nx-plugin/package.json
+++ b/packages/nx-plugin/package.json
@@ -6,15 +6,31 @@
   "publishConfig": {
     "access": "public"
   },
-  "homepage": "code-pushup.dev",
+  "homepage": "https://code-pushup.dev",
   "bugs": {
-    "url": "https://github.com/code-pushup/cli/issues"
+    "url": "https://github.com/code-pushup/cli/issues?q=is%3Aissue%20state%3Aopen%20type%3ABug%20label%3A\"🧩%20nx-plugin\""
   },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/code-pushup/cli.git",
     "directory": "packages/nx-plugin"
   },
+  "keywords": [
+    "CLI",
+    "Code PushUp",
+    "Nx",
+    "plugin",
+    "automation",
+    "developer tools",
+    "code quality",
+    "conformance",
+    "build tools"
+  ],
+  "type": "commonjs",
+  "main": "./src/index.js",
+  "typings": "./src/index.d.ts",
+  "generators": "./generators.json",
+  "executors": "./executors.json",
   "dependencies": {
     "@nx/devkit": "^17.1.3",
     "tslib": "2.6.3",
@@ -22,10 +38,5 @@
     "@code-pushup/models": "0.53.0",
     "zod": "^3.22.4",
     "@code-pushup/utils": "0.53.0"
-  },
-  "type": "commonjs",
-  "main": "./src/index.js",
-  "typings": "./src/index.d.ts",
-  "generators": "./generators.json",
-  "executors": "./executors.json"
+  }
 }

--- a/packages/plugin-coverage/package.json
+++ b/packages/plugin-coverage/package.json
@@ -2,6 +2,39 @@
   "name": "@code-pushup/coverage-plugin",
   "version": "0.53.0",
   "description": "Code PushUp plugin for tracking code coverage ☂",
+  "license": "MIT",
+  "homepage": "https://github.com/code-pushup/cli/tree/main/packages/plugin-coverage#readme",
+  "bugs": {
+    "url": "https://github.com/code-pushup/cli/issues?q=is%3Aissue%20state%3Aopen%20type%3ABug%20label%3A\"🧩%20coverage-plugin\""
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/code-pushup/cli.git",
+    "directory": "packages/plugin-coverage"
+  },
+  "keywords": [
+    "CLI",
+    "Code PushUp",
+    "plugin",
+    "automation",
+    "developer tools",
+    "conformance",
+    "code coverage",
+    "unit tests",
+    "testing",
+    "KPI tracking",
+    "automated feedback",
+    "regression guard",
+    "actionable feedback",
+    "audit",
+    "score monitoring"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "type": "module",
+  "main": "./index.js",
+  "types": "./src/index.d.ts",
   "dependencies": {
     "@code-pushup/models": "0.53.0",
     "@code-pushup/utils": "0.53.0",

--- a/packages/plugin-eslint/package.json
+++ b/packages/plugin-eslint/package.json
@@ -3,6 +3,42 @@
   "version": "0.53.0",
   "license": "MIT",
   "description": "Code PushUp plugin for detecting problems in source code using ESLint.📋",
+  "homepage": "https://github.com/code-pushup/cli/tree/main/packages/plugin-eslint#readme",
+  "bugs": {
+    "url": "https://github.com/code-pushup/cli/issues?q=is%3Aissue%20state%3Aopen%20type%3ABug%20label%3A\"🧩%20eslint-plugin\""
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/code-pushup/cli.git",
+    "directory": "packages/plugin-eslint"
+  },
+  "keywords": [
+    "CLI",
+    "Code PushUp",
+    "ESLint",
+    "JavaScript",
+    "TypeScript",
+    "plugin",
+    "static analysis",
+    "linting",
+    "audit",
+    "performance",
+    "score monitoring",
+    "code quality",
+    "conformance",
+    "KPI tracking",
+    "tech debt",
+    "automated feedback",
+    "regression guard",
+    "actionable feedback",
+    "trend analysis"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "type": "module",
+  "main": "./index.js",
+  "types": "./src/index.d.ts",
   "dependencies": {
     "@code-pushup/utils": "0.53.0",
     "@code-pushup/models": "0.53.0",

--- a/packages/plugin-js-packages/package.json
+++ b/packages/plugin-js-packages/package.json
@@ -2,6 +2,42 @@
   "name": "@code-pushup/js-packages-plugin",
   "version": "0.53.0",
   "description": "Code PushUp plugin for JavaScript packages 🛡️",
+  "license": "MIT",
+  "homepage": "https://github.com/code-pushup/cli/tree/main/packages/plugin-js-packages#readme",
+  "bugs": {
+    "url": "https://github.com/code-pushup/cli/issues?q=is%3Aissue%20state%3Aopen%20type%3ABug%20label%3A\"🧩%20js-packages-plugin\""
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/code-pushup/cli.git",
+    "directory": "packages/plugin-js-packages"
+  },
+  "keywords": [
+    "CLI",
+    "Code PushUp",
+    "developer tools",
+    "dependencies",
+    "audit",
+    "outdated",
+    "security",
+    "updates",
+    "npm",
+    "yarn",
+    "pnpm",
+    "conformance",
+    "build tools",
+    "tech debt",
+    "automated feedback",
+    "regression guard",
+    "CI integration",
+    "actionable feedback"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "type": "module",
+  "main": "./index.js",
+  "types": "./src/index.d.ts",
   "dependencies": {
     "@code-pushup/models": "0.53.0",
     "@code-pushup/utils": "0.53.0",

--- a/packages/plugin-lighthouse/package.json
+++ b/packages/plugin-lighthouse/package.json
@@ -3,6 +3,40 @@
   "version": "0.53.0",
   "license": "MIT",
   "description": "Code PushUp plugin for measuring web performance and quality with Lighthouse 🔥",
+  "homepage": "https://github.com/code-pushup/cli/tree/main/packages/plugin-lighthouse#readme",
+  "bugs": {
+    "url": "https://github.com/code-pushup/cli/issues?q=is%3Aissue%20state%3Aopen%20type%3ABug%20label%3A\"🧩%20lighthouse-plugin\""
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/code-pushup/cli.git",
+    "directory": "packages/plugin-lighthouse"
+  },
+  "keywords": [
+    "CLI",
+    "Code PushUp",
+    "plugin",
+    "lighthouse",
+    "automation",
+    "actionable feedback",
+    "runtime analysis",
+    "audit",
+    "accessibility",
+    "performance",
+    "score monitoring",
+    "developer tools",
+    "conformance",
+    "KPI tracking",
+    "tech debt",
+    "automated feedback",
+    "regression guard"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "type": "module",
+  "main": "./index.js",
+  "types": "./src/index.d.ts",
   "dependencies": {
     "@code-pushup/models": "0.53.0",
     "@code-pushup/utils": "0.53.0",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -2,6 +2,29 @@
   "name": "@code-pushup/utils",
   "version": "0.53.0",
   "description": "Low-level utilities (helper functions, etc.) used by Code PushUp CLI",
+  "license": "MIT",
+  "homepage": "https://github.com/code-pushup/cli/tree/main/packages/utils#readme",
+  "bugs": {
+    "url": "https://github.com/code-pushup/cli/issues?q=is%3Aissue%20state%3Aopen%20type%3ABug%20label%3A\"🧩%20utils\""
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/code-pushup/cli.git",
+    "directory": "packages/utils"
+  },
+  "keywords": [
+    "CLI",
+    "Code PushUp",
+    "developer tools",
+    "helpers",
+    "utils"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "type": "module",
+  "main": "./index.js",
+  "types": "./src/index.d.ts",
   "dependencies": {
     "@code-pushup/models": "0.53.0",
     "@isaacs/cliui": "^8.0.2",


### PR DESCRIPTION
closes #848 

- [x] remove esbuild post build step transforming sub-package `package.json`s
- [x] move all necessary metadata into each of the sub-package `package.json`s
- [x] add keywords to all sub-package `package.json`s
  - NPM displays keywords and uses them for search categorizing, I've added a few so our package is more visible