### PR TITLE
fix: handle skipped audits and groups

### DIFF
--- a/packages/cli/src/lib/implementation/filter.middleware.unit.test.ts
+++ b/packages/cli/src/lib/implementation/filter.middleware.unit.test.ts
@@ -1,6 +1,10 @@
 import type { CategoryConfig, PluginConfig } from '@code-pushup/models';
 import { ui } from '@code-pushup/utils';
-import { filterMiddleware } from './filter.middleware.js';
+import {
+  filterMiddleware,
+  filterSkippedCategories,
+  processPlugins,
+} from './filter.middleware.js';
 import { OptionValidationError } from './validate-filter-options.utils.js';
 
 vi.mock('@code-pushup/core', async () => {
@@ -34,8 +38,8 @@ describe('filterMiddleware', () => {
       {
         slug: 'c1',
         refs: [
-          { plugin: 'p1', slug: 'a1-p1' },
-          { plugin: 'p2', slug: 'a1-p2' },
+          { type: 'audit', plugin: 'p1', slug: 'a1-p1' },
+          { type: 'audit', plugin: 'p2', slug: 'a1-p2' },
         ],
       },
     ] as CategoryConfig[];
@@ -58,8 +62,8 @@ describe('filterMiddleware', () => {
       {
         slug: 'c1',
         refs: [
-          { plugin: 'p1', slug: 'a1-p1' },
-          { plugin: 'p2', slug: 'a1-p2' },
+          { type: 'audit', plugin: 'p1', slug: 'a1-p1' },
+          { type: 'audit', plugin: 'p2', slug: 'a1-p2' },
         ],
       },
     ] as CategoryConfig[];
@@ -87,104 +91,116 @@ describe('filterMiddleware', () => {
     (option, expected) => {
       const { plugins } = filterMiddleware({
         ...option,
-        plugins: [{ slug: 'p1' }, { slug: 'p2' }] as PluginConfig[],
+        plugins: [
+          {
+            slug: 'p1',
+            groups: [{ slug: 'g1-p1', refs: [{ slug: 'a1-p1', weight: 1 }] }],
+            audits: [{ slug: 'a1-p1' }],
+          },
+          {
+            slug: 'p2',
+            groups: [{ slug: 'g1-p2', refs: [{ slug: 'a1-p2', weight: 1 }] }],
+            audits: [{ slug: 'a1-p2' }],
+          },
+        ] as PluginConfig[],
       });
       expect(plugins).toStrictEqual([expect.objectContaining(expected)]);
     },
   );
 
   it.each([
-    [
-      { onlyPlugins: ['p1'] },
-      [{ slug: 'p1' }],
-      [{ slug: 'c1', refs: [{ plugin: 'p1', slug: 'a1-p1' }] }],
-    ],
-    [
-      { skipPlugins: ['p1'], onlyPlugins: ['p3'] },
-      [{ slug: 'p3' }],
-      [{ slug: 'c2', refs: [{ plugin: 'p3', slug: 'a1-p3' }] }],
-    ],
-    [
-      { skipPlugins: ['p1'] },
-      [{ slug: 'p2' }, { slug: 'p3' }],
-      [
-        { slug: 'c1', refs: [{ plugin: 'p2', slug: 'a1-p2' }] },
-        { slug: 'c2', refs: [{ plugin: 'p3', slug: 'a1-p3' }] },
-      ],
-    ],
+    [{ onlyPlugins: ['p1'] }, ['p1'], ['c1']],
+    [{ skipPlugins: ['p1'], onlyPlugins: ['p3'] }, ['p3'], ['c2']],
+    [{ skipPlugins: ['p1'] }, ['p2', 'p3'], ['c1', 'c2']],
   ])(
     'should filter plugins and categories with plugin filter option %o',
     (option, expectedPlugins, expectedCategories) => {
       const { plugins, categories } = filterMiddleware({
         ...option,
         plugins: [
-          { slug: 'p1' },
-          { slug: 'p2' },
-          { slug: 'p3' },
+          {
+            slug: 'p1',
+            audits: [{ slug: 'a1-p1' }],
+            groups: [{ slug: 'g1-p1', refs: [{ slug: 'a1-p1', weight: 1 }] }],
+          },
+          {
+            slug: 'p2',
+            audits: [{ slug: 'a1-p2' }],
+            groups: [{ slug: 'g1-p2', refs: [{ slug: 'a1-p2', weight: 1 }] }],
+          },
+          {
+            slug: 'p3',
+            audits: [{ slug: 'a1-p3' }],
+            groups: [{ slug: 'g1-p3', refs: [{ slug: 'a1-p3', weight: 1 }] }],
+          },
         ] as PluginConfig[],
         categories: [
           {
             slug: 'c1',
             refs: [
-              { plugin: 'p1', slug: 'a1-p1' },
-              { plugin: 'p2', slug: 'a1-p2' },
+              { type: 'group', plugin: 'p1', slug: 'g1-p1', weight: 1 },
+              { type: 'group', plugin: 'p2', slug: 'g1-p2', weight: 1 },
             ],
           },
-          { slug: 'c2', refs: [{ plugin: 'p3', slug: 'a1-p3' }] },
+          {
+            slug: 'c2',
+            refs: [{ type: 'group', plugin: 'p3', slug: 'g1-p3', weight: 1 }],
+          },
         ] as CategoryConfig[],
       });
-      expect(plugins).toStrictEqual(expectedPlugins);
-      expect(categories).toStrictEqual(expectedCategories);
+      const pluginSlugs = plugins.map(({ slug }) => slug);
+      const categorySlugs = categories.map(({ slug }) => slug);
+
+      expect(pluginSlugs).toStrictEqual(expectedPlugins);
+      expect(categorySlugs).toStrictEqual(expectedCategories);
     },
   );
 
   it.each([
-    [
-      { skipCategories: ['c1'] },
-      [{ slug: 'p3' }],
-      [{ slug: 'c2', refs: [{ plugin: 'p3', slug: 'a1-p3' }] }],
-    ],
-    [
-      { skipCategories: ['c1'], onlyCategories: ['c2'] },
-      [{ slug: 'p3' }],
-      [{ slug: 'c2', refs: [{ plugin: 'p3', slug: 'a1-p3' }] }],
-    ],
-    [
-      { onlyCategories: ['c1'] },
-      [{ slug: 'p1' }, { slug: 'p2' }],
-      [
-        {
-          slug: 'c1',
-          refs: [
-            { plugin: 'p1', slug: 'a1-p1' },
-            { plugin: 'p2', slug: 'a1-p2' },
-          ],
-        },
-      ],
-    ],
+    [{ skipCategories: ['c1'] }, ['p3'], ['c2']],
+    [{ skipCategories: ['c1'], onlyCategories: ['c2'] }, ['p3'], ['c2']],
+    [{ onlyCategories: ['c1'] }, ['p1', 'p2'], ['c1']],
   ])(
     'should filter plugins and categories with category filter option %o',
     (option, expectedPlugins, expectedCategories) => {
       const { plugins, categories } = filterMiddleware({
         ...option,
         plugins: [
-          { slug: 'p1' },
-          { slug: 'p2' },
-          { slug: 'p3' },
+          {
+            slug: 'p1',
+            audits: [{ slug: 'a1-p1' }],
+            groups: [{ slug: 'g1-p1', refs: [{ slug: 'a1-p1', weight: 1 }] }],
+          },
+          {
+            slug: 'p2',
+            audits: [{ slug: 'a1-p2' }],
+            groups: [{ slug: 'g1-p2', refs: [{ slug: 'a1-p2', weight: 1 }] }],
+          },
+          {
+            slug: 'p3',
+            audits: [{ slug: 'a1-p3' }],
+            groups: [{ slug: 'g1-p3', refs: [{ slug: 'a1-p3', weight: 1 }] }],
+          },
         ] as PluginConfig[],
         categories: [
           {
             slug: 'c1',
             refs: [
-              { plugin: 'p1', slug: 'a1-p1' },
-              { plugin: 'p2', slug: 'a1-p2' },
+              { type: 'group', plugin: 'p1', slug: 'g1-p1', weight: 1 },
+              { type: 'group', plugin: 'p2', slug: 'g1-p2', weight: 1 },
             ],
           },
-          { slug: 'c2', refs: [{ plugin: 'p3', slug: 'a1-p3' }] },
+          {
+            slug: 'c2',
+            refs: [{ type: 'group', plugin: 'p3', slug: 'g1-p3', weight: 1 }],
+          },
         ] as CategoryConfig[],
       });
-      expect(plugins).toStrictEqual(expectedPlugins);
-      expect(categories).toStrictEqual(expectedCategories);
+      const pluginSlugs = plugins.map(({ slug }) => slug);
+      const categorySlugs = categories.map(({ slug }) => slug);
+
+      expect(pluginSlugs).toStrictEqual(expectedPlugins);
+      expect(categorySlugs).toStrictEqual(expectedCategories);
     },
   );
 
@@ -193,25 +209,41 @@ describe('filterMiddleware', () => {
       skipPlugins: ['p1'],
       onlyCategories: ['c1'],
       plugins: [
-        { slug: 'p1' },
-        { slug: 'p2' },
-        { slug: 'p3' },
+        {
+          slug: 'p1',
+          audits: [{ slug: 'a1-p1' }],
+          groups: [{ slug: 'g1-p1', refs: [{ slug: 'a1-p1', weight: 1 }] }],
+        },
+        {
+          slug: 'p2',
+          audits: [{ slug: 'a1-p2' }],
+          groups: [{ slug: 'g1-p2', refs: [{ slug: 'a1-p2', weight: 1 }] }],
+        },
+        {
+          slug: 'p3',
+          audits: [{ slug: 'a1-p3' }],
+          groups: [{ slug: 'g1-p3', refs: [{ slug: 'a1-p3', weight: 1 }] }],
+        },
       ] as PluginConfig[],
       categories: [
         {
           slug: 'c1',
           refs: [
-            { plugin: 'p1', slug: 'a1-p1' },
-            { plugin: 'p2', slug: 'a1-p2' },
+            { type: 'group', plugin: 'p1', slug: 'g1-p1', weight: 1 },
+            { type: 'group', plugin: 'p2', slug: 'g1-p2', weight: 1 },
           ],
         },
-        { slug: 'c2', refs: [{ plugin: 'p3', slug: 'a1-p3' }] },
+        {
+          slug: 'c2',
+          refs: [{ type: 'group', plugin: 'p3', slug: 'g1-p3', weight: 1 }],
+        },
       ] as CategoryConfig[],
     });
-    expect(plugins).toStrictEqual([{ slug: 'p2' }]);
-    expect(categories).toStrictEqual([
-      { slug: 'c1', refs: [{ plugin: 'p2', slug: 'a1-p2' }] },
-    ]);
+    const pluginSlugs = plugins.map(({ slug }) => slug);
+    const categorySlugs = categories?.map(({ slug }) => slug);
+
+    expect(pluginSlugs).toStrictEqual(['p2']);
+    expect(categorySlugs).toStrictEqual(['c1']);
   });
 
   it('should trigger verbose logging when skipPlugins or onlyPlugins removes categories', () => {
@@ -220,16 +252,22 @@ describe('filterMiddleware', () => {
     filterMiddleware({
       onlyPlugins: ['p1'],
       skipPlugins: ['p2'],
-      plugins: [{ slug: 'p1' }, { slug: 'p2' }] as PluginConfig[],
+      plugins: [
+        { slug: 'p1', audits: [{ slug: 'a1-p1' }] },
+        { slug: 'p2', audits: [{ slug: 'a1-p2' }] },
+      ] as PluginConfig[],
       categories: [
         {
           slug: 'c1',
           refs: [
-            { plugin: 'p1', slug: 'a1-p1' },
-            { plugin: 'p2', slug: 'a1-p2' },
+            { type: 'audit', plugin: 'p1', slug: 'a1-p1', weight: 1 },
+            { type: 'audit', plugin: 'p2', slug: 'a1-p2', weight: 1 },
           ],
         },
-        { slug: 'c2', refs: [{ plugin: 'p2', slug: 'a1-p2' }] },
+        {
+          slug: 'c2',
+          refs: [{ type: 'audit', plugin: 'p2', slug: 'a1-p2', weight: 1 }],
+        },
       ] as CategoryConfig[],
       verbose: true,
     });
@@ -251,11 +289,14 @@ describe('filterMiddleware', () => {
           {
             slug: 'c1',
             refs: [
-              { plugin: 'p1', slug: 'a1-p1' },
-              { plugin: 'p2', slug: 'a1-p2' },
+              { type: 'audit', plugin: 'p1', slug: 'a1-p1', weight: 1 },
+              { type: 'audit', plugin: 'p2', slug: 'a1-p2', weight: 1 },
             ],
           },
-          { slug: 'c2', refs: [{ plugin: 'p2', slug: 'a1-p2' }] },
+          {
+            slug: 'c2',
+            refs: [{ type: 'audit', plugin: 'p2', slug: 'a1-p2', weight: 1 }],
+          },
         ] as CategoryConfig[],
       }),
     ).toThrow(
@@ -276,8 +317,8 @@ describe('filterMiddleware', () => {
           {
             slug: 'c1',
             refs: [
-              { plugin: 'p1', slug: 'a1-p1' },
-              { plugin: 'p2', slug: 'a1-p2' },
+              { type: 'audit', plugin: 'p1', slug: 'a1-p1', weight: 1 },
+              { type: 'audit', plugin: 'p2', slug: 'a1-p2', weight: 1 },
             ],
           },
         ] as CategoryConfig[],
@@ -295,18 +336,156 @@ describe('filterMiddleware', () => {
     expect(() => {
       filterMiddleware({
         plugins: [
-          { slug: 'p1', audits: [{ slug: 'a1-p1' }] },
+          {
+            slug: 'p1',
+            audits: [{ slug: 'a1-p1', isSkipped: false }],
+          },
+          {
+            slug: 'p2',
+            groups: [{ slug: 'g1-p2', isSkipped: true }],
+          },
         ] as PluginConfig[],
         categories: [
-          { slug: 'c1', refs: [{ plugin: 'p1', slug: 'a1-p1' }] },
+          {
+            slug: 'c1',
+            refs: [{ type: 'audit', plugin: 'p1', slug: 'a1-p1', weight: 1 }],
+          },
+          {
+            slug: 'c2',
+            refs: [{ type: 'group', plugin: 'p1', slug: 'g1-p2', weight: 1 }],
+          },
         ] as CategoryConfig[],
         skipPlugins: ['p1'],
         onlyCategories: ['c1'],
       });
     }).toThrow(
       new OptionValidationError(
-        `Nothing to report. No plugins or categories are available after filtering. Available plugins: p1. Available categories: c1.`,
+        `Nothing to report. No plugins or categories are available after filtering. Available plugins: p1, p2. Available categories: c1, c2.`,
       ),
     );
+  });
+});
+
+describe('processPlugins', () => {
+  it('should filter out skipped audits and groups', () => {
+    expect(
+      processPlugins([
+        {
+          slug: 'p1',
+          audits: [
+            { slug: 'a1', isSkipped: false },
+            { slug: 'a2', isSkipped: true },
+          ],
+          groups: [
+            {
+              slug: 'g1',
+              refs: [
+                { slug: 'a1', weight: 1 },
+                { slug: 'a2', weight: 1 },
+              ],
+              isSkipped: false,
+            },
+          ],
+        },
+      ] as PluginConfig[]),
+    ).toEqual([
+      {
+        slug: 'p1',
+        audits: [{ slug: 'a1' }],
+        groups: [
+          {
+            slug: 'g1',
+            refs: [{ slug: 'a1', weight: 1 }],
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('should filter out entire groups when marked as skipped', () => {
+    expect(
+      processPlugins([
+        {
+          slug: 'p1',
+          audits: [{ slug: 'a1', isSkipped: false }],
+          groups: [
+            {
+              slug: 'g1',
+              refs: [{ slug: 'a1', weight: 1 }],
+              isSkipped: true,
+            },
+          ],
+        },
+      ] as PluginConfig[]),
+    ).toEqual([
+      {
+        slug: 'p1',
+        audits: [{ slug: 'a1' }],
+        groups: [],
+      },
+    ]);
+  });
+});
+
+describe('filterSkippedCategories', () => {
+  it('should filter out categories with all skipped refs', () => {
+    expect(
+      filterSkippedCategories(
+        [
+          {
+            slug: 'c1',
+            refs: [{ type: 'group', plugin: 'p1', slug: 'g1', weight: 1 }],
+          },
+        ] as CategoryConfig[],
+        [
+          {
+            slug: 'p1',
+            audits: [{ slug: 'a1' }, { slug: 'a2' }],
+          },
+        ] as PluginConfig[],
+      ),
+    ).toStrictEqual([]);
+  });
+
+  it('should retain categories with valid refs', () => {
+    expect(
+      filterSkippedCategories(
+        [
+          {
+            slug: 'c1',
+            refs: [{ type: 'group', plugin: 'p1', slug: 'g1-p1', weight: 1 }],
+          },
+          {
+            slug: 'c2',
+            refs: [{ type: 'group', plugin: 'p2', slug: 'g1-p2', weight: 1 }],
+          },
+        ] as CategoryConfig[],
+        [
+          {
+            slug: 'p1',
+            audits: [{ slug: 'a1-p1' }, { slug: 'a2-p1' }],
+            groups: [],
+          },
+          {
+            slug: 'p2',
+            audits: [{ slug: 'a1-p2' }, { slug: 'a2-p2' }],
+            groups: [
+              {
+                slug: 'g1-p2',
+                refs: [
+                  { slug: 'a1-p2', weight: 1 },
+                  { slug: 'a2-p2', weight: 1 },
+                ],
+              },
+            ],
+          },
+        ] as PluginConfig[],
+      ),
+    ).toEqual([
+      {
+        slug: 'c2',
+        refs: [{ type: 'group', plugin: 'p2', slug: 'g1-p2', weight: 1 }],
+      },
+    ]);
   });
 });

--- a/packages/cli/src/lib/implementation/filter.middleware.utils.ts
+++ b/packages/cli/src/lib/implementation/filter.middleware.utils.ts
@@ -1,0 +1,67 @@
+import type { CategoryRef, CoreConfig } from '@code-pushup/models';
+import type { Filterables } from './filter.model';
+
+export function applyFilters<T>(
+  items: T[],
+  skipItems: string[],
+  onlyItems: string[],
+  key: keyof T,
+): T[] {
+  return items.filter(item => {
+    const itemKey = item[key] as unknown as string;
+    return (
+      !skipItems.includes(itemKey) &&
+      (onlyItems.length === 0 || onlyItems.includes(itemKey))
+    );
+  });
+}
+
+export function extractSkippedItems<T extends { slug: string }>(
+  originalItems: T[] | undefined,
+  filteredItems: T[] | undefined,
+): string[] {
+  if (!originalItems || !filteredItems) {
+    return [];
+  }
+  const filteredSlugs = new Set(filteredItems.map(({ slug }) => slug));
+  return originalItems
+    .filter(({ slug }) => !filteredSlugs.has(slug))
+    .map(({ slug }) => slug);
+}
+
+export function filterSkippedItems<T extends { isSkipped?: boolean }>(
+  items: T[] | undefined,
+): Omit<T, 'isSkipped'>[] {
+  return (items ?? [])
+    .filter(({ isSkipped }) => isSkipped !== true)
+    .map(({ isSkipped, ...props }) => props);
+}
+
+export function isValidCategoryRef(
+  ref: CategoryRef,
+  plugins: Filterables['plugins'],
+): boolean {
+  const plugin = plugins.find(({ slug }) => slug === ref.plugin);
+  if (!plugin) {
+    return false;
+  }
+  switch (ref.type) {
+    case 'audit':
+      return plugin.audits.some(({ slug }) => slug === ref.slug);
+    case 'group':
+      return plugin.groups?.some(({ slug }) => slug === ref.slug) ?? false;
+  }
+}
+
+export function filterPluginsFromCategories({
+  categories,
+  plugins,
+}: Filterables): CoreConfig['plugins'] {
+  if (!categories || categories.length === 0) {
+    return plugins;
+  }
+  const validPluginSlugs = new Set(
+    categories.flatMap(category => category.refs.map(ref => ref.plugin)),
+  );
+  return plugins.filter(plugin => validPluginSlugs.has(plugin.slug));
+}

--- a/packages/cli/src/lib/implementation/filter.middleware.utils.unit.test.ts
+++ b/packages/cli/src/lib/implementation/filter.middleware.utils.unit.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect } from 'vitest';
+import type { CategoryRef } from '@code-pushup/models';
+import {
+  extractSkippedItems,
+  isValidCategoryRef,
+} from './filter.middleware.utils';
+import type { Filterables } from './filter.model';
+
+describe('isValidCategoryRef', () => {
+  const plugins = [
+    {
+      slug: 'p1',
+      audits: [{ slug: 'a1' }],
+      groups: [{ slug: 'g1' }],
+    },
+  ] as Filterables['plugins'];
+
+  it('should return true for valid audit ref', () => {
+    const ref = {
+      type: 'audit',
+      slug: 'a1',
+      plugin: 'p1',
+      weight: 1,
+    } satisfies CategoryRef;
+    expect(isValidCategoryRef(ref, plugins)).toBe(true);
+  });
+
+  it('should return false for skipped audit ref', () => {
+    const ref = {
+      type: 'audit',
+      slug: 'a2',
+      plugin: 'p1',
+      weight: 1,
+    } satisfies CategoryRef;
+    expect(isValidCategoryRef(ref, plugins)).toBe(false);
+  });
+
+  it('should return true for valid group ref', () => {
+    const ref = {
+      type: 'group',
+      slug: 'g1',
+      plugin: 'p1',
+      weight: 1,
+    } satisfies CategoryRef;
+    expect(isValidCategoryRef(ref, plugins)).toBe(true);
+  });
+
+  it('should return false for skipped group ref', () => {
+    const ref = {
+      type: 'group',
+      slug: 'g2',
+      plugin: 'p1',
+      weight: 1,
+    } satisfies CategoryRef;
+    expect(isValidCategoryRef(ref, plugins)).toBe(false);
+  });
+
+  it('should return false for nonexistent plugin', () => {
+    const ref = {
+      type: 'audit',
+      slug: 'a1',
+      plugin: 'nonexistent',
+      weight: 1,
+    } satisfies CategoryRef;
+    expect(isValidCategoryRef(ref, plugins)).toBe(false);
+  });
+});
+
+describe('extractSkippedItems', () => {
+  it('should extract skipped items', () => {
+    expect(
+      extractSkippedItems(
+        [{ slug: 'p1' }, { slug: 'p2' }, { slug: 'p3' }, { slug: 'p4' }],
+        [{ slug: 'p1' }, { slug: 'p2' }, { slug: 'p3' }],
+      ),
+    ).toStrictEqual(['p4']);
+  });
+});

--- a/packages/cli/src/lib/implementation/validate-filter-options.utils.ts
+++ b/packages/cli/src/lib/implementation/validate-filter-options.utils.ts
@@ -1,61 +1,69 @@
-import type {
-  CategoryConfig,
-  CategoryRef,
-  PluginConfig,
-} from '@code-pushup/models';
+import type { PluginConfig } from '@code-pushup/models';
 import {
   capitalize,
   filterItemRefsBy,
   pluralize,
   ui,
 } from '@code-pushup/utils';
-import type {
-  FilterOptionType,
-  FilterOptions,
-  Filterables,
-} from './filter.model.js';
+import type { FilterOptionType, Filterables } from './filter.model.js';
 
 export class OptionValidationError extends Error {}
 
+// eslint-disable-next-line max-lines-per-function
 export function validateFilterOption(
   option: FilterOptionType,
   { plugins, categories = [] }: Filterables,
-  { itemsToFilter, verbose }: { itemsToFilter: string[]; verbose: boolean },
+  {
+    itemsToFilter,
+    skippedItems,
+    verbose,
+  }: { itemsToFilter: string[]; skippedItems: string[]; verbose: boolean },
 ): void {
   const itemsToFilterSet = new Set(itemsToFilter);
-  const validItems = isCategoryOption(option)
-    ? categories
-    : isPluginOption(option)
-      ? plugins
-      : [];
-  const invalidItems = itemsToFilter.filter(
-    item => !validItems.some(({ slug }) => slug === item),
+  const skippedItemsSet = new Set(skippedItems);
+  const validItemsSet = new Set(
+    isCategoryOption(option)
+      ? categories.map(({ slug }) => slug)
+      : isPluginOption(option)
+        ? plugins.map(({ slug }) => slug)
+        : [''],
   );
-
-  const message = createValidationMessage(option, invalidItems, validItems);
-
-  if (
-    isOnlyOption(option) &&
-    itemsToFilterSet.size > 0 &&
-    itemsToFilterSet.size === invalidItems.length
-  ) {
-    throw new OptionValidationError(message);
-  }
-
-  if (invalidItems.length > 0) {
+  const nonExistentItems = itemsToFilter.filter(
+    item => !validItemsSet.has(item) && !skippedItemsSet.has(item),
+  );
+  const skippedValidItems = itemsToFilter.filter(item =>
+    skippedItemsSet.has(item),
+  );
+  if (nonExistentItems.length > 0) {
+    const message = createValidationMessage(
+      option,
+      nonExistentItems,
+      validItemsSet,
+    );
+    if (
+      isOnlyOption(option) &&
+      itemsToFilterSet.size > 0 &&
+      itemsToFilterSet.size === nonExistentItems.length
+    ) {
+      throw new OptionValidationError(message);
+    }
     ui().logger.warning(message);
   }
-
+  if (skippedValidItems.length > 0 && verbose) {
+    ui().logger.warning(
+      `The --${option} argument references skipped ${getItemType(option, skippedValidItems.length)}: ${skippedValidItems.join(', ')}.`,
+    );
+  }
   if (isPluginOption(option) && categories.length > 0 && verbose) {
-    const removedCategorySlugs = filterItemRefsBy(categories, ({ plugin }) =>
+    const removedCategories = filterItemRefsBy(categories, ({ plugin }) =>
       isOnlyOption(option)
         ? !itemsToFilterSet.has(plugin)
         : itemsToFilterSet.has(plugin),
     ).map(({ slug }) => slug);
 
-    if (removedCategorySlugs.length > 0) {
+    if (removedCategories.length > 0) {
       ui().logger.info(
-        `The --${option} argument removed the following categories: ${removedCategorySlugs.join(
+        `The --${option} argument removed the following categories: ${removedCategories.join(
           ', ',
         )}.`,
       );
@@ -63,19 +71,15 @@ export function validateFilterOption(
   }
 }
 
-export function validateFilteredCategories(
+export function validateSkippedCategories(
   originalCategories: NonNullable<Filterables['categories']>,
   filteredCategories: NonNullable<Filterables['categories']>,
-  {
-    onlyCategories,
-    skipCategories,
-    verbose,
-  }: Pick<FilterOptions, 'onlyCategories' | 'skipCategories' | 'verbose'>,
+  verbose: boolean,
 ): void {
   const skippedCategories = originalCategories.filter(
     original => !filteredCategories.some(({ slug }) => slug === original.slug),
   );
-  if (verbose) {
+  if (skippedCategories.length > 0 && verbose) {
     skippedCategories.forEach(category => {
       ui().logger.info(
         `Category ${category.slug} was removed because all its refs were skipped. Affected refs: ${category.refs
@@ -84,44 +88,12 @@ export function validateFilteredCategories(
       );
     });
   }
-  const invalidArgs = [
-    { option: 'onlyCategories', args: onlyCategories ?? [] },
-    { option: 'skipCategories', args: skipCategories ?? [] },
-  ].filter(({ args }) =>
-    args.some(arg => skippedCategories.some(({ slug }) => slug === arg)),
-  );
-  if (invalidArgs.length > 0) {
-    throw new OptionValidationError(
-      invalidArgs
-        .map(
-          ({ option, args }) =>
-            `The --${option} argument references skipped categories: ${args.join(', ')}`,
-        )
-        .join('. '),
-    );
-  }
   if (filteredCategories.length === 0) {
     throw new OptionValidationError(
       `No categories remain after filtering. Removed categories: ${skippedCategories
         .map(({ slug }) => slug)
         .join(', ')}`,
     );
-  }
-}
-
-export function isValidCategoryRef(
-  ref: CategoryRef,
-  plugins: Filterables['plugins'],
-): boolean {
-  const plugin = plugins.find(({ slug }) => slug === ref.plugin);
-  if (!plugin) {
-    return false;
-  }
-  switch (ref.type) {
-    case 'audit':
-      return plugin.audits.some(({ slug }) => slug === ref.slug);
-    case 'group':
-      return plugin.groups?.some(({ slug }) => slug === ref.slug) ?? false;
   }
 }
 
@@ -146,9 +118,9 @@ export function validateFinalState(
       `Nothing to report. No plugins or categories are available after filtering. Available plugins: ${availablePlugins}. Available categories: ${availableCategories}.`,
     );
   }
-  if (filteredPlugins.every(pluginHasZeroWeightRefs)) {
+  if (filteredPlugins.some(pluginHasZeroWeightRefs)) {
     throw new OptionValidationError(
-      `All groups in the filtered plugins have refs with zero weight. Please adjust your filters or weights.`,
+      'Some groups in the filtered plugins have only zero-weight references. Please adjust your filters or weights.',
     );
   }
 }
@@ -159,17 +131,9 @@ export function pluginHasZeroWeightRefs(
   if (!plugin.groups || plugin.groups.length === 0) {
     return false;
   }
-  const weightMap = new Map<string, number>();
-  plugin.groups.forEach(group => {
-    group.refs.forEach(ref => {
-      weightMap.set(ref.slug, (weightMap.get(ref.slug) ?? 0) + ref.weight);
-    });
-  });
-  const totalWeight = plugin.audits.reduce(
-    (sum, audit) => sum + (weightMap.get(audit.slug) ?? 0),
-    0,
+  return plugin.groups.some(
+    group => group.refs.reduce((sum, ref) => sum + ref.weight, 0) === 0,
   );
-  return totalWeight === 0;
 }
 
 function isCategoryOption(option: FilterOptionType): boolean {
@@ -196,7 +160,7 @@ export function getItemType(option: FilterOptionType, count: number): string {
 export function createValidationMessage(
   option: FilterOptionType,
   invalidItems: string[],
-  validItems: Pick<PluginConfig | CategoryConfig, 'slug'>[],
+  validItems: Set<string>,
 ): string {
   const invalidItem = getItemType(option, invalidItems.length);
   const invalidItemText =
@@ -205,12 +169,12 @@ export function createValidationMessage(
       : `${invalidItem} that do not exist:`;
   const invalidSlugs = invalidItems.join(', ');
 
-  const validItem = getItemType(option, validItems.length);
+  const validItem = getItemType(option, validItems.size);
   const validItemText =
-    validItems.length === 1
+    validItems.size === 1
       ? `The only valid ${validItem} is`
       : `Valid ${validItem} are`;
-  const validSlugs = validItems.map(({ slug }) => slug).join(', ');
+  const validSlugs = [...validItems].join(', ');
 
   return `The --${option} argument references ${invalidItemText} ${invalidSlugs}. ${validItemText} ${validSlugs}.`;
 }

--- a/packages/cli/src/lib/implementation/validate-filter-options.utils.ts
+++ b/packages/cli/src/lib/implementation/validate-filter-options.utils.ts
@@ -19,21 +19,23 @@ export function validateFilterOption(
     verbose,
   }: { itemsToFilter: string[]; skippedItems: string[]; verbose: boolean },
 ): void {
+  const validItems = isCategoryOption(option)
+    ? categories.map(({ slug }) => slug)
+    : isPluginOption(option)
+      ? plugins.map(({ slug }) => slug)
+      : [];
+
   const itemsToFilterSet = new Set(itemsToFilter);
   const skippedItemsSet = new Set(skippedItems);
-  const validItemsSet = new Set(
-    isCategoryOption(option)
-      ? categories.map(({ slug }) => slug)
-      : isPluginOption(option)
-        ? plugins.map(({ slug }) => slug)
-        : [''],
-  );
+  const validItemsSet = new Set(validItems);
+
   const nonExistentItems = itemsToFilter.filter(
     item => !validItemsSet.has(item) && !skippedItemsSet.has(item),
   );
   const skippedValidItems = itemsToFilter.filter(item =>
     skippedItemsSet.has(item),
   );
+
   if (nonExistentItems.length > 0) {
     const message = createValidationMessage(
       option,
@@ -50,8 +52,10 @@ export function validateFilterOption(
     ui().logger.warning(message);
   }
   if (skippedValidItems.length > 0 && verbose) {
+    const item = getItemType(option, skippedValidItems.length);
+    const prefix = skippedValidItems.length === 1 ? `a skipped` : `skipped`;
     ui().logger.warning(
-      `The --${option} argument references skipped ${getItemType(option, skippedValidItems.length)}: ${skippedValidItems.join(', ')}.`,
+      `The --${option} argument references ${prefix} ${item}: ${skippedValidItems.join(', ')}.`,
     );
   }
   if (isPluginOption(option) && categories.length > 0 && verbose) {

--- a/packages/cli/src/lib/implementation/validate-filter-options.utils.unit.test.ts
+++ b/packages/cli/src/lib/implementation/validate-filter-options.utils.unit.test.ts
@@ -223,7 +223,7 @@ describe('validateFilterOption', () => {
     );
     const logs = getLogMessages(ui().logger);
     expect(logs[0]).toContain(
-      'The --skipPlugins argument references skipped plugin: p1.',
+      'The --skipPlugins argument references a skipped plugin: p1.',
     );
   });
 });

--- a/packages/models/docs/models-reference.md
+++ b/packages/models/docs/models-reference.md
@@ -24,7 +24,7 @@ _Object containing the following properties:_
 | `docsUrl`                | Documentation site                   | `string` (_url_) (_optional_) _or_ `''`                                                                                                                                                                                                                                                                              |
 | **`scores`** (\*)        | Score comparison                     | _Object with properties:_<ul><li>`before`: `number` (_≥0, ≤1_) - Value between 0 and 1 (source commit)</li><li>`after`: `number` (_≥0, ≤1_) - Value between 0 and 1 (target commit)</li><li>`diff`: `number` (_≥-1, ≤1_) - Score change (`scores.after - scores.before`)</li></ul>                                   |
 | **`plugin`** (\*)        | Plugin which defines it              | _Object with properties:_<ul><li>`slug`: `string` (_regex: `/^[a-z\d]+(?:-[a-z\d]+)*$/`, max length: 128_) - Unique plugin slug within core config</li><li>`title`: `string` (_max length: 256_) - Descriptive name</li><li>`docsUrl`: `string` (_url_) (_optional_) _or_ `''` - Plugin documentation site</li></ul> |
-| **`values`** (\*)        | Audit `value` comparison             | _Object with properties:_<ul><li>`before`: `number` (_≥0_) - Raw numeric value (source commit)</li><li>`after`: `number` (_≥0_) - Raw numeric value (target commit)</li><li>`diff`: `number` (_int_) - Value change (`values.after - values.before`)</li></ul>                                                       |
+| **`values`** (\*)        | Audit `value` comparison             | _Object with properties:_<ul><li>`before`: `number` (_≥0_) - Raw numeric value (source commit)</li><li>`after`: `number` (_≥0_) - Raw numeric value (target commit)</li><li>`diff`: `number` - Value change (`values.after - values.before`)</li></ul>                                                               |
 | **`displayValues`** (\*) | Audit `displayValue` comparison      | _Object with properties:_<ul><li>`before`: `string` - Formatted value (e.g. '0.9 s', '2.1 MB') (source commit)</li><li>`after`: `string` - Formatted value (e.g. '0.9 s', '2.1 MB') (target commit)</li></ul>                                                                                                        |
 
 _(\*) Required._
@@ -59,6 +59,7 @@ _Object containing the following properties:_
 | **`title`** (\*) | Descriptive name                         | `string` (_max length: 256_)                                      |
 | `description`    | Description (markdown)                   | `string` (_max length: 65536_)                                    |
 | `docsUrl`        | Link to documentation (rationale)        | `string` (_url_) (_optional_) _or_ `''`                           |
+| `isSkipped`      | Indicates whether the audit is skipped   | `boolean`                                                         |
 | `displayValue`   | Formatted value (e.g. '0.9 s', '2.1 MB') | `string`                                                          |
 | **`value`** (\*) | Raw numeric value                        | `number` (_≥0_)                                                   |
 | **`score`** (\*) | Value between 0 and 1                    | `number` (_≥0, ≤1_)                                               |
@@ -86,12 +87,13 @@ _(\*) Required._
 
 _Object containing the following properties:_
 
-| Property         | Description                       | Type                                                              |
-| :--------------- | :-------------------------------- | :---------------------------------------------------------------- |
-| **`slug`** (\*)  | ID (unique within plugin)         | `string` (_regex: `/^[a-z\d]+(?:-[a-z\d]+)*$/`, max length: 128_) |
-| **`title`** (\*) | Descriptive name                  | `string` (_max length: 256_)                                      |
-| `description`    | Description (markdown)            | `string` (_max length: 65536_)                                    |
-| `docsUrl`        | Link to documentation (rationale) | `string` (_url_) (_optional_) _or_ `''`                           |
+| Property         | Description                            | Type                                                              |
+| :--------------- | :------------------------------------- | :---------------------------------------------------------------- |
+| **`slug`** (\*)  | ID (unique within plugin)              | `string` (_regex: `/^[a-z\d]+(?:-[a-z\d]+)*$/`, max length: 128_) |
+| **`title`** (\*) | Descriptive name                       | `string` (_max length: 256_)                                      |
+| `description`    | Description (markdown)                 | `string` (_max length: 65536_)                                    |
+| `docsUrl`        | Link to documentation (rationale)      | `string` (_url_) (_optional_) _or_ `''`                           |
+| `isSkipped`      | Indicates whether the audit is skipped | `boolean`                                                         |
 
 _(\*) Required._
 
@@ -106,6 +108,7 @@ _Object containing the following properties:_
 | **`title`** (\*) | Category Title                                                             | `string` (_max length: 256_)                                      |
 | `description`    | Category description                                                       | `string` (_max length: 65536_)                                    |
 | `docsUrl`        | Category docs URL                                                          | `string` (_url_) (_optional_) _or_ `''`                           |
+| `isSkipped`      |                                                                            | `boolean`                                                         |
 | `isBinary`       | Is this a binary category (i.e. only a perfect score considered a "pass")? | `boolean`                                                         |
 
 _(\*) Required._
@@ -236,6 +239,7 @@ _Object containing the following properties:_
 | **`title`** (\*) | Descriptive name for the group               | `string` (_max length: 256_)                                      |
 | `description`    | Description of the group (markdown)          | `string` (_max length: 65536_)                                    |
 | `docsUrl`        | Group documentation site                     | `string` (_url_) (_optional_) _or_ `''`                           |
+| `isSkipped`      | Indicates whether the group is skipped       | `boolean`                                                         |
 
 _(\*) Required._
 
@@ -245,11 +249,11 @@ Issue information
 
 _Object containing the following properties:_
 
-| Property            | Description               | Type                                                                                                                                                                                                                                                                                                                                                                                                                           |
-| :------------------ | :------------------------ | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **`message`** (\*)  | Descriptive error message | `string` (_max length: 1024_)                                                                                                                                                                                                                                                                                                                                                                                                  |
-| **`severity`** (\*) | Severity level            | [IssueSeverity](#issueseverity)                                                                                                                                                                                                                                                                                                                                                                                                |
-| `source`            | Source file location      | _Object with properties:_<ul><li>`file`: `string` (_min length: 1_) - Relative path to source file in Git repo</li><li>`position`: _Object with properties:_<ul><li>`startLine`: `number` (_int, >0_) - Start line</li><li>`startColumn`: `number` (_int, >0_) - Start column</li><li>`endLine`: `number` (_int, >0_) - End line</li><li>`endColumn`: `number` (_int, >0_) - End column</li></ul> - Location in file</li></ul> |
+| Property            | Description               | Type                                      |
+| :------------------ | :------------------------ | :---------------------------------------- |
+| **`message`** (\*)  | Descriptive error message | `string` (_max length: 1024_)             |
+| **`severity`** (\*) | Severity level            | [IssueSeverity](#issueseverity)           |
+| `source`            | Source file location      | [SourceFileLocation](#sourcefilelocation) |
 
 _(\*) Required._
 
@@ -270,7 +274,7 @@ Icon from VSCode Material Icons extension
 _Enum string, one of the following possible values:_
 
 <details>
-<summary><i>Expand for full list of 839 values</i></summary>
+<summary><i>Expand for full list of 858 values</i></summary>
 
 - `'git'`
 - `'yaml'`
@@ -481,6 +485,8 @@ _Enum string, one of the following possible values:_
 - `'vercel'`
 - `'vercel_light'`
 - `'verdaccio'`
+- `'payload'`
+- `'payload_light'`
 - `'next'`
 - `'next_light'`
 - `'remix'`
@@ -574,6 +580,7 @@ _Enum string, one of the following possible values:_
 - `'hcl_light'`
 - `'helm'`
 - `'san'`
+- `'quokka'`
 - `'wallaby'`
 - `'stencil'`
 - `'red'`
@@ -634,7 +641,7 @@ _Enum string, one of the following possible values:_
 - `'meson'`
 - `'commitlint'`
 - `'buck'`
-- `'nrwl'`
+- `'nx'`
 - `'opam'`
 - `'dune'`
 - `'imba'`
@@ -703,13 +710,18 @@ _Enum string, one of the following possible values:_
 - `'pnpm_light'`
 - `'gridsome'`
 - `'steadybit'`
+- `'capnp'`
 - `'caddy'`
+- `'openapi'`
+- `'openapi_light'`
+- `'swagger'`
 - `'bun'`
 - `'bun_light'`
 - `'antlr'`
 - `'pinejs'`
 - `'nano-staged'`
 - `'nano-staged_light'`
+- `'knip'`
 - `'taskfile'`
 - `'craco'`
 - `'gamemaker'`
@@ -723,6 +735,7 @@ _Enum string, one of the following possible values:_
 - `'unocss'`
 - `'ifanr-cloud'`
 - `'mermaid'`
+- `'syncpack'`
 - `'werf'`
 - `'roblox'`
 - `'panda'`
@@ -749,6 +762,12 @@ _Enum string, one of the following possible values:_
 - `'folder-css-open'`
 - `'folder-sass'`
 - `'folder-sass-open'`
+- `'folder-television'`
+- `'folder-television-open'`
+- `'folder-desktop'`
+- `'folder-desktop-open'`
+- `'folder-console'`
+- `'folder-console-open'`
 - `'folder-images'`
 - `'folder-images-open'`
 - `'folder-scripts'`
@@ -1107,6 +1126,10 @@ _Enum string, one of the following possible values:_
 - `'folder-lottie-open'`
 - `'folder-taskfile'`
 - `'folder-taskfile-open'`
+- `'folder-cloudflare'`
+- `'folder-cloudflare-open'`
+- `'folder-seeders'`
+- `'folder-seeders-open'`
 - `'folder'`
 - `'folder-open'`
 - `'folder-root'`
@@ -1149,6 +1172,7 @@ _Object containing the following properties:_
 | **`title`** (\*)  | Descriptive name                          | `string` (_max length: 256_)                                         |
 | `description`     | Description (markdown)                    | `string` (_max length: 65536_)                                       |
 | `docsUrl`         | Plugin documentation site                 | `string` (_url_) (_optional_) _or_ `''`                              |
+| `isSkipped`       |                                           | `boolean`                                                            |
 | **`slug`** (\*)   | Unique plugin slug within core config     | `string` (_regex: `/^[a-z\d]+(?:-[a-z\d]+)*$/`, max length: 128_)    |
 | **`icon`** (\*)   | Icon from VSCode Material Icons extension | [MaterialIcon](#materialicon)                                        |
 | **`runner`** (\*) |                                           | [RunnerConfig](#runnerconfig) _or_ [RunnerFunction](#runnerfunction) |
@@ -1168,6 +1192,7 @@ _Object containing the following properties:_
 | **`title`** (\*) | Descriptive name                          | `string` (_max length: 256_)                                      |
 | `description`    | Description (markdown)                    | `string` (_max length: 65536_)                                    |
 | `docsUrl`        | Plugin documentation site                 | `string` (_url_) (_optional_) _or_ `''`                           |
+| `isSkipped`      |                                           | `boolean`                                                         |
 | **`slug`** (\*)  | Unique plugin slug within core config     | `string` (_regex: `/^[a-z\d]+(?:-[a-z\d]+)*$/`, max length: 128_) |
 | **`icon`** (\*)  | Icon from VSCode Material Icons extension | [MaterialIcon](#materialicon)                                     |
 
@@ -1184,6 +1209,7 @@ _Object containing the following properties:_
 | **`title`** (\*)    | Descriptive name                          | `string` (_max length: 256_)                                      |
 | `description`       | Description (markdown)                    | `string` (_max length: 65536_)                                    |
 | `docsUrl`           | Plugin documentation site                 | `string` (_url_) (_optional_) _or_ `''`                           |
+| `isSkipped`         |                                           | `boolean`                                                         |
 | **`slug`** (\*)     | Unique plugin slug within core config     | `string` (_regex: `/^[a-z\d]+(?:-[a-z\d]+)*$/`, max length: 128_) |
 | **`icon`** (\*)     | Icon from VSCode Material Icons extension | [MaterialIcon](#materialicon)                                     |
 | **`date`** (\*)     | Start date and time of plugin run         | `string`                                                          |
@@ -1203,8 +1229,8 @@ _Object containing the following properties:_
 | **`version`** (\*)     | NPM version of the CLI                    | `string`                                                                                                                                                                                                                                                                                            |
 | **`date`** (\*)        | Start date and time of the collect run    | `string`                                                                                                                                                                                                                                                                                            |
 | **`duration`** (\*)    | Duration of the collect run in ms         | `number`                                                                                                                                                                                                                                                                                            |
-| **`categories`** (\*)  |                                           | _Array of [CategoryConfig](#categoryconfig) items_                                                                                                                                                                                                                                                  |
 | **`plugins`** (\*)     |                                           | _Array of at least 1 [PluginReport](#pluginreport) items_                                                                                                                                                                                                                                           |
+| `categories`           |                                           | _Array of [CategoryConfig](#categoryconfig) items_                                                                                                                                                                                                                                                  |
 | **`commit`** (\*)      | Git commit for which report was collected | _Object with properties:_<ul><li>`hash`: `string` (_regex: `/^[\da-f]{40}$/`_) - Commit SHA (full)</li><li>`message`: `string` - Commit message</li><li>`date`: `Date` (_nullable_) - Date and time when commit was authored</li><li>`author`: `string` - Commit author name</li></ul> (_nullable_) |
 
 _(\*) Required._
@@ -1254,6 +1280,19 @@ _Parameters:_
 _Returns:_
 
 - [AuditOutputs](#auditoutputs) _or_ _Promise of_ [AuditOutputs](#auditoutputs)
+
+## SourceFileLocation
+
+Source file location
+
+_Object containing the following properties:_
+
+| Property        | Description                              | Type                                                                                                                                                                                                                                                           |
+| :-------------- | :--------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`file`** (\*) | Relative path to source file in Git repo | `string` (_min length: 1_)                                                                                                                                                                                                                                     |
+| `position`      | Location in file                         | _Object with properties:_<ul><li>`startLine`: `number` (_int, >0_) - Start line</li><li>`startColumn`: `number` (_int, >0_) - Start column</li><li>`endLine`: `number` (_int, >0_) - End line</li><li>`endColumn`: `number` (_int, >0_) - End column</li></ul> |
+
+_(\*) Required._
 
 ## TableAlignment
 

--- a/packages/models/src/lib/audit.ts
+++ b/packages/models/src/lib/audit.ts
@@ -12,6 +12,7 @@ export const auditSchema = z
       descriptionDescription: 'Description (markdown)',
       docsUrlDescription: 'Link to documentation (rationale)',
       description: 'List of scorable metrics for the given plugin',
+      isSkippedDescription: 'Indicates whether the audit is skipped',
     }),
   );
 

--- a/packages/models/src/lib/core-config.unit.test.ts
+++ b/packages/models/src/lib/core-config.unit.test.ts
@@ -136,4 +136,60 @@ describe('coreConfigSchema', () => {
       'category references need to point to an audit or group: eslint#eslint-errors (group)',
     );
   });
+
+  it('should throw for a category with a zero-weight audit', () => {
+    const config = {
+      categories: [
+        {
+          slug: 'performance',
+          title: 'Performance',
+          refs: [
+            {
+              slug: 'performance',
+              weight: 1,
+              type: 'group',
+              plugin: 'lighthouse',
+            },
+          ],
+        },
+        {
+          slug: 'best-practices',
+          title: 'Best practices',
+          refs: [
+            {
+              slug: 'best-practices',
+              weight: 1,
+              type: 'group',
+              plugin: 'lighthouse',
+            },
+          ],
+        },
+      ],
+      plugins: [
+        {
+          slug: 'lighthouse',
+          title: 'Lighthouse',
+          icon: 'lighthouse',
+          runner: { command: 'npm run lint', outputFile: 'output.json' },
+          audits: [
+            {
+              slug: 'csp-xss',
+              title: 'Ensure CSP is effective against XSS attacks',
+            },
+          ],
+          groups: [
+            {
+              slug: 'best-practices',
+              title: 'Best practices',
+              refs: [{ slug: 'csp-xss', weight: 0 }],
+            },
+          ],
+        },
+      ],
+    } satisfies CoreConfig;
+
+    expect(() => coreConfigSchema.parse(config)).toThrow(
+      'In a category, there has to be at least one ref with weight > 0. Affected refs: csp-xss',
+    );
+  });
 });

--- a/packages/models/src/lib/group.ts
+++ b/packages/models/src/lib/group.ts
@@ -22,6 +22,7 @@ export const groupMetaSchema = metaSchema({
   descriptionDescription: 'Description of the group (markdown)',
   docsUrlDescription: 'Group documentation site',
   description: 'Group metadata',
+  isSkippedDescription: 'Indicates whether the group is skipped',
 });
 export type GroupMeta = z.infer<typeof groupMetaSchema>;
 

--- a/packages/models/src/lib/implementation/schemas.ts
+++ b/packages/models/src/lib/implementation/schemas.ts
@@ -69,6 +69,9 @@ export const scoreSchema = z
   .min(0)
   .max(1);
 
+/** Schema for a property indicating whether an entity is filtered out */
+export const isSkippedSchema = z.boolean().optional();
+
 /**
  * Used for categories, plugins and audits
  * @param options
@@ -78,12 +81,14 @@ export function metaSchema(options?: {
   descriptionDescription?: string;
   docsUrlDescription?: string;
   description?: string;
+  isSkippedDescription?: string;
 }) {
   const {
     descriptionDescription,
     titleDescription,
     docsUrlDescription,
     description,
+    isSkippedDescription,
   } = options ?? {};
   return z.object(
     {
@@ -96,6 +101,9 @@ export function metaSchema(options?: {
       docsUrl: docsUrlDescription
         ? docsUrlSchema.describe(docsUrlDescription)
         : docsUrlSchema,
+      isSkipped: isSkippedDescription
+        ? isSkippedSchema.describe(isSkippedDescription)
+        : isSkippedSchema,
     },
     { description },
   );

--- a/packages/plugin-lighthouse/src/lib/lighthouse-plugin.ts
+++ b/packages/plugin-lighthouse/src/lib/lighthouse-plugin.ts
@@ -8,7 +8,7 @@ import {
 } from './runner/constants.js';
 import { createRunnerFunction } from './runner/runner.js';
 import type { LighthouseOptions } from './types.js';
-import { filterAuditsAndGroupsByOnlyOptions } from './utils.js';
+import { markSkippedAuditsAndGroups } from './utils.js';
 
 export function lighthousePlugin(
   url: string,
@@ -17,7 +17,7 @@ export function lighthousePlugin(
   const { skipAudits, onlyAudits, onlyCategories, ...unparsedFlags } =
     normalizeFlags(flags ?? {});
 
-  const { audits, groups } = filterAuditsAndGroupsByOnlyOptions(
+  const { audits, groups } = markSkippedAuditsAndGroups(
     LIGHTHOUSE_NAVIGATION_AUDITS,
     LIGHTHOUSE_GROUPS,
     { skipAudits, onlyAudits, onlyCategories },

--- a/packages/plugin-lighthouse/src/lib/lighthouse-plugin.unit.test.ts
+++ b/packages/plugin-lighthouse/src/lib/lighthouse-plugin.unit.test.ts
@@ -17,47 +17,36 @@ describe('lighthousePlugin-config-object', () => {
     ]);
   });
 
-  it('should filter audits by onlyAudits string "first-contentful-paint"', () => {
+  it('should mark audits in onlyAudits as not skipped', () => {
     const pluginConfig = lighthousePlugin('https://code-pushup-portal.com', {
       onlyAudits: ['first-contentful-paint'],
     });
 
     expect(() => pluginConfigSchema.parse(pluginConfig)).not.toThrow();
-
-    expect(pluginConfig.audits[0]).toEqual(
+    expect(
+      pluginConfig.audits.find(({ slug }) => slug === 'first-contentful-paint'),
+    ).toEqual(
       expect.objectContaining({
-        slug: 'first-contentful-paint',
+        isSkipped: false,
       }),
     );
   });
 
-  it('should filter groups by onlyAudits string "first-contentful-paint"', () => {
+  it('should mark groups referencing audits in onlyAudits as not skipped', () => {
     const pluginConfig = lighthousePlugin('https://code-pushup-portal.com', {
       onlyAudits: ['first-contentful-paint'],
     });
 
     expect(() => pluginConfigSchema.parse(pluginConfig)).not.toThrow();
-    expect(pluginConfig.groups).toHaveLength(1);
 
-    const refs = pluginConfig.groups?.[0]?.refs;
-    expect(refs).toHaveLength(1);
-
-    expect(refs).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          slug: 'first-contentful-paint',
-        }),
-      ]),
+    const group = pluginConfig.groups?.find(({ refs }) =>
+      refs.some(ref => ref.slug === 'first-contentful-paint'),
     );
-  });
 
-  it('should throw when filtering groups by zero-weight onlyAudits', () => {
-    const pluginConfig = lighthousePlugin('https://code-pushup-portal.com', {
-      onlyAudits: ['csp-xss'],
-    });
-
-    expect(() => pluginConfigSchema.parse(pluginConfig)).toThrow(
-      'In a category, there has to be at least one ref with weight > 0. Affected refs: csp-xss',
+    expect(group).toEqual(
+      expect.objectContaining({
+        isSkipped: false,
+      }),
     );
   });
 });

--- a/packages/plugin-lighthouse/src/lib/lighthouse-plugin.unit.test.ts
+++ b/packages/plugin-lighthouse/src/lib/lighthouse-plugin.unit.test.ts
@@ -1,6 +1,7 @@
 import { expect } from 'vitest';
 import { pluginConfigSchema } from '@code-pushup/models';
 import { lighthousePlugin } from './lighthouse-plugin.js';
+import type { LighthouseOptions } from './types.js';
 
 describe('lighthousePlugin-config-object', () => {
   it('should create valid plugin config', () => {
@@ -17,20 +18,57 @@ describe('lighthousePlugin-config-object', () => {
     ]);
   });
 
-  it('should mark audits in onlyAudits as not skipped', () => {
-    const pluginConfig = lighthousePlugin('https://code-pushup-portal.com', {
-      onlyAudits: ['first-contentful-paint'],
-    });
+  it.each([
+    [
+      { onlyAudits: ['first-contentful-paint'] },
+      'first-contentful-paint',
+      false,
+    ],
+    [
+      { onlyAudits: ['first-contentful-paint'] },
+      'largest-contentful-paint',
+      true,
+    ],
+    [
+      { skipAudits: ['first-contentful-paint'] },
+      'first-contentful-paint',
+      true,
+    ],
+    [
+      { skipAudits: ['first-contentful-paint'] },
+      'largest-contentful-paint',
+      false,
+    ],
+  ])(
+    'should apply option %o and set the "%s" audit skipped status to %s',
+    (option, audit, isSkipped) => {
+      const pluginConfig = lighthousePlugin(
+        'https://code-pushup-portal.com',
+        option as LighthouseOptions,
+      );
+      expect(() => pluginConfigSchema.parse(pluginConfig)).not.toThrow();
+      expect(pluginConfig.audits.find(({ slug }) => audit === slug)).toEqual(
+        expect.objectContaining({ isSkipped }),
+      );
+    },
+  );
 
-    expect(() => pluginConfigSchema.parse(pluginConfig)).not.toThrow();
-    expect(
-      pluginConfig.audits.find(({ slug }) => slug === 'first-contentful-paint'),
-    ).toEqual(
-      expect.objectContaining({
-        isSkipped: false,
-      }),
-    );
-  });
+  it.each([
+    [{ onlyGroups: ['performance'] }, 'performance', false],
+    [{ onlyGroups: ['performance'] }, 'accessibility', true],
+  ])(
+    'should apply option %o and set the "%s" group skipped status to %s',
+    (option, group, isSkipped) => {
+      const pluginConfig = lighthousePlugin(
+        'https://code-pushup-portal.com',
+        option as LighthouseOptions,
+      );
+      expect(() => pluginConfigSchema.parse(pluginConfig)).not.toThrow();
+      expect(pluginConfig.groups?.find(({ slug }) => group === slug)).toEqual(
+        expect.objectContaining({ isSkipped }),
+      );
+    },
+  );
 
   it('should mark groups referencing audits in onlyAudits as not skipped', () => {
     const pluginConfig = lighthousePlugin('https://code-pushup-portal.com', {


### PR DESCRIPTION
Fixes #903 

This fix enhances the filtering of report results by audits and groups through the core configuration (currently implemented for the Lighthouse plugin only).

The `isSkipped` property is introduced in the `PluginConfig` metadata for audits and groups, ensuring the complete set of plugin audits and groups is retained during `CoreConfig` validation to prevent unexpected errors. Filtering is now deferred to the filter middleware, which accurately handles skipped items by removing categories that contain only skipped or zero-weight references.