### PR TITLE
test(test-utils): disable GPG sign for commit/tag utility

### DIFF
--- a/testing/test-utils/src/lib/utils/git.ts
+++ b/testing/test-utils/src/lib/utils/git.ts
@@ -21,6 +21,8 @@ export async function initGitRepo(
   await git.init();
   await git.addConfig('user.name', name);
   await git.addConfig('user.email', email);
+  await git.addConfig('commit.gpgSign', 'false');
+  await git.addConfig('tag.gpgSign', 'false');
   await git.branch(['-M', 'main']);
   return git;
 }


### PR DESCRIPTION
I've recently added a GPG signature to my commits and that broke running the integration tests locally for me 😅 this is fixing it