### PR TITLE
fix(ci): pass project name to downloadReportArtifact and ignore errors

### DIFF
--- a/packages/ci/README.md
+++ b/packages/ci/README.md
@@ -14,10 +14,10 @@
 
 This package exports **provider-agnostic core logic for running Code PushUp in CI pipelines**. It serves as the base for the following provider integrations:
 
-|                |                                                                                   |
-| :------------- | :-------------------------------------------------------------------------------- |
-| GitHub Actions | [`code-pushup/github-action`](https://github.com/marketplace/actions/code-pushup) |
-| GitLab CI/CD   | _coming soon_                                                                     |
+|                |                                                                                                     |
+| :------------- | :-------------------------------------------------------------------------------------------------- |
+| GitHub Actions | [`code-pushup/github-action`](https://github.com/marketplace/actions/code-pushup)                   |
+| GitLab CI/CD   | [`code-pushup/gitlab-pipelines-template`](https://gitlab.com/code-pushup/gitlab-pipelines-template) |
 
 ## Setup
 

--- a/packages/ci/README.md
+++ b/packages/ci/README.md
@@ -74,13 +74,13 @@ This will additionally compare reports from both source and target branches and 
 The PR flow requires interacting with the Git provider's API to post a comparison comment.
 Wrap these requests in functions and pass them in as an object which configures the provider.
 
-| Property                 | Required | Type                                             | Description                                                                                                              |
-| :----------------------- | :------: | :----------------------------------------------- | :----------------------------------------------------------------------------------------------------------------------- |
-| `createComment`          |   yes    | `(body: string) => Promise<Comment>`             | Posts a new comment to PR                                                                                                |
-| `updateComment`          |   yes    | `(id: number, body: string) => Promise<Comment>` | Updates existing PR comment                                                                                              |
-| `listComments`           |   yes    | `() => Promise<Comment[]>`                       | Fetches all comments from PR                                                                                             |
-| `maxCommentChars`        |   yes    | `number`                                         | Character limit for comment body                                                                                         |
-| `downloadReportArtifact` |    no    | `() => Promise<string \| null>`                  | Fetches previous report for base branch (returns path to downloaded `report.json`), used as cache to speed up comparison |
+| Property                 | Required | Type                                             | Description                                                                                                          |
+| :----------------------- | :------: | :----------------------------------------------- | :------------------------------------------------------------------------------------------------------------------- |
+| `createComment`          |   yes    | `(body: string) => Promise<Comment>`             | Posts a new comment to PR                                                                                            |
+| `updateComment`          |   yes    | `(id: number, body: string) => Promise<Comment>` | Updates existing PR comment                                                                                          |
+| `listComments`           |   yes    | `() => Promise<Comment[]>`                       | Fetches all comments from PR                                                                                         |
+| `maxCommentChars`        |   yes    | `number`                                         | Character limit for comment body                                                                                     |
+| `downloadReportArtifact` |    no    | `(project?: string) => Promise<string \| null>`  | Fetches previous (root/project) `report.json` for base branch and returns path, used as cache to speed up comparison |
 
 A `Comment` object has the following required properties:
 

--- a/packages/ci/src/lib/models.ts
+++ b/packages/ci/src/lib/models.ts
@@ -44,7 +44,7 @@ export type ProviderAPIClient = {
 };
 
 /**
- * PR comment from {@link ProviderAPIClient}
+ * PR/MR comment from {@link ProviderAPIClient}
  */
 export type Comment = {
   id: number;

--- a/packages/ci/src/lib/models.ts
+++ b/packages/ci/src/lib/models.ts
@@ -37,7 +37,7 @@ export type GitRefs = {
  */
 export type ProviderAPIClient = {
   maxCommentChars: number;
-  downloadReportArtifact?: () => Promise<string | null>;
+  downloadReportArtifact?: (project?: string) => Promise<string | null>;
   listComments: () => Promise<Comment[]>;
   updateComment: (id: number, body: string) => Promise<Comment>;
   createComment: (body: string) => Promise<Comment>;

--- a/packages/ci/src/lib/run.integration.test.ts
+++ b/packages/ci/src/lib/run.integration.test.ts
@@ -328,7 +328,7 @@ describe('runInCI', () => {
         expect.stringContaining(diffMdString),
       );
       expect(api.createComment).not.toHaveBeenCalled();
-      expect(api.downloadReportArtifact).toHaveBeenCalledWith();
+      expect(api.downloadReportArtifact).toHaveBeenCalledWith(undefined);
 
       expect(utils.executeProcess).toHaveBeenCalledTimes(2);
       expect(utils.executeProcess).toHaveBeenNthCalledWith(1, {

--- a/packages/ci/src/lib/run.ts
+++ b/packages/ci/src/lib/run.ts
@@ -189,16 +189,17 @@ async function runOnProject(args: {
 }
 
 async function collectPreviousReport(args: {
+  project: ProjectConfig | null;
   base: GitBranch;
   api: ProviderAPIClient;
   settings: Settings;
   ctx: CommandContext;
   git: SimpleGit;
 }): Promise<string | null> {
-  const { base, api, settings, ctx, git } = args;
+  const { project, base, api, settings, ctx, git } = args;
   const logger = settings.logger;
 
-  const cachedBaseReport = await api.downloadReportArtifact?.();
+  const cachedBaseReport = await api.downloadReportArtifact?.(project?.name);
   if (api.downloadReportArtifact != null) {
     logger.info(
       `Previous report artifact ${cachedBaseReport ? 'found' : 'not found'}`,

--- a/packages/ci/src/lib/run.ts
+++ b/packages/ci/src/lib/run.ts
@@ -140,7 +140,7 @@ async function runOnProject(args: {
   }
 
   logger.info(
-    `PR detected, preparing to compare base branch ${base.ref} to head ${head.ref}`,
+    `PR/MR detected, preparing to compare base branch ${base.ref} to head ${head.ref}`,
   );
 
   const prevReport = await collectPreviousReport({ ...args, base, ctx });
@@ -236,7 +236,7 @@ async function collectPreviousReport(args: {
     logger.debug(`Collected previous report at ${prevReportPath}`);
 
     await git.checkout(['-f', '-']);
-    logger.info('Switched back to PR branch');
+    logger.info('Switched back to PR/MR branch');
 
     return prevReport;
   }
@@ -267,7 +267,7 @@ async function findNewIssues(args: {
   logger.debug(
     `Found ${issues.length} relevant issues for ${
       Object.keys(changedFiles).length
-    } changed files and created GitHub annotations`,
+    } changed files`,
   );
 
   return issues;


### PR DESCRIPTION
Artifact cache wasn't working correctly in monorepo mode. This change will allow provider integrations to download the correct report based on the project name. Also improved error handling and docs.