### PR TITLE
docs: update plugin-js-packages example

### DIFF
--- a/packages/plugin-js-packages/README.md
+++ b/packages/plugin-js-packages/README.md
@@ -78,8 +78,8 @@ It supports the following package managers:
          refs: [
            {
              type: 'group',
-             plugin: 'npm-audit', // replace prefix with your package manager
-             slug: 'js-packages',
+             slug: 'npm-audit', // replace prefix with your package manager
+             plugin: 'js-packages',
              weight: 1,
            },
          ],
@@ -90,8 +90,8 @@ It supports the following package managers:
          refs: [
            {
              type: 'group',
-             plugin: 'npm-outdated', // replace prefix with your package manager
-             slug: 'js-packages',
+             slug: 'npm-outdated', // replace prefix with your package manager
+             plugin: 'js-packages',
              weight: 1,
            },
            // ...


### PR DESCRIPTION
`plugin` and `slug` were inverted.

Check this [poetic discussion](https://push-based.slack.com/archives/C06JCR9L1FE/p1732813464191089?thread_ts=1732809995.748769&cid=C06JCR9L1FE) for a reference.