### PR TITLE
fix(ci): handle monorepo mode in non-PR flow

### DIFF
--- a/packages/ci/src/lib/run.ts
+++ b/packages/ci/src/lib/run.ts
@@ -75,6 +75,7 @@ export async function runInCI(
         diffArtifact,
       };
     }
+    return { mode: 'monorepo', projects: projectResults };
   }
 
   logger.info('Running Code PushUp in standalone project mode');


### PR DESCRIPTION
Came across error in monorepo mode when triggered on `push` and not `pull_request`. Falls through to standalone mode.

![image](https://github.com/user-attachments/assets/7955973d-f6e2-4f8c-b817-cbc7c7552b4b)
