### PR TITLE
feat(ci): add useful exports

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -10,6 +10,18 @@
   - changed-files:
       - any-glob-to-any-file: 'packages/models/src/**'
 
+🧩 utils:
+  - changed-files:
+      - any-glob-to-any-file: 'packages/utils/src/**'
+
+🧩 ci:
+  - changed-files:
+      - any-glob-to-any-file: 'packages/ci/src/**'
+
+🧩 create-cli:
+  - changed-files:
+      - any-glob-to-any-file: 'packages/create-cli/src/**'
+
 🧩 nx-plugin:
   - changed-files:
       - any-glob-to-any-file: 'packages/nx-plugin/src/**'
@@ -17,10 +29,6 @@
 🧩 eslint-plugin:
   - changed-files:
       - any-glob-to-any-file: 'packages/plugin-eslint/src/**'
-
-🧩 lighthouse-plugin:
-  - changed-files:
-      - any-glob-to-any-file: 'packages/plugin-lighthouse/src/**'
 
 🧩 coverage-plugin:
   - changed-files:
@@ -30,9 +38,9 @@
   - changed-files:
       - any-glob-to-any-file: 'packages/plugin-js-packages/src/**'
 
-🧩 utils:
+🧩 lighthouse-plugin:
   - changed-files:
-      - any-glob-to-any-file: 'packages/utils/src/**'
+      - any-glob-to-any-file: 'packages/plugin-lighthouse/src/**'
 
 🔬 testing:
   - changed-files:

--- a/packages/ci/src/index.ts
+++ b/packages/ci/src/index.ts
@@ -1,2 +1,8 @@
+export type { SourceFileIssue } from './lib/issues';
 export type * from './lib/models';
+export {
+  MONOREPO_TOOLS,
+  isMonorepoTool,
+  type MonorepoTool,
+} from './lib/monorepo';
 export { runInCI } from './lib/run';

--- a/packages/ci/src/lib/monorepo/index.ts
+++ b/packages/ci/src/lib/monorepo/index.ts
@@ -1,2 +1,7 @@
 export { listMonorepoProjects } from './list-projects';
-export { MONOREPO_TOOLS, type MonorepoTool, type ProjectConfig } from './tools';
+export {
+  MONOREPO_TOOLS,
+  isMonorepoTool,
+  type MonorepoTool,
+  type ProjectConfig,
+} from './tools';

--- a/packages/ci/src/lib/monorepo/tools.ts
+++ b/packages/ci/src/lib/monorepo/tools.ts
@@ -20,3 +20,7 @@ export type ProjectConfig = {
   bin: string;
   directory?: string;
 };
+
+export function isMonorepoTool(value: string): value is MonorepoTool {
+  return MONOREPO_TOOLS.includes(value as MonorepoTool);
+}


### PR DESCRIPTION
Integrating `ci` package in GitHub Action as part of #829, realized a few more exports would be useful for types and runtime validation.