### PR TITLE
feat(core): enhance config validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,8 @@
         "vscode-material-icons": "^0.1.1",
         "yaml": "^2.5.1",
         "yargs": "^17.7.2",
-        "zod": "^3.23.8"
+        "zod": "^3.23.8",
+        "zod-validation-error": "^3.4.0"
       },
       "devDependencies": {
         "@beaussan/nx-knip": "^0.0.5-15",
@@ -27746,10 +27747,10 @@
       }
     },
     "node_modules/zod-validation-error": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-3.3.1.tgz",
-      "integrity": "sha512-uFzCZz7FQis256dqw4AhPQgD6f3pzNca/Zh62RNELavlumQB3nDIUFbF5JQfFLcMbO1s02Q7Xg/gpcOBlEnYZA==",
-      "dev": true,
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-3.4.0.tgz",
+      "integrity": "sha512-ZOPR9SVY6Pb2qqO5XHt+MkkTRxGXb4EVtnjc9JpXUOtUB1T9Ru7mZOT361AN3MsetVe7R0a1KZshJDZdgp9miQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "vscode-material-icons": "^0.1.1",
     "yaml": "^2.5.1",
     "yargs": "^17.7.2",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "zod-validation-error": "^3.4.0"
   },
   "devDependencies": {
     "@beaussan/nx-knip": "^0.0.5-15",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -41,7 +41,8 @@
   "dependencies": {
     "@code-pushup/models": "0.56.0",
     "@code-pushup/utils": "0.56.0",
-    "ansis": "^3.3.0"
+    "ansis": "^3.3.0",
+    "zod-validation-error": "^3.4.0"
   },
   "peerDependencies": {
     "@code-pushup/portal-client": "^0.9.0"

--- a/packages/core/src/lib/implementation/read-rc-file.integration.test.ts
+++ b/packages/core/src/lib/implementation/read-rc-file.integration.test.ts
@@ -1,7 +1,7 @@
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect } from 'vitest';
-import { readRcByPath } from './read-rc-file.js';
+import { ConfigValidationError, readRcByPath } from './read-rc-file.js';
 
 describe('readRcByPath', () => {
   const configDirPath = join(
@@ -69,7 +69,7 @@ describe('readRcByPath', () => {
   it('should throw if the configuration is empty', async () => {
     await expect(
       readRcByPath(join(configDirPath, 'code-pushup.empty.config.js')),
-    ).rejects.toThrow(`"code": "invalid_type",`);
+    ).rejects.toThrow(expect.any(ConfigValidationError));
   });
 
   it('should throw if the configuration is invalid', async () => {

--- a/packages/core/src/lib/implementation/read-rc-file.ts
+++ b/packages/core/src/lib/implementation/read-rc-file.ts
@@ -8,9 +8,9 @@ import {
   coreConfigSchema,
 } from '@code-pushup/models';
 import {
-  coreConfigMessageBuilder,
   fileExists,
   importModule,
+  zodErrorMessageBuilder,
 } from '@code-pushup/utils';
 
 export class ConfigPathError extends Error {
@@ -44,7 +44,7 @@ export async function readRcByPath(
     return coreConfigSchema.parse(cfg);
   } catch (error) {
     const validationError = fromError(error, {
-      messageBuilder: coreConfigMessageBuilder,
+      messageBuilder: zodErrorMessageBuilder,
     });
     throw isZodErrorLike(error)
       ? new ConfigValidationError(filepath, validationError.message)

--- a/packages/core/src/lib/implementation/read-rc-file.ts
+++ b/packages/core/src/lib/implementation/read-rc-file.ts
@@ -80,8 +80,8 @@ export async function autoloadRc(tsconfig?: string): Promise<CoreConfig> {
   let ext = '';
   // eslint-disable-next-line functional/no-loop-statements
   for (const extension of SUPPORTED_CONFIG_FILE_FORMATS) {
-    const path = `${CONFIG_FILE_NAME}.${extension}`;
-    const exists = await fileExists(path);
+    const filePath = `${CONFIG_FILE_NAME}.${extension}`;
+    const exists = await fileExists(filePath);
 
     if (exists) {
       ext = extension;

--- a/packages/core/src/lib/implementation/read-rc-file.ts
+++ b/packages/core/src/lib/implementation/read-rc-file.ts
@@ -1,40 +1,17 @@
-import { bold, red } from 'ansis';
+import { bold } from 'ansis';
 import path, { join } from 'node:path';
-import {
-  type MessageBuilder,
-  fromError,
-  isZodErrorLike,
-} from 'zod-validation-error';
+import { fromError, isZodErrorLike } from 'zod-validation-error';
 import {
   CONFIG_FILE_NAME,
   type CoreConfig,
   SUPPORTED_CONFIG_FILE_FORMATS,
   coreConfigSchema,
 } from '@code-pushup/models';
-import { fileExists, importModule } from '@code-pushup/utils';
-
-function formatErrorPath(errorPath: (string | number)[]): string {
-  return errorPath
-    .map((key, index) => {
-      if (typeof key === 'number') {
-        return `[${key}]`;
-      }
-      return index > 0 ? `.${key}` : key;
-    })
-    .join('');
-}
-
-const coreConfigMessageBuilder: MessageBuilder = issues =>
-  issues
-    .map(issue => {
-      const formattedMessage = red(`${bold(issue.code)}: ${issue.message}`);
-      const formattedPath = formatErrorPath(issue.path);
-      if (formattedPath) {
-        return `Validation error at ${bold(formattedPath)}\n${formattedMessage}\n`;
-      }
-      return `${formattedMessage}\n`;
-    })
-    .join('\n');
+import {
+  coreConfigMessageBuilder,
+  fileExists,
+  importModule,
+} from '@code-pushup/utils';
 
 export class ConfigPathError extends Error {
   constructor(configPath: string) {

--- a/packages/models/src/lib/category-config.ts
+++ b/packages/models/src/lib/category-config.ts
@@ -23,13 +23,14 @@ export const categoryRefSchema = weightedRefSchema(
 );
 export type CategoryRef = z.infer<typeof categoryRefSchema>;
 
-export const categoryConfigSchema = scorableSchema(
-  'Category with a score calculated from audits and groups from various plugins',
-  categoryRefSchema,
-  getDuplicateRefsInCategoryMetrics,
-  duplicateRefsInCategoryMetricsErrorMsg,
-)
-  .merge(
+export const categoryConfigSchema = z
+  .intersection(
+    scorableSchema(
+      'Category with a score calculated from audits and groups from various plugins',
+      categoryRefSchema,
+      getDuplicateRefsInCategoryMetrics,
+      duplicateRefsInCategoryMetricsErrorMsg,
+    ),
     metaSchema({
       titleDescription: 'Category Title',
       docsUrlDescription: 'Category docs URL',
@@ -37,7 +38,7 @@ export const categoryConfigSchema = scorableSchema(
       description: 'Meta info for category',
     }),
   )
-  .merge(
+  .and(
     z.object({
       isBinary: z
         .boolean({

--- a/packages/models/src/lib/category-config.ts
+++ b/packages/models/src/lib/category-config.ts
@@ -23,14 +23,13 @@ export const categoryRefSchema = weightedRefSchema(
 );
 export type CategoryRef = z.infer<typeof categoryRefSchema>;
 
-export const categoryConfigSchema = z
-  .intersection(
-    scorableSchema(
-      'Category with a score calculated from audits and groups from various plugins',
-      categoryRefSchema,
-      getDuplicateRefsInCategoryMetrics,
-      duplicateRefsInCategoryMetricsErrorMsg,
-    ),
+export const categoryConfigSchema = scorableSchema(
+  'Category with a score calculated from audits and groups from various plugins',
+  categoryRefSchema,
+  getDuplicateRefsInCategoryMetrics,
+  duplicateRefsInCategoryMetricsErrorMsg,
+)
+  .merge(
     metaSchema({
       titleDescription: 'Category Title',
       docsUrlDescription: 'Category docs URL',
@@ -38,7 +37,7 @@ export const categoryConfigSchema = z
       description: 'Meta info for category',
     }),
   )
-  .and(
+  .merge(
     z.object({
       isBinary: z
         .boolean({

--- a/packages/models/src/lib/category-config.unit.test.ts
+++ b/packages/models/src/lib/category-config.unit.test.ts
@@ -129,7 +129,7 @@ describe('categoryConfigSchema', () => {
         title: 'This category is empty for now',
         refs: [],
       } satisfies CategoryConfig),
-    ).toThrow('In category in-progress, there has to be at least one ref');
+    ).toThrow('In a category, there has to be at least one ref');
   });
 
   it('should throw for duplicate category references', () => {
@@ -176,7 +176,7 @@ describe('categoryConfigSchema', () => {
         ],
       } satisfies CategoryConfig),
     ).toThrow(
-      'In category informational, there has to be at least one ref with weight > 0. Affected refs: functional/immutable-data, lighthouse-experimental',
+      /In a category, there has to be at least one ref with weight > 0. Affected refs: \\"functional\/immutable-data\\", \\"lighthouse-experimental\\"/,
     );
   });
 });

--- a/packages/models/src/lib/category-config.unit.test.ts
+++ b/packages/models/src/lib/category-config.unit.test.ts
@@ -176,7 +176,7 @@ describe('categoryConfigSchema', () => {
         ],
       } satisfies CategoryConfig),
     ).toThrow(
-      /In a category, there has to be at least one ref with weight > 0. Affected refs: \\"functional\/immutable-data\\", \\"lighthouse-experimental\\"/,
+      'In a category, there has to be at least one ref with weight > 0. Affected refs: functional/immutable-data, lighthouse-experimental',
     );
   });
 });

--- a/packages/models/src/lib/category-config.unit.test.ts
+++ b/packages/models/src/lib/category-config.unit.test.ts
@@ -129,7 +129,7 @@ describe('categoryConfigSchema', () => {
         title: 'This category is empty for now',
         refs: [],
       } satisfies CategoryConfig),
-    ).toThrow('In a category there has to be at least one ref');
+    ).toThrow('In category in-progress, there has to be at least one ref');
   });
 
   it('should throw for duplicate category references', () => {
@@ -175,7 +175,9 @@ describe('categoryConfigSchema', () => {
           },
         ],
       } satisfies CategoryConfig),
-    ).toThrow('In a category there has to be at least one ref with weight > 0');
+    ).toThrow(
+      'In category informational, there has to be at least one ref with weight > 0. Affected refs: functional/immutable-data, lighthouse-experimental',
+    );
   });
 });
 

--- a/packages/models/src/lib/group.ts
+++ b/packages/models/src/lib/group.ts
@@ -25,16 +25,14 @@ export const groupMetaSchema = metaSchema({
 });
 export type GroupMeta = z.infer<typeof groupMetaSchema>;
 
-export const groupSchema = z.intersection(
-  scorableSchema(
-    'A group aggregates a set of audits into a single score which can be referenced from a category. ' +
-      'E.g. the group slug "performance" groups audits and can be referenced in a category',
-    groupRefSchema,
-    getDuplicateRefsInGroups,
-    duplicateRefsInGroupsErrorMsg,
-  ),
-  groupMetaSchema,
-);
+export const groupSchema = scorableSchema(
+  'A group aggregates a set of audits into a single score which can be referenced from a category. ' +
+    'E.g. the group slug "performance" groups audits and can be referenced in a category',
+  groupRefSchema,
+  getDuplicateRefsInGroups,
+  duplicateRefsInGroupsErrorMsg,
+).merge(groupMetaSchema);
+
 export type Group = z.infer<typeof groupSchema>;
 
 export const groupsSchema = z

--- a/packages/models/src/lib/group.ts
+++ b/packages/models/src/lib/group.ts
@@ -25,13 +25,16 @@ export const groupMetaSchema = metaSchema({
 });
 export type GroupMeta = z.infer<typeof groupMetaSchema>;
 
-export const groupSchema = scorableSchema(
-  'A group aggregates a set of audits into a single score which can be referenced from a category. ' +
-    'E.g. the group slug "performance" groups audits and can be referenced in a category',
-  groupRefSchema,
-  getDuplicateRefsInGroups,
-  duplicateRefsInGroupsErrorMsg,
-).merge(groupMetaSchema);
+export const groupSchema = z.intersection(
+  scorableSchema(
+    'A group aggregates a set of audits into a single score which can be referenced from a category. ' +
+      'E.g. the group slug "performance" groups audits and can be referenced in a category',
+    groupRefSchema,
+    getDuplicateRefsInGroups,
+    duplicateRefsInGroupsErrorMsg,
+  ),
+  groupMetaSchema,
+);
 export type Group = z.infer<typeof groupSchema>;
 
 export const groupsSchema = z

--- a/packages/models/src/lib/group.unit.test.ts
+++ b/packages/models/src/lib/group.unit.test.ts
@@ -69,7 +69,7 @@ describe('groupSchema', () => {
         title: 'Empty group',
         refs: [],
       } satisfies Group),
-    ).toThrow('In a category there has to be at least one ref');
+    ).toThrow('In category empty-group, there has to be at least one ref');
   });
 
   it('should throw for duplicate group references', () => {

--- a/packages/models/src/lib/group.unit.test.ts
+++ b/packages/models/src/lib/group.unit.test.ts
@@ -69,7 +69,7 @@ describe('groupSchema', () => {
         title: 'Empty group',
         refs: [],
       } satisfies Group),
-    ).toThrow('In category empty-group, there has to be at least one ref');
+    ).toThrow('In a category, there has to be at least one ref');
   });
 
   it('should throw for duplicate group references', () => {

--- a/packages/models/src/lib/implementation/schemas.ts
+++ b/packages/models/src/lib/implementation/schemas.ts
@@ -182,7 +182,7 @@ export function scorableSchema<T extends ReturnType<typeof weightedRefSchema>>(
         )
         // category weights are correct
         .refine(hasNonZeroWeightedRef, refs => {
-          const affectedRefs = refs.map(ref => `"${ref.slug}"`).join(', ');
+          const affectedRefs = refs.map(ref => ref.slug).join(', ');
           return {
             message: `In a category, there has to be at least one ref with weight > 0. Affected refs: ${affectedRefs}`,
           };

--- a/packages/plugin-lighthouse/src/lib/lighthouse-plugin.unit.test.ts
+++ b/packages/plugin-lighthouse/src/lib/lighthouse-plugin.unit.test.ts
@@ -57,7 +57,7 @@ describe('lighthousePlugin-config-object', () => {
     });
 
     expect(() => pluginConfigSchema.parse(pluginConfig)).toThrow(
-      /In a category, there has to be at least one ref with weight > 0. Affected refs: \\"csp-xss\\"/,
+      'In a category, there has to be at least one ref with weight > 0. Affected refs: csp-xss',
     );
   });
 });

--- a/packages/plugin-lighthouse/src/lib/lighthouse-plugin.unit.test.ts
+++ b/packages/plugin-lighthouse/src/lib/lighthouse-plugin.unit.test.ts
@@ -57,7 +57,7 @@ describe('lighthousePlugin-config-object', () => {
     });
 
     expect(() => pluginConfigSchema.parse(pluginConfig)).toThrow(
-      'In category best-practices, there has to be at least one ref with weight > 0. Affected refs: csp-xss',
+      /In a category, there has to be at least one ref with weight > 0. Affected refs: \\"csp-xss\\"/,
     );
   });
 });

--- a/packages/plugin-lighthouse/src/lib/lighthouse-plugin.unit.test.ts
+++ b/packages/plugin-lighthouse/src/lib/lighthouse-plugin.unit.test.ts
@@ -50,4 +50,14 @@ describe('lighthousePlugin-config-object', () => {
       ]),
     );
   });
+
+  it('should throw when filtering groups by zero-weight onlyAudits', () => {
+    const pluginConfig = lighthousePlugin('https://code-pushup-portal.com', {
+      onlyAudits: ['csp-xss'],
+    });
+
+    expect(() => pluginConfigSchema.parse(pluginConfig)).toThrow(
+      'In category best-practices, there has to be at least one ref with weight > 0. Affected refs: csp-xss',
+    );
+  });
 });

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -33,6 +33,7 @@
     "esbuild": "^0.19.2",
     "multi-progress-bars": "^5.0.3",
     "semver": "^7.6.0",
-    "simple-git": "^3.20.0"
+    "simple-git": "^3.20.0",
+    "zod-validation-error": "^3.4.0"
   }
 }

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -122,4 +122,4 @@ export type {
   WithRequired,
 } from './lib/types.js';
 export { verboseUtils } from './lib/verbose-utils.js';
-export { coreConfigMessageBuilder } from './lib/zod-validation.js';
+export { zodErrorMessageBuilder } from './lib/zod-validation.js';

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -122,3 +122,4 @@ export type {
   WithRequired,
 } from './lib/types.js';
 export { verboseUtils } from './lib/verbose-utils.js';
+export { coreConfigMessageBuilder } from './lib/zod-validation.js';

--- a/packages/utils/src/lib/zod-validation.ts
+++ b/packages/utils/src/lib/zod-validation.ts
@@ -12,7 +12,7 @@ export function formatErrorPath(errorPath: (string | number)[]): string {
     .join('');
 }
 
-export const coreConfigMessageBuilder: MessageBuilder = issues =>
+export const zodErrorMessageBuilder: MessageBuilder = issues =>
   issues
     .map(issue => {
       const formattedMessage = red(`${bold(issue.code)}: ${issue.message}`);

--- a/packages/utils/src/lib/zod-validation.ts
+++ b/packages/utils/src/lib/zod-validation.ts
@@ -1,0 +1,25 @@
+import { bold, red } from 'ansis';
+import type { MessageBuilder } from 'zod-validation-error';
+
+export function formatErrorPath(errorPath: (string | number)[]): string {
+  return errorPath
+    .map((key, index) => {
+      if (typeof key === 'number') {
+        return `[${key}]`;
+      }
+      return index > 0 ? `.${key}` : key;
+    })
+    .join('');
+}
+
+export const coreConfigMessageBuilder: MessageBuilder = issues =>
+  issues
+    .map(issue => {
+      const formattedMessage = red(`${bold(issue.code)}: ${issue.message}`);
+      const formattedPath = formatErrorPath(issue.path);
+      if (formattedPath) {
+        return `Validation error at ${bold(formattedPath)}\n${formattedMessage}\n`;
+      }
+      return `${formattedMessage}\n`;
+    })
+    .join('\n');

--- a/packages/utils/src/lib/zod-validation.unit.test.ts
+++ b/packages/utils/src/lib/zod-validation.unit.test.ts
@@ -1,0 +1,14 @@
+import { formatErrorPath } from './zod-validation';
+
+describe('formatErrorPath', () => {
+  it.each([
+    [['categories', 1, 'slug'], 'categories[1].slug'],
+    [['plugins', 2, 'groups', 0, 'refs'], 'plugins[2].groups[0].refs'],
+    [['refs', 0, 'slug'], 'refs[0].slug'],
+    [['categories'], 'categories'],
+    [[], ''],
+    [['path', 5], 'path[5]'],
+  ])('formats error path correctly for $input', (input, expected) => {
+    expect(formatErrorPath(input)).toBe(expected);
+  });
+});

--- a/packages/utils/src/lib/zod-validation.unit.test.ts
+++ b/packages/utils/src/lib/zod-validation.unit.test.ts
@@ -8,7 +8,7 @@ describe('formatErrorPath', () => {
     [['categories'], 'categories'],
     [[], ''],
     [['path', 5], 'path[5]'],
-  ])('formats error path correctly for $input', (input, expected) => {
+  ])('should format error path %j as %j', (input, expected) => {
     expect(formatErrorPath(input)).toBe(expected);
   });
 });


### PR DESCRIPTION
Fixes #704 

This PR introduces `zod-validation-error` as a new project dependency to make `Zod` validation errors more compact and readable. Due to the limited scope of the issue being resolved, `zod-validation-error` is currently used only to validate `coreConfigSchema`.

<details>
  <summary>Formatted config validation errors</summary>
<img width="923" alt="ConfigValidationErrors" src="https://github.com/user-attachments/assets/1452cc3b-2f42-4ba2-8691-d21196311a5a" />
</details>