### PR TITLE
refactor: standardize undefined handling for categories

### DIFF
--- a/packages/cli/src/lib/autorun/autorun-command.ts
+++ b/packages/cli/src/lib/autorun/autorun-command.ts
@@ -41,7 +41,7 @@ export function yargsAutorunCommandObject() {
       await collectAndPersistReports(optionsWithFormat);
       collectSuccessfulLog();
 
-      if (options.categories.length === 0) {
+      if (!options.categories || options.categories.length === 0) {
         renderConfigureCategoriesHint();
       }
 

--- a/packages/cli/src/lib/collect/collect-command.ts
+++ b/packages/cli/src/lib/collect/collect-command.ts
@@ -24,7 +24,7 @@ export function yargsCollectCommandObject(): CommandModule {
       await collectAndPersistReports(options);
       collectSuccessfulLog();
 
-      if (options.categories.length === 0) {
+      if (!options.categories || options.categories.length === 0) {
         renderConfigureCategoriesHint();
       }
 

--- a/packages/cli/src/lib/implementation/core-config.integration.test.ts
+++ b/packages/cli/src/lib/implementation/core-config.integration.test.ts
@@ -144,7 +144,7 @@ describe('parsing values from CLI and middleware', () => {
     });
   });
 
-  it('should set empty array for categories if not given in config file', async () => {
+  it('should keep categories undefined if not given in config file', async () => {
     const { categories } = await yargsCli<CoreConfig>(
       ['--config=./no-category.config.ts'],
       {
@@ -153,7 +153,7 @@ describe('parsing values from CLI and middleware', () => {
       },
     ).parseAsync();
 
-    expect(categories).toEqual([]);
+    expect(categories).toBeUndefined();
   });
 
   it('should accept an upload configuration with CLI overrides', async () => {

--- a/packages/cli/src/lib/implementation/core-config.middleware.ts
+++ b/packages/cli/src/lib/implementation/core-config.middleware.ts
@@ -32,7 +32,6 @@ export async function coreConfigMiddleware<
   const {
     persist: rcPersist,
     upload: rcUpload,
-    categories: rcCategories,
     ...remainingRcConfig
   } = importedRc;
   const upload =
@@ -56,7 +55,6 @@ export async function coreConfigMiddleware<
       ),
     },
     ...(upload != null && { upload }),
-    categories: rcCategories ?? [],
     ...remainingRcConfig,
     ...remainingCliOptions,
   };

--- a/packages/cli/src/lib/implementation/filter.middleware.unit.test.ts
+++ b/packages/cli/src/lib/implementation/filter.middleware.unit.test.ts
@@ -22,7 +22,6 @@ describe('filterMiddleware', () => {
       }),
     ).toStrictEqual({
       plugins: [{ slug: 'p1', audits: [{ slug: 'a1-p1' }] }],
-      categories: [],
     });
   });
 
@@ -89,7 +88,6 @@ describe('filterMiddleware', () => {
       const { plugins } = filterMiddleware({
         ...option,
         plugins: [{ slug: 'p1' }, { slug: 'p2' }] as PluginConfig[],
-        categories: [],
       });
       expect(plugins).toStrictEqual([expect.objectContaining(expected)]);
     },

--- a/packages/cli/src/lib/implementation/filter.model.ts
+++ b/packages/cli/src/lib/implementation/filter.model.ts
@@ -1,9 +1,5 @@
 import type { GlobalOptions } from '@code-pushup/core';
-import type {
-  CategoryConfig,
-  CoreConfig,
-  PluginConfig,
-} from '@code-pushup/models';
+import type { CoreConfig } from '@code-pushup/models';
 
 export type FilterOptions = Partial<GlobalOptions> &
   Pick<CoreConfig, 'categories' | 'plugins'> &
@@ -17,7 +13,4 @@ export type FilterOptionType =
   | 'skipPlugins'
   | 'onlyPlugins';
 
-export type Filterables = {
-  categories: CategoryConfig[];
-  plugins: PluginConfig[];
-};
+export type Filterables = Pick<CoreConfig, 'plugins' | 'categories'>;

--- a/packages/cli/src/lib/implementation/validate-filter-options.utils.ts
+++ b/packages/cli/src/lib/implementation/validate-filter-options.utils.ts
@@ -11,7 +11,7 @@ export class OptionValidationError extends Error {}
 
 export function validateFilterOption(
   option: FilterOptionType,
-  { plugins, categories }: Filterables,
+  { plugins, categories = [] }: Filterables,
   { itemsToFilter, verbose }: { itemsToFilter: string[]; verbose: boolean },
 ): void {
   const itemsToFilterSet = new Set(itemsToFilter);
@@ -59,9 +59,9 @@ export function validateFinalState(
   filteredItems: Filterables,
   originalItems: Filterables,
 ): void {
-  const { categories: filteredCategories, plugins: filteredPlugins } =
+  const { categories: filteredCategories = [], plugins: filteredPlugins } =
     filteredItems;
-  const { categories: originalCategories, plugins: originalPlugins } =
+  const { categories: originalCategories = [], plugins: originalPlugins } =
     originalItems;
   if (
     filteredCategories.length === 0 &&

--- a/packages/cli/src/lib/implementation/validate-filter-options.utils.unit.test.ts
+++ b/packages/cli/src/lib/implementation/validate-filter-options.utils.unit.test.ts
@@ -106,7 +106,6 @@ describe('validateFilterOption', () => {
           { slug: 'p1', audits: [{ slug: 'a1-p1' }] },
           { slug: 'p2', audits: [{ slug: 'a1-p2' }] },
         ] as PluginConfig[],
-        categories: [],
       },
       { itemsToFilter: ['p1'], verbose: false },
     );
@@ -145,7 +144,6 @@ describe('validateFilterOption', () => {
             { slug: 'p2', audits: [{ slug: 'a1-p2' }] },
             { slug: 'p3', audits: [{ slug: 'a1-p3' }] },
           ] as PluginConfig[],
-          categories: [],
         },
         { itemsToFilter: ['p4', 'p5'], verbose: false },
       );
@@ -165,12 +163,12 @@ describe('validateFilterOption', () => {
     expect(() => {
       validateFilterOption(
         'skipPlugins',
-        { plugins: allPlugins, categories: [] },
+        { plugins: allPlugins },
         { itemsToFilter: ['plugin1'], verbose: false },
       );
       validateFilterOption(
         'onlyPlugins',
-        { plugins: allPlugins, categories: [] },
+        { plugins: allPlugins },
         { itemsToFilter: ['plugin3'], verbose: false },
       );
     }).toThrow(
@@ -319,6 +317,21 @@ describe('validateFinalState', () => {
     expect(() => {
       validateFinalState(filteredItems, originalItems);
     }).toThrow(expect.any(OptionValidationError));
+  });
+
+  it('should perform validation without throwing an error when categories are missing', () => {
+    const filteredItems = {
+      plugins: [{ slug: 'p1', audits: [{ slug: 'a1-p1' }] }] as PluginConfig[],
+    };
+    const originalItems = {
+      plugins: [
+        { slug: 'p1', audits: [{ slug: 'a1-p1' }] },
+        { slug: 'p2', audits: [{ slug: 'a1-p2' }] },
+      ] as PluginConfig[],
+    };
+    expect(() => {
+      validateFinalState(filteredItems, originalItems);
+    }).not.toThrow();
   });
 });
 

--- a/packages/core/src/lib/collect-and-persist.ts
+++ b/packages/core/src/lib/collect-and-persist.ts
@@ -13,8 +13,9 @@ import { collect } from './implementation/collect';
 import { logPersistedResults, persistReport } from './implementation/persist';
 import type { GlobalOptions } from './types';
 
-export type CollectAndPersistReportsOptions = Required<
-  Pick<CoreConfig, 'plugins' | 'categories'>
+export type CollectAndPersistReportsOptions = Pick<
+  CoreConfig,
+  'plugins' | 'categories'
 > & { persist: Required<PersistConfig> } & Partial<GlobalOptions>;
 
 export async function collectAndPersistReports(

--- a/packages/core/src/lib/collect-and-persist.unit.test.ts
+++ b/packages/core/src/lib/collect-and-persist.unit.test.ts
@@ -46,7 +46,6 @@ describe('collectAndPersistReports', () => {
   it('should call collect and persistReport with correct parameters in non-verbose mode', async () => {
     const sortedScoredReport = sortReport(scoreReport(MINIMAL_REPORT_MOCK));
     const nonVerboseConfig: CollectAndPersistReportsOptions = {
-      categories: [],
       ...MINIMAL_CONFIG_MOCK,
       persist: {
         outputDir: 'output',
@@ -69,7 +68,6 @@ describe('collectAndPersistReports', () => {
         date: expect.stringMatching(ISO_STRING_REGEXP),
         duration: 666,
         commit: expect.any(Object),
-        categories: expect.any(Array),
         plugins: expect.any(Array),
       },
       sortedScoredReport,
@@ -87,7 +85,6 @@ describe('collectAndPersistReports', () => {
   it('should call collect and persistReport with correct parameters in verbose mode', async () => {
     const sortedScoredReport = sortReport(scoreReport(MINIMAL_REPORT_MOCK));
     const verboseConfig: CollectAndPersistReportsOptions = {
-      categories: [],
       ...MINIMAL_CONFIG_MOCK,
       persist: {
         outputDir: 'output',

--- a/packages/core/src/lib/history.ts
+++ b/packages/core/src/lib/history.ts
@@ -13,9 +13,7 @@ export type HistoryOnlyOptions = {
   skipUploads?: boolean;
   forceCleanStatus?: boolean;
 };
-export type HistoryOptions = Required<
-  Pick<CoreConfig, 'plugins'> & Required<Pick<CoreConfig, 'categories'>>
-> & {
+export type HistoryOptions = Pick<CoreConfig, 'plugins' | 'categories'> & {
   persist: Required<PersistConfig>;
   upload?: Required<UploadConfig>;
 } & HistoryOnlyOptions &

--- a/packages/core/src/lib/history.unit.test.ts
+++ b/packages/core/src/lib/history.unit.test.ts
@@ -30,7 +30,6 @@ describe('history', () => {
       format: ['json'],
     },
     plugins: [MINIMAL_PLUGIN_CONFIG_MOCK],
-    categories: [],
   };
   it('should check out all passed commits and reset to initial branch or tag', async () => {
     await history(historyBaseOptions, ['abc', 'def']);

--- a/packages/core/src/lib/implementation/collect.integration.test.ts
+++ b/packages/core/src/lib/implementation/collect.integration.test.ts
@@ -8,7 +8,6 @@ describe('collect', () => {
   it('should execute with valid options', async () => {
     vol.fromJSON({}, MEMFS_VOLUME);
     const report = await collect({
-      categories: [],
       ...MINIMAL_CONFIG_MOCK,
       verbose: true,
       progress: false,

--- a/packages/core/src/lib/implementation/collect.ts
+++ b/packages/core/src/lib/implementation/collect.ts
@@ -4,9 +4,7 @@ import { name, version } from '../../../package.json';
 import type { GlobalOptions } from '../types';
 import { executePlugins } from './execute-plugin';
 
-export type CollectOptions = Required<
-  Pick<CoreConfig, 'plugins' | 'categories'>
-> &
+export type CollectOptions = Pick<CoreConfig, 'plugins' | 'categories'> &
   Partial<GlobalOptions>;
 
 /**

--- a/packages/core/src/lib/implementation/compare-scorables.ts
+++ b/packages/core/src/lib/implementation/compare-scorables.ts
@@ -26,8 +26,8 @@ export function compareCategories(
   reports: ReportsToCompare,
 ): ReportsDiff['categories'] {
   const { pairs, added, removed } = matchArrayItemsByKey({
-    before: reports.before.categories,
-    after: reports.after.categories,
+    before: reports.before.categories ?? [],
+    after: reports.after.categories ?? [],
     key: 'slug',
   });
   const { changed, unchanged } = comparePairs(

--- a/packages/core/src/lib/implementation/report-to-gql.ts
+++ b/packages/core/src/lib/implementation/report-to-gql.ts
@@ -35,7 +35,7 @@ export function reportToGQL(
     commandStartDate: report.date,
     commandDuration: report.duration,
     plugins: report.plugins.map(pluginToGQL),
-    categories: report.categories.map(categoryToGQL),
+    categories: (report.categories ?? []).map(categoryToGQL),
   };
 }
 

--- a/packages/models/src/lib/core-config.ts
+++ b/packages/models/src/lib/core-config.ts
@@ -32,13 +32,10 @@ export const coreConfigSchema = refineCoreConfig(unrefinedCoreConfigSchema);
 export function refineCoreConfig(schema: typeof unrefinedCoreConfigSchema) {
   // categories point to existing audit or group refs
   return schema.refine(
-    coreCfg =>
-      !getMissingRefsForCategories(coreCfg.categories ?? [], coreCfg.plugins),
-    coreCfg => ({
-      message: missingRefsForCategoriesErrorMsg(
-        coreCfg.categories ?? [],
-        coreCfg.plugins,
-      ),
+    ({ plugins, categories }) =>
+      !getMissingRefsForCategories(plugins, categories),
+    ({ plugins, categories }) => ({
+      message: missingRefsForCategoriesErrorMsg(plugins, categories),
     }),
   ) as unknown as typeof unrefinedCoreConfigSchema;
 }

--- a/packages/models/src/lib/implementation/utils.ts
+++ b/packages/models/src/lib/implementation/utils.ts
@@ -64,10 +64,10 @@ export function exists<T>(value: T): value is NonNullable<T> {
  * @returns Array of missing references.
  */
 export function getMissingRefsForCategories(
-  categories: CategoryConfig[],
   plugins: PluginConfig[] | PluginReport[],
+  categories?: CategoryConfig[],
 ) {
-  if (categories.length === 0) {
+  if (!categories || categories.length === 0) {
     return false;
   }
 
@@ -108,10 +108,10 @@ export function getMissingRefsForCategories(
 }
 
 export function missingRefsForCategoriesErrorMsg(
-  categories: CategoryConfig[],
   plugins: PluginConfig[] | PluginReport[],
+  categories?: CategoryConfig[],
 ) {
-  const missingRefs = getMissingRefsForCategories(categories, plugins);
+  const missingRefs = getMissingRefsForCategories(plugins, categories);
   return `The following category references need to point to an audit or group: ${errorItems(
     missingRefs,
   )}`;

--- a/packages/models/src/lib/report.ts
+++ b/packages/models/src/lib/report.ts
@@ -75,8 +75,8 @@ export const reportSchema = packageVersionSchema({
   .merge(
     z.object(
       {
-        categories: z.array(categoryConfigSchema),
         plugins: z.array(pluginReportSchema).min(1),
+        categories: z.array(categoryConfigSchema).optional(),
         commit: commitSchema
           .describe('Git commit for which report was collected')
           .nullable(),
@@ -85,12 +85,10 @@ export const reportSchema = packageVersionSchema({
     ),
   )
   .refine(
-    report => !getMissingRefsForCategories(report.categories, report.plugins),
-    report => ({
-      message: missingRefsForCategoriesErrorMsg(
-        report.categories,
-        report.plugins,
-      ),
+    ({ plugins, categories }) =>
+      !getMissingRefsForCategories(plugins, categories),
+    ({ plugins, categories }) => ({
+      message: missingRefsForCategoriesErrorMsg(plugins, categories),
     }),
   );
 

--- a/packages/models/src/lib/report.unit.test.ts
+++ b/packages/models/src/lib/report.unit.test.ts
@@ -219,7 +219,6 @@ describe('reportSchema', () => {
         packageName: 'cli',
         version: '1.0.1',
         plugins: [],
-        categories: [],
       }),
     ).toThrow('too_small');
   });

--- a/packages/utils/perf/score-report/optimized0.ts
+++ b/packages/utils/perf/score-report/optimized0.ts
@@ -78,7 +78,7 @@ export function scoreReportOptimized0(report: Report): ScoredReport {
   const allScoredAudits = scoredPlugins.flatMap(({ audits }) => audits);
   const allScoredGroups = scoredPlugins.flatMap(({ groups }) => groups);
 
-  const scoredCategories = report.categories.map(category => ({
+  const scoredCategories = report.categories?.map(category => ({
     ...category,
     score: calculateScore(
       category.refs,

--- a/packages/utils/src/lib/reports/generate-md-report-categoy-section.ts
+++ b/packages/utils/src/lib/reports/generate-md-report-categoy-section.ts
@@ -14,7 +14,7 @@ import {
 } from './utils';
 
 export function categoriesOverviewSection(
-  report: Pick<ScoredReport, 'categories' | 'plugins'>,
+  report: Required<Pick<ScoredReport, 'plugins' | 'categories'>>,
 ): MarkdownDocument {
   const { categories, plugins } = report;
   return new MarkdownDocument().table(
@@ -36,7 +36,7 @@ export function categoriesOverviewSection(
 }
 
 export function categoriesDetailsSection(
-  report: Pick<ScoredReport, 'categories' | 'plugins'>,
+  report: Required<Pick<ScoredReport, 'plugins' | 'categories'>>,
 ): MarkdownDocument {
   const { categories, plugins } = report;
 

--- a/packages/utils/src/lib/reports/generate-md-report.unit.test.ts
+++ b/packages/utils/src/lib/reports/generate-md-report.unit.test.ts
@@ -551,8 +551,8 @@ describe('generateMdReport', () => {
     expect(md).toMatch('Made with ❤ by [Code PushUp]');
   });
 
-  it('should skip categories section if empty', () => {
-    const md = generateMdReport({ ...baseScoredReport, categories: [] });
+  it('should skip categories section when categories are missing', () => {
+    const md = generateMdReport({ ...baseScoredReport, categories: undefined });
     expect(md).not.toMatch('## 🏷 Categories');
     expect(md).toMatch('# Code PushUp Report\n\n## 🛡️ Audits');
   });

--- a/packages/utils/src/lib/reports/log-stdout-summary.integration.test.ts
+++ b/packages/utils/src/lib/reports/log-stdout-summary.integration.test.ts
@@ -37,9 +37,9 @@ describe('logStdoutSummary', () => {
     );
   });
 
-  it('should not contain category section when categories are empty', async () => {
+  it('should not contain category section when categories are missing', async () => {
     logStdoutSummary(
-      sortReport(scoreReport({ ...reportMock(), categories: [] })),
+      sortReport(scoreReport({ ...reportMock(), categories: undefined })),
     );
     const output = logs.join('\n');
 

--- a/packages/utils/src/lib/reports/log-stdout-summary.ts
+++ b/packages/utils/src/lib/reports/log-stdout-summary.ts
@@ -16,20 +16,21 @@ function log(msg = ''): void {
 }
 
 export function logStdoutSummary(report: ScoredReport, verbose = false): void {
-  const printCategories = report.categories.length > 0;
-
-  log(reportToHeaderSection(report));
+  const { plugins, categories, packageName, version } = report;
+  log(reportToHeaderSection({ packageName, version }));
   log();
-  logPlugins(report.plugins, verbose);
-  if (printCategories) {
-    logCategories(report);
+  logPlugins(plugins, verbose);
+  if (categories && categories.length > 0) {
+    logCategories({ plugins, categories });
   }
   log(`${FOOTER_PREFIX} ${CODE_PUSHUP_DOMAIN}`);
   log();
 }
 
-function reportToHeaderSection(report: ScoredReport): string {
-  const { packageName, version } = report;
+function reportToHeaderSection({
+  packageName,
+  version,
+}: Pick<ScoredReport, 'packageName' | 'version'>): string {
   return `${bold(REPORT_HEADLINE_TEXT)} - ${packageName}@${version}`;
 }
 
@@ -92,7 +93,10 @@ function logRow(score: number, title: string, value?: string): void {
   ]);
 }
 
-export function logCategories({ categories, plugins }: ScoredReport): void {
+export function logCategories({
+  plugins,
+  categories,
+}: Required<Pick<ScoredReport, 'plugins' | 'categories'>>): void {
   const hAlign = (idx: number) => (idx === 0 ? 'left' : 'right');
 
   const rows = categories.map(({ title, score, refs, isBinary }) => [

--- a/packages/utils/src/lib/reports/log-stdout-summary.unit.test.ts
+++ b/packages/utils/src/lib/reports/log-stdout-summary.unit.test.ts
@@ -61,7 +61,7 @@ describe('logCategories', () => {
       },
     ] as ScoredReport['plugins'];
 
-    logCategories({ categories, plugins } as ScoredReport);
+    logCategories({ plugins, categories });
 
     const output = logs.join('\n');
 
@@ -105,7 +105,7 @@ describe('logCategories', () => {
       },
     ] as ScoredReport['plugins'];
 
-    logCategories({ categories, plugins } as ScoredReport);
+    logCategories({ plugins, categories });
 
     const output = logs.join('\n');
 
@@ -149,7 +149,7 @@ describe('logCategories', () => {
       },
     ] as ScoredReport['plugins'];
 
-    logCategories({ categories, plugins } as ScoredReport);
+    logCategories({ plugins, categories });
 
     const output = logs.join('\n');
 

--- a/packages/utils/src/lib/reports/scoring.ts
+++ b/packages/utils/src/lib/reports/scoring.ts
@@ -62,7 +62,7 @@ export function scoreReport(report: Report): ScoredReport {
     return item.score;
   }
 
-  const scoredCategories = report.categories.map(category => ({
+  const scoredCategories = report.categories?.map(category => ({
     ...category,
     score: calculateScore(category.refs, catScoreFn),
   }));

--- a/packages/utils/src/lib/reports/scoring.unit.test.ts
+++ b/packages/utils/src/lib/reports/scoring.unit.test.ts
@@ -130,9 +130,9 @@ describe('scoreReport', () => {
     );
   });
 
-  it('should accept a report with empty categories', () => {
-    expect(scoreReport({ ...REPORT_MOCK, categories: [] })).toEqual(
-      expect.objectContaining({ categories: [] }),
+  it('should accept a report with no categories', () => {
+    expect(scoreReport({ ...REPORT_MOCK, categories: undefined })).toEqual(
+      expect.objectContaining({ categories: undefined }),
     );
   });
 });

--- a/packages/utils/src/lib/reports/sorting.integration.test.ts
+++ b/packages/utils/src/lib/reports/sorting.integration.test.ts
@@ -57,8 +57,10 @@ describe('sortReport', () => {
 
   it('should sort a report with no categories', () => {
     const sortedReport = sortReport(
-      scoreReport({ ...REPORT_MOCK, categories: [] }),
+      scoreReport({ ...REPORT_MOCK, categories: undefined }),
     );
-    expect(sortedReport).toEqual(expect.objectContaining({ categories: [] }));
+    expect(sortedReport).toEqual(
+      expect.objectContaining({ categories: undefined }),
+    );
   });
 });

--- a/packages/utils/src/lib/reports/sorting.ts
+++ b/packages/utils/src/lib/reports/sorting.ts
@@ -91,7 +91,7 @@ export function getSortableGroupByRef(
 
 export function sortReport(report: ScoredReport): ScoredReport {
   const { categories, plugins } = report;
-  const sortedCategories = categories.map(category => {
+  const sortedCategories = categories?.map(category => {
     const { audits, groups } = category.refs.reduce(
       (
         acc: {

--- a/packages/utils/src/lib/reports/types.ts
+++ b/packages/utils/src/lib/reports/types.ts
@@ -17,7 +17,7 @@ export type ScoredReport = Omit<Report, 'plugins' | 'categories'> & {
   plugins: (Omit<PluginReport, 'groups'> & {
     groups?: ScoredGroup[];
   })[];
-  categories: ScoredCategoryConfig[];
+  categories?: ScoredCategoryConfig[];
 };
 
 export type SortableGroup = ScoredGroup & {

--- a/testing/test-utils/src/lib/utils/report.mock.ts
+++ b/testing/test-utils/src/lib/utils/report.mock.ts
@@ -11,7 +11,6 @@ export const MINIMAL_REPORT_MOCK: Report = {
   date: '2023-08-16T09:00:00.000Z',
   duration: 666,
   commit: COMMIT_MOCK,
-  categories: [],
   plugins: [
     {
       slug: 'eslint',


### PR DESCRIPTION
Closes #518 

This refactor standardizes the handling of categories as undefined throughout the CLI pipeline until conversion to the GQL report. Previously, an empty array was assigned by default in middlewares, leading to inconsistencies with `CoreConfig` where `categories` are optional.

By removing the default empty array, `categories` remain undefined unless explicitly provided. This update improves type consistency, ensuring that categories are only included in the final report if defined. When no categories are provided, the JSON report omits the categories field, and the Markdown report summary table indicates that there are 0 categories.