### PR TITLE
fix(plugin-eslint,plugin-coverage): future-proof version range of nx peer deps

### DIFF
--- a/packages/plugin-coverage/package.json
+++ b/packages/plugin-coverage/package.json
@@ -43,9 +43,9 @@
     "zod": "^3.22.4"
   },
   "peerDependencies": {
-    "@nx/devkit": "^17.0.0 || ^18.0.0 || ^19.0.0",
-    "@nx/jest": "^17.0.0 || ^18.0.0 || ^19.0.0",
-    "@nx/vite": "^17.0.0 || ^18.0.0 || ^19.0.0"
+    "@nx/devkit": ">=17.0.0",
+    "@nx/jest": ">=17.0.0",
+    "@nx/vite": ">=17.0.0"
   },
   "peerDependenciesMeta": {
     "@nx/devkit": {

--- a/packages/plugin-eslint/package.json
+++ b/packages/plugin-eslint/package.json
@@ -46,7 +46,7 @@
     "zod": "^3.22.4"
   },
   "peerDependencies": {
-    "@nx/devkit": "^17.0.0 || ^18.0.0 || ^19.0.0"
+    "@nx/devkit": ">=17.0.0"
   },
   "peerDependenciesMeta": {
     "@nx/devkit": {


### PR DESCRIPTION
Not possible to install these plugins without `--legacy-peer-deps` otherwise for Nx 20.