### PR TITLE
fix(plugin-js-packages): add ignoreExitCode option for yarn v2 package manager

### DIFF
--- a/packages/plugin-js-packages/src/lib/package-managers/yarn-modern/yarn-modern.ts
+++ b/packages/plugin-js-packages/src/lib/package-managers/yarn-modern/yarn-modern.ts
@@ -31,6 +31,7 @@ export const yarnv2PackageManager: PackageManager = {
     ],
     supportedDepGroups: ['prod', 'dev'], // Yarn v2 does not support audit for optional dependencies
     unifyResult: yarnv2ToAuditResult,
+    ignoreExitCode: true,
   },
   outdated: {
     commandArgs: COMMON_OUTDATED_ARGS,


### PR DESCRIPTION
Fix #877 