### PR TITLE
feat(plugin-coverage): support lcovonly option for vitest

### DIFF
--- a/packages/plugin-coverage/src/lib/nx/coverage-paths.ts
+++ b/packages/plugin-coverage/src/lib/nx/coverage-paths.ts
@@ -143,7 +143,7 @@ export async function getCoveragePathForVitest(
     );
   }
 
-  if (!reporter?.includes('lcov')) {
+  if (!reporter?.some(format => format === 'lcov' || format === 'lcovonly')) {
     throw new Error(
       `Vitest coverage configuration at ${config} does not include LCOV report format for target ${target} in project ${project.name}. Add 'lcov' format under coverage > reporter.`,
     );


### PR DESCRIPTION
Vitest has an option to generate only lcov files without the HTML UI polluting the coverage folders.