### PR TITLE
feat(plugin-eslint): add exclude option for Nx projects

### DIFF
--- a/packages/plugin-eslint/README.md
+++ b/packages/plugin-eslint/README.md
@@ -59,7 +59,7 @@ Detected ESLint rules are mapped to Code PushUp audits. Audit reports are calcul
 
    If you're using an Nx monorepo, additional helper functions are provided to simplify your configuration:
 
-   - If you wish to combine all projects in your workspace into one report, use the `eslintConfigFromAllNxProjects` helper. You can exclude specific projects if needed by passing their names in the exclude option:
+   - If you wish to combine all projects in your workspace into one report, use the `eslintConfigFromAllNxProjects` helper:
 
      ```js
      import eslintPlugin, { eslintConfigFromAllNxProjects } from '@code-pushup/eslint-plugin';
@@ -67,9 +67,15 @@ Detected ESLint rules are mapped to Code PushUp audits. Audit reports are calcul
      export default {
        plugins: [
          // ...
-         await eslintPlugin(await eslintConfigFromAllNxProjects({ exclude: ['server'] })),
+         await eslintPlugin(await eslintConfigFromAllNxProjects()),
        ],
      };
+     ```
+
+     You can also exclude specific projects if needed by passing their names in the `exclude` option:
+
+     ```js
+     await eslintConfigFromAllNxProjects({ exclude: ['server'] });
      ```
 
    - If you wish to target a specific project along with other projects it depends on, use the `eslintConfigFromNxProjectAndDeps` helper and pass in in your project name:

--- a/packages/plugin-eslint/README.md
+++ b/packages/plugin-eslint/README.md
@@ -59,7 +59,7 @@ Detected ESLint rules are mapped to Code PushUp audits. Audit reports are calcul
 
    If you're using an Nx monorepo, additional helper functions are provided to simplify your configuration:
 
-   - If you wish to combine all projects in your workspace into one report, use the `eslintConfigFromAllNxProjects` helper:
+   - If you wish to combine all projects in your workspace into one report, use the `eslintConfigFromAllNxProjects` helper. You can exclude specific projects if needed by passing their names in the exclude option:
 
      ```js
      import eslintPlugin, { eslintConfigFromAllNxProjects } from '@code-pushup/eslint-plugin';
@@ -67,7 +67,7 @@ Detected ESLint rules are mapped to Code PushUp audits. Audit reports are calcul
      export default {
        plugins: [
          // ...
-         await eslintPlugin(await eslintConfigFromAllNxProjects()),
+         await eslintPlugin(await eslintConfigFromAllNxProjects({ exclude: ['server'] })),
        ],
      };
      ```

--- a/packages/plugin-eslint/src/lib/nx.integration.test.ts
+++ b/packages/plugin-eslint/src/lib/nx.integration.test.ts
@@ -88,6 +88,25 @@ describe('Nx helpers', () => {
         },
       ] satisfies ESLintTarget[]);
     });
+
+    it('should exclude specified projects and return only eslintrc and patterns of a remaining project', async () => {
+      await expect(
+        eslintConfigFromAllNxProjects({ exclude: ['cli', 'core', 'utils'] }),
+      ).resolves.toEqual([
+        {
+          eslintrc: './packages/nx-plugin/.eslintrc.json',
+          patterns: [
+            'packages/nx-plugin/**/*.ts',
+            'packages/nx-plugin/package.json',
+            'packages/nx-plugin/generators.json',
+            'packages/nx-plugin/src/*.spec.ts',
+            'packages/nx-plugin/src/*.cy.ts',
+            'packages/nx-plugin/src/*.stories.ts',
+            'packages/nx-plugin/src/.storybook/main.ts',
+          ],
+        },
+      ] satisfies ESLintTarget[]);
+    });
   });
 
   describe('create config from target Nx project and its dependencies', () => {

--- a/packages/plugin-eslint/src/lib/nx/filter-project-graph.ts
+++ b/packages/plugin-eslint/src/lib/nx/filter-project-graph.ts
@@ -1,0 +1,31 @@
+import type {
+  ProjectGraph,
+  ProjectGraphDependency,
+  ProjectGraphProjectNode,
+} from '@nx/devkit';
+
+export function filterProjectGraph(
+  projectGraph: ProjectGraph,
+  exclude: string[] = [],
+): ProjectGraph {
+  const filteredNodes: Record<string, ProjectGraphProjectNode> = Object.entries(
+    projectGraph.nodes,
+  ).reduce(
+    (acc, [projectName, projectNode]) =>
+      exclude.includes(projectName)
+        ? acc
+        : { ...acc, [projectName]: projectNode },
+    {},
+  );
+  const filteredDependencies: Record<string, ProjectGraphDependency[]> =
+    Object.entries(projectGraph.dependencies).reduce(
+      (acc, [key, deps]) =>
+        exclude.includes(key) ? acc : { ...acc, [key]: deps },
+      {},
+    );
+  return {
+    nodes: filteredNodes,
+    dependencies: filteredDependencies,
+    version: projectGraph.version,
+  };
+}

--- a/packages/plugin-eslint/src/lib/nx/filter-project-graph.unit.test.ts
+++ b/packages/plugin-eslint/src/lib/nx/filter-project-graph.unit.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { toProjectGraph } from '@code-pushup/test-utils';
+import { filterProjectGraph } from './filter-project-graph';
+
+describe('filterProjectGraph', () => {
+  it('should exclude specified projects from nodes', () => {
+    const projectGraph = toProjectGraph([
+      { name: 'client', type: 'app', data: { root: 'apps/client' } },
+      { name: 'server', type: 'app', data: { root: 'apps/server' } },
+      { name: 'models', type: 'lib', data: { root: 'libs/models' } },
+    ]);
+
+    const filteredGraph = filterProjectGraph(projectGraph, ['client']);
+
+    expect(Object.keys(filteredGraph.nodes)).not.toContain('client');
+    expect(Object.keys(filteredGraph.nodes)).toContain('server');
+    expect(Object.keys(filteredGraph.nodes)).toContain('models');
+  });
+
+  it('should exclude dependencies of excluded projects', () => {
+    const projectGraph = toProjectGraph(
+      [
+        { name: 'client', type: 'app', data: { root: 'apps/client' } },
+        { name: 'server', type: 'app', data: { root: 'apps/server' } },
+        { name: 'models', type: 'lib', data: { root: 'libs/models' } },
+      ],
+      {
+        client: ['server'],
+        server: ['models'],
+      },
+    );
+
+    const filteredGraph = filterProjectGraph(projectGraph, ['client']);
+
+    expect(Object.keys(filteredGraph.dependencies)).not.toContain('client');
+    expect(filteredGraph.dependencies['server']).toEqual([
+      { source: 'server', target: 'models', type: 'static' },
+    ]);
+  });
+
+  it('should include all projects if exclude list is empty', () => {
+    const projectGraph = toProjectGraph([
+      { name: 'client', type: 'app', data: { root: 'apps/client' } },
+      { name: 'server', type: 'app', data: { root: 'apps/server' } },
+      { name: 'models', type: 'lib', data: { root: 'libs/models' } },
+    ]);
+
+    const filteredGraph = filterProjectGraph(projectGraph, []);
+
+    expect(Object.keys(filteredGraph.nodes)).toContain('client');
+    expect(Object.keys(filteredGraph.nodes)).toContain('server');
+    expect(Object.keys(filteredGraph.nodes)).toContain('models');
+  });
+
+  it('should ignore non-existent projects in the exclude list', () => {
+    const projectGraph = toProjectGraph([
+      { name: 'client', type: 'app', data: { root: 'apps/client' } },
+      { name: 'server', type: 'app', data: { root: 'apps/server' } },
+      { name: 'models', type: 'lib', data: { root: 'libs/models' } },
+    ]);
+
+    const filteredGraph = filterProjectGraph(projectGraph, ['non-existent']);
+
+    expect(Object.keys(filteredGraph.nodes)).toContain('client');
+    expect(Object.keys(filteredGraph.nodes)).toContain('server');
+    expect(Object.keys(filteredGraph.nodes)).toContain('models');
+  });
+});

--- a/packages/plugin-eslint/src/lib/nx/find-all-projects.ts
+++ b/packages/plugin-eslint/src/lib/nx/find-all-projects.ts
@@ -1,11 +1,15 @@
 import type { ESLintTarget } from '../config';
+import { filterProjectGraph } from './filter-project-graph';
 import { nxProjectsToConfig } from './projects-to-config';
 
 /**
  * Finds all Nx projects in workspace and converts their lint configurations to Code PushUp ESLint plugin parameters.
  *
+ * Allows excluding certain projects from the configuration using the `options.exclude` parameter.
+ *
  * Use when you wish to automatically include every Nx project in a single Code PushUp project.
- * If you prefer to only include a subset of your Nx monorepo, refer to {@link eslintConfigFromNxProjectAndDeps} instead.
+ * If you prefer to include only a subset of your Nx monorepo, specify projects to exclude using the `exclude` option
+ * or consider using {@link eslintConfigFromNxProjectAndDeps} for finer control.
  *
  * @example
  * import eslintPlugin, {
@@ -15,17 +19,25 @@ import { nxProjectsToConfig } from './projects-to-config';
  * export default {
  *   plugins: [
  *     await eslintPlugin(
- *       await eslintConfigFromAllNxProjects()
+ *       await eslintConfigFromAllNxProjects({ exclude: ['server'] })
  *     )
  *   ]
  * }
  *
+ * @param options - Configuration options to filter projects
+ * @param options.exclude - Array of project names to exclude from the ESLint configuration
  * @returns ESLint config and patterns, intended to be passed to {@link eslintPlugin}
  */
-export async function eslintConfigFromAllNxProjects(): Promise<ESLintTarget[]> {
+export async function eslintConfigFromAllNxProjects(
+  options: { exclude?: string[] } = {},
+): Promise<ESLintTarget[]> {
   const { createProjectGraphAsync } = await import('@nx/devkit');
   const projectGraph = await createProjectGraphAsync({ exitOnError: false });
-  return nxProjectsToConfig(projectGraph);
+  const filteredProjectGraph = filterProjectGraph(
+    projectGraph,
+    options.exclude,
+  );
+  return nxProjectsToConfig(filteredProjectGraph);
 }
 
 /**

--- a/packages/plugin-eslint/src/lib/nx/projects-to-config.unit.test.ts
+++ b/packages/plugin-eslint/src/lib/nx/projects-to-config.unit.test.ts
@@ -1,52 +1,10 @@
-import type {
-  ProjectGraph,
-  ProjectGraphDependency,
-  ProjectGraphProjectNode,
-} from '@nx/devkit';
 import { vol } from 'memfs';
 import type { MockInstance } from 'vitest';
-import { MEMFS_VOLUME } from '@code-pushup/test-utils';
+import { MEMFS_VOLUME, toProjectGraph } from '@code-pushup/test-utils';
 import type { ESLintPluginConfig, ESLintTarget } from '../config';
 import { nxProjectsToConfig } from './projects-to-config';
 
 describe('nxProjectsToConfig', () => {
-  const toProjectGraph = (
-    nodes: ProjectGraphProjectNode[],
-    dependencies?: Record<string, string[]>,
-  ): ProjectGraph => ({
-    nodes: Object.fromEntries(
-      nodes.map(node => [
-        node.name,
-        {
-          ...node,
-          data: {
-            targets: {
-              lint: {
-                options: {
-                  lintFilePatterns: `${node.data.root}/**/*.ts`,
-                },
-              },
-            },
-            sourceRoot: `${node.data.root}/src`,
-            ...node.data,
-          },
-        },
-      ]),
-    ),
-    dependencies: Object.fromEntries(
-      nodes.map(node => [
-        node.name,
-        dependencies?.[node.name]?.map(
-          (target): ProjectGraphDependency => ({
-            source: node.name,
-            target,
-            type: 'static',
-          }),
-        ) ?? [],
-      ]),
-    ),
-  });
-
   let cwdSpy: MockInstance<[], string>;
 
   beforeAll(() => {

--- a/testing/test-utils/src/index.ts
+++ b/testing/test-utils/src/index.ts
@@ -8,6 +8,7 @@ export * from './lib/utils/string';
 export * from './lib/utils/file-system';
 export * from './lib/utils/create-npm-workshpace';
 export * from './lib/utils/omit-report-data';
+export * from './lib/utils/project-graph';
 
 // static mocks
 export * from './lib/utils/commit.mock';

--- a/testing/test-utils/src/lib/utils/project-graph.ts
+++ b/testing/test-utils/src/lib/utils/project-graph.ts
@@ -1,0 +1,51 @@
+import type {
+  ProjectGraph,
+  ProjectGraphDependency,
+  ProjectGraphProjectNode,
+} from '@nx/devkit';
+
+/**
+ * Converts nodes and dependencies into a ProjectGraph object for testing purposes.
+ *
+ * @param nodes - Array of ProjectGraphProjectNode representing project nodes.
+ * @param dependencies - Optional dependencies for each project in a record format.
+ * @returns A ProjectGraph object.
+ */
+export function toProjectGraph(
+  nodes: ProjectGraphProjectNode[],
+  dependencies?: Record<string, string[]>,
+): ProjectGraph {
+  return {
+    nodes: Object.fromEntries(
+      nodes.map(node => [
+        node.name,
+        {
+          ...node,
+          data: {
+            targets: {
+              lint: {
+                options: {
+                  lintFilePatterns: `${node.data.root}/**/*.ts`,
+                },
+              },
+            },
+            sourceRoot: `${node.data.root}/src`,
+            ...node.data,
+          },
+        },
+      ]),
+    ),
+    dependencies: Object.fromEntries(
+      nodes.map(node => [
+        node.name,
+        dependencies?.[node.name]?.map(
+          (target): ProjectGraphDependency => ({
+            source: node.name,
+            target,
+            type: 'static',
+          }),
+        ) ?? [],
+      ]),
+    ),
+  };
+}


### PR DESCRIPTION
Closes #496 

This PR adds an exclude option to the `eslintConfigFromAllNxProjects` function, allowing Nx projects to be selectively excluded from ESLint configuration and additionally moves the `toProjectGraph` helper into `test-utils` for reuse across test suites.