### PR TITLE
fix(plugin-eslint): parse rule names containing slashes correctly

### DIFF
--- a/packages/plugin-eslint/src/lib/meta/parse.ts
+++ b/packages/plugin-eslint/src/lib/meta/parse.ts
@@ -8,7 +8,9 @@ export type RuleData = {
 };
 
 export function parseRuleId(ruleId: string): { plugin?: string; name: string } {
-  const i = ruleId.lastIndexOf('/');
+  const i = ruleId.startsWith('@')
+    ? ruleId.lastIndexOf('/')
+    : ruleId.indexOf('/');
   if (i === -1) {
     return { name: ruleId };
   }

--- a/packages/plugin-eslint/src/lib/meta/parse.unit.test.ts
+++ b/packages/plugin-eslint/src/lib/meta/parse.unit.test.ts
@@ -32,6 +32,11 @@ describe('parseRuleId', () => {
       plugin: '@angular-eslint/template',
       name: 'no-negated-async',
     },
+    {
+      ruleId: 'n/prefer-promises/fs',
+      plugin: 'n',
+      name: 'prefer-promises/fs',
+    },
   ])('$ruleId => name: $name, plugin: $plugin', ({ ruleId, name, plugin }) => {
     expect(parseRuleId(ruleId)).toEqual({ name, plugin });
   });


### PR DESCRIPTION
Some rules from `eslint-plugin-n` weren't being discovered correctly, was being [logged as warning](https://github.com/code-pushup/cli/actions/runs/12370364730/job/34524165627#step:5:25):

![image](https://github.com/user-attachments/assets/1a92ebc0-0b57-4619-b715-8cb8bea3aab3)

This is because for rule IDs like `n/prefer-promises/fs` the parser incorrectly identified which part was the plugin name.

Now that the parsing was adjusted, the [warnings are gone](https://github.com/code-pushup/cli/actions/runs/12372744687/job/34531635769?pr=895#step:5:25).