### PR TITLE
fix: lint import extensions and fix missing .js extensions

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -96,6 +96,12 @@ export default tseslint.config(
     languageOptions: { parser: jsoncParser },
   },
   {
+    files: ['**/*.ts', '**/*.js'],
+    rules: {
+      'n/file-extension-in-import': ['error', 'always'],
+    },
+  },
+  {
     files: ['**/perf/**/*.ts'],
     rules: {
       '@typescript-eslint/no-magic-numbers': 'off',

--- a/packages/plugin-coverage/src/lib/runner/runner.integration.test.ts
+++ b/packages/plugin-coverage/src/lib/runner/runner.integration.test.ts
@@ -8,13 +8,13 @@ import type {
   RunnerConfig,
 } from '@code-pushup/models';
 import { readJsonFile, removeDirectoryIfExists } from '@code-pushup/utils';
-import { createRunnerConfig, executeRunner } from '.';
 import type { FinalCoveragePluginConfig } from '../config.js';
 import {
   PLUGIN_CONFIG_PATH,
   RUNNER_OUTPUT_PATH,
   WORKDIR,
 } from './constants.js';
+import { createRunnerConfig, executeRunner } from './index.js';
 
 describe('createRunnerConfig', () => {
   it('should create a valid runner config', async () => {

--- a/packages/plugin-js-packages/src/lib/js-packages-plugin.ts
+++ b/packages/plugin-js-packages/src/lib/js-packages-plugin.ts
@@ -10,7 +10,7 @@ import {
   dependencyGroups,
 } from './config.js';
 import { dependencyDocs, dependencyGroupWeights } from './constants.js';
-import { packageManagers } from './package-managers/package-managers';
+import { packageManagers } from './package-managers/package-managers.js';
 import { createRunnerConfig } from './runner/index.js';
 import { normalizeConfig } from './utils.js';
 

--- a/packages/plugin-js-packages/src/lib/runner/runner.integration.test.ts
+++ b/packages/plugin-js-packages/src/lib/runner/runner.integration.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import type { RunnerConfig } from '@code-pushup/models';
 import { readJsonFile, removeDirectoryIfExists } from '@code-pushup/utils';
-import { createRunnerConfig } from '.';
 import type { FinalJSPackagesPluginConfig } from '../config.js';
 import { defaultAuditLevelMapping } from '../constants.js';
 import { PLUGIN_CONFIG_PATH, WORKDIR } from './constants.js';
+import { createRunnerConfig } from './index.js';
 
 describe('createRunnerConfig', () => {
   it('should create a valid runner config', async () => {

--- a/packages/plugin-lighthouse/src/lib/normalize-flags.ts
+++ b/packages/plugin-lighthouse/src/lib/normalize-flags.ts
@@ -2,7 +2,7 @@ import { bold, yellow } from 'ansis';
 import { ui } from '@code-pushup/utils';
 import { LIGHTHOUSE_PLUGIN_SLUG } from './constants.js';
 import { DEFAULT_CLI_FLAGS } from './runner/constants.js';
-import type { LighthouseCliFlags } from './runner/types';
+import type { LighthouseCliFlags } from './runner/types.js';
 import type { LighthouseOptions } from './types.js';
 
 const { onlyCategories, ...originalDefaultCliFlags } = DEFAULT_CLI_FLAGS;

--- a/packages/plugin-lighthouse/src/lib/utils.ts
+++ b/packages/plugin-lighthouse/src/lib/utils.ts
@@ -1,7 +1,7 @@
 import type { Audit, CategoryRef, Group } from '@code-pushup/models';
 import { filterItemRefsBy, toArray } from '@code-pushup/utils';
 import { LIGHTHOUSE_PLUGIN_SLUG } from './constants.js';
-import type { LighthouseCliFlags } from './runner/types';
+import type { LighthouseCliFlags } from './runner/types.js';
 
 export type LighthouseGroupSlugs =
   | 'performance'

--- a/packages/utils/src/lib/zod-validation.unit.test.ts
+++ b/packages/utils/src/lib/zod-validation.unit.test.ts
@@ -1,4 +1,4 @@
-import { formatErrorPath } from './zod-validation';
+import { formatErrorPath } from './zod-validation.js';
 
 describe('formatErrorPath', () => {
   it.each([


### PR DESCRIPTION
Now that we build using `tsc` for ESM runtime, imports without `.js` extensions have to be linted to prevent runtime errors.