### PR TITLE
feat(plugin-eslint): add support for custom groups

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -41,8 +41,7 @@
   "dependencies": {
     "@code-pushup/models": "0.57.0",
     "@code-pushup/utils": "0.57.0",
-    "ansis": "^3.3.0",
-    "zod-validation-error": "^3.4.0"
+    "ansis": "^3.3.0"
   },
   "peerDependencies": {
     "@code-pushup/portal-client": "^0.9.0"

--- a/packages/core/src/lib/implementation/read-rc-file.integration.test.ts
+++ b/packages/core/src/lib/implementation/read-rc-file.integration.test.ts
@@ -1,7 +1,7 @@
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect } from 'vitest';
-import { ConfigValidationError, readRcByPath } from './read-rc-file.js';
+import { readRcByPath } from './read-rc-file.js';
 
 describe('readRcByPath', () => {
   const configDirPath = path.join(
@@ -69,7 +69,7 @@ describe('readRcByPath', () => {
   it('should throw if the configuration is empty', async () => {
     await expect(
       readRcByPath(path.join(configDirPath, 'code-pushup.empty.config.js')),
-    ).rejects.toThrow(expect.any(ConfigValidationError));
+    ).rejects.toThrow(/invalid_type/);
   });
 
   it('should throw if the configuration is invalid', async () => {

--- a/packages/core/src/lib/implementation/read-rc-file.ts
+++ b/packages/core/src/lib/implementation/read-rc-file.ts
@@ -1,28 +1,15 @@
-import { bold } from 'ansis';
 import path from 'node:path';
-import { fromError, isZodErrorLike } from 'zod-validation-error';
 import {
   CONFIG_FILE_NAME,
   type CoreConfig,
   SUPPORTED_CONFIG_FILE_FORMATS,
   coreConfigSchema,
 } from '@code-pushup/models';
-import {
-  fileExists,
-  importModule,
-  zodErrorMessageBuilder,
-} from '@code-pushup/utils';
+import { fileExists, importModule, parseSchema } from '@code-pushup/utils';
 
 export class ConfigPathError extends Error {
   constructor(configPath: string) {
     super(`Provided path '${configPath}' is not valid.`);
-  }
-}
-
-export class ConfigValidationError extends Error {
-  constructor(configPath: string, message: string) {
-    const relativePath = path.relative(process.cwd(), configPath);
-    super(`Failed parsing core config in ${bold(relativePath)}.\n\n${message}`);
   }
 }
 
@@ -38,18 +25,16 @@ export async function readRcByPath(
     throw new ConfigPathError(filepath);
   }
 
-  const cfg = await importModule({ filepath, tsconfig, format: 'esm' });
+  const cfg: CoreConfig = await importModule({
+    filepath,
+    tsconfig,
+    format: 'esm',
+  });
 
-  try {
-    return coreConfigSchema.parse(cfg);
-  } catch (error) {
-    const validationError = fromError(error, {
-      messageBuilder: zodErrorMessageBuilder,
-    });
-    throw isZodErrorLike(error)
-      ? new ConfigValidationError(filepath, validationError.message)
-      : error;
-  }
+  return parseSchema(coreConfigSchema, cfg, {
+    schemaType: 'core config',
+    sourcePath: filepath,
+  });
 }
 
 export async function autoloadRc(tsconfig?: string): Promise<CoreConfig> {

--- a/packages/plugin-eslint/README.md
+++ b/packages/plugin-eslint/README.md
@@ -95,7 +95,7 @@ Detected ESLint rules are mapped to Code PushUp audits. Audit reports are calcul
 
 ### Custom groups
 
-You can extend the plugin configuration with custom groups to categorize ESLint rules according to your project's specific needs. Custom groups allow you to assign weights to individual rules, influencing their impact on the report. Rules can be defined as an object with explicit weights or as an array where each rule defaults to a weight of 1.
+You can extend the plugin configuration with custom groups to categorize ESLint rules according to your project's specific needs. Custom groups allow you to assign weights to individual rules, influencing their impact on the report. Rules can be defined as an object with explicit weights or as an array where each rule defaults to a weight of 1. Additionally, you can use wildcard patterns (`*`) to include multiple rules with similar prefixes.
 
 ```js
 import eslintPlugin from '@code-pushup/eslint-plugin';
@@ -120,7 +120,7 @@ export default {
           {
             slug: 'type-safety',
             title: 'Type safety',
-            rules: ['@typescript-eslint/no-explicit-any', '@typescript-eslint/no-unsafe-*'],
+            rules: ['@typescript-eslint/no-unsafe-*'],
           },
         ],
       },

--- a/packages/plugin-eslint/README.md
+++ b/packages/plugin-eslint/README.md
@@ -93,6 +93,42 @@ Detected ESLint rules are mapped to Code PushUp audits. Audit reports are calcul
 
 5. Run the CLI with `npx code-pushup collect` and view or upload report (refer to [CLI docs](../cli/README.md)).
 
+### Custom groups
+
+You can extend the plugin configuration with custom groups to categorize ESLint rules according to your project's specific needs. Custom groups allow you to assign weights to individual rules, influencing their impact on the report. Rules can be defined as an object with explicit weights or as an array where each rule defaults to a weight of 1.
+
+```js
+import eslintPlugin from '@code-pushup/eslint-plugin';
+
+export default {
+  // ...
+  plugins: [
+    // ...
+    await eslintPlugin(
+      { eslintrc: '.eslintrc.js', patterns: ['src/**/*.js'] },
+      {
+        groups: [
+          {
+            slug: 'modern-angular',
+            title: 'Modern Angular',
+            rules: {
+              '@angular-eslint/template/prefer-control-flow': 3,
+              '@angular-eslint/template/prefer-ngsrc': 2,
+              '@angular-eslint/component-selector': 1,
+            },
+          },
+          {
+            slug: 'type-safety',
+            title: 'Type safety',
+            rules: ['@typescript-eslint/no-explicit-any', '@typescript-eslint/no-unsafe-*'],
+          },
+        ],
+      },
+    ),
+  ],
+};
+```
+
 ### Optionally set up categories
 
 1. Reference audits (or groups) which you wish to include in custom categories (use `npx code-pushup print-config` to list audits and groups).

--- a/packages/plugin-eslint/src/lib/config.ts
+++ b/packages/plugin-eslint/src/lib/config.ts
@@ -35,7 +35,18 @@ export type ESLintPluginRunnerConfig = {
 };
 
 const customGroupRulesSchema = z.union(
-  [z.array(z.string()).min(1), z.record(z.string(), z.number())],
+  [
+    z
+      .array(z.string())
+      .min(1, 'Custom group rules must contain at least 1 element'),
+    z.record(z.string(), z.number()).refine(
+      schema => Object.keys(schema).length > 0,
+      () => ({
+        code: 'too_small',
+        message: 'Custom group rules must contain at least 1 element',
+      }),
+    ),
+  ],
   {
     description:
       'Array of rule IDs with equal weights or object mapping rule IDs to specific weights',

--- a/packages/plugin-eslint/src/lib/config.ts
+++ b/packages/plugin-eslint/src/lib/config.ts
@@ -33,3 +33,25 @@ export type ESLintPluginRunnerConfig = {
   targets: ESLintTarget[];
   slugs: string[];
 };
+
+const customGroupRulesSchema = z.union(
+  [z.array(z.string()).min(1), z.record(z.string(), z.number())],
+  {
+    description:
+      'Array of rule IDs with equal weights or object mapping rule IDs to specific weights',
+  },
+);
+
+const customGroupSchema = z.object({
+  slug: z.string({ description: 'Unique group identifier' }),
+  title: z.string({ description: 'Group display title' }),
+  description: z.string({ description: 'Group metadata' }).optional(),
+  docsUrl: z.string({ description: 'Group documentation site' }).optional(),
+  rules: customGroupRulesSchema,
+});
+export type CustomGroup = z.infer<typeof customGroupSchema>;
+
+export const eslintPluginOptionsSchema = z.object({
+  groups: z.array(customGroupSchema).optional(),
+});
+export type ESLintPluginOptions = z.infer<typeof eslintPluginOptionsSchema>;

--- a/packages/plugin-eslint/src/lib/eslint-plugin.integration.test.ts
+++ b/packages/plugin-eslint/src/lib/eslint-plugin.integration.test.ts
@@ -71,15 +71,12 @@ describe('eslintPlugin', () => {
     );
   });
 
-  it('should initialize with plugin options for custom rules', async () => {
+  it('should initialize with plugin options for custom groups', async () => {
     cwdSpy.mockReturnValue(path.join(fixturesDir, 'nx-monorepo'));
     const plugin = await eslintPlugin(
       {
         eslintrc: './packages/nx-plugin/eslint.config.js',
-        patterns: [
-          'packages/nx-plugin/**/*.ts',
-          'packages/nx-plugin/**/*.json',
-        ],
+        patterns: ['packages/nx-plugin/**/*.ts'],
       },
       {
         groups: [
@@ -114,11 +111,36 @@ describe('eslintPlugin', () => {
     );
   });
 
+  it('should throw when custom group rules are empty', async () => {
+    await expect(
+      eslintPlugin(
+        {
+          eslintrc: './packages/nx-plugin/eslint.config.js',
+          patterns: ['packages/nx-plugin/**/*.ts'],
+        },
+        {
+          groups: [{ slug: 'type-safety', title: 'Type safety', rules: [] }],
+        },
+      ),
+    ).rejects.toThrow(/Custom group rules must contain at least 1 element/);
+    await expect(
+      eslintPlugin(
+        {
+          eslintrc: './packages/nx-plugin/eslint.config.js',
+          patterns: ['packages/nx-plugin/**/*.ts'],
+        },
+        {
+          groups: [{ slug: 'type-safety', title: 'Type safety', rules: {} }],
+        },
+      ),
+    ).rejects.toThrow(/Custom group rules must contain at least 1 element/);
+  });
+
   it('should throw when invalid parameters provided', async () => {
     await expect(
       // @ts-expect-error simulating invalid non-TS config
       eslintPlugin({ eslintrc: '.eslintrc.json' }),
-    ).rejects.toThrow('patterns');
+    ).rejects.toThrow(/Invalid input/);
   });
 
   it("should throw if eslintrc file doesn't exist", async () => {

--- a/packages/plugin-eslint/src/lib/eslint-plugin.integration.test.ts
+++ b/packages/plugin-eslint/src/lib/eslint-plugin.integration.test.ts
@@ -71,6 +71,49 @@ describe('eslintPlugin', () => {
     );
   });
 
+  it('should initialize with plugin options for custom rules', async () => {
+    cwdSpy.mockReturnValue(path.join(fixturesDir, 'nx-monorepo'));
+    const plugin = await eslintPlugin(
+      {
+        eslintrc: './packages/nx-plugin/eslint.config.js',
+        patterns: [
+          'packages/nx-plugin/**/*.ts',
+          'packages/nx-plugin/**/*.json',
+        ],
+      },
+      {
+        groups: [
+          {
+            slug: 'type-safety',
+            title: 'Type safety',
+            rules: [
+              '@typescript-eslint/no-explicit-any',
+              '@typescript-eslint/no-unsafe-*',
+            ],
+          },
+        ],
+      },
+    );
+
+    expect(plugin.groups).toContainEqual({
+      slug: 'type-safety',
+      title: 'Type safety',
+      refs: [
+        { slug: 'typescript-eslint-no-explicit-any', weight: 1 },
+        {
+          slug: 'typescript-eslint-no-unsafe-declaration-merging',
+          weight: 1,
+        },
+        { slug: 'typescript-eslint-no-unsafe-function-type', weight: 1 },
+      ],
+    });
+    expect(plugin.audits).toContainEqual(
+      expect.objectContaining<Partial<Audit>>({
+        slug: 'typescript-eslint-no-explicit-any',
+      }),
+    );
+  });
+
   it('should throw when invalid parameters provided', async () => {
     await expect(
       // @ts-expect-error simulating invalid non-TS config

--- a/packages/plugin-eslint/src/lib/eslint-plugin.ts
+++ b/packages/plugin-eslint/src/lib/eslint-plugin.ts
@@ -2,6 +2,7 @@ import { createRequire } from 'node:module';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { PluginConfig } from '@code-pushup/models';
+import { parseSchema } from '@code-pushup/utils';
 import {
   type ESLintPluginConfig,
   type ESLintPluginOptions,
@@ -36,10 +37,14 @@ export async function eslintPlugin(
   config: ESLintPluginConfig,
   options?: ESLintPluginOptions,
 ): Promise<PluginConfig> {
-  const targets = eslintPluginConfigSchema.parse(config);
+  const targets = parseSchema(eslintPluginConfigSchema, config, {
+    schemaType: 'ESLint plugin config',
+  });
 
   const customGroups = options
-    ? eslintPluginOptionsSchema.parse(options).groups
+    ? parseSchema(eslintPluginOptionsSchema, options, {
+        schemaType: 'ESLint plugin options',
+      }).groups
     : undefined;
 
   const { audits, groups } = await listAuditsAndGroups(targets, customGroups);

--- a/packages/plugin-eslint/src/lib/eslint-plugin.ts
+++ b/packages/plugin-eslint/src/lib/eslint-plugin.ts
@@ -2,7 +2,12 @@ import { createRequire } from 'node:module';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { PluginConfig } from '@code-pushup/models';
-import { type ESLintPluginConfig, eslintPluginConfigSchema } from './config.js';
+import {
+  type ESLintPluginConfig,
+  type ESLintPluginOptions,
+  eslintPluginConfigSchema,
+  eslintPluginOptionsSchema,
+} from './config.js';
 import { listAuditsAndGroups } from './meta/index.js';
 import { createRunnerConfig } from './runner/index.js';
 
@@ -24,14 +29,20 @@ import { createRunnerConfig } from './runner/index.js';
  * }
  *
  * @param config Configuration options.
+ * @param options Optional settings for customizing the plugin behavior.
  * @returns Plugin configuration as a promise.
  */
 export async function eslintPlugin(
   config: ESLintPluginConfig,
+  options?: ESLintPluginOptions,
 ): Promise<PluginConfig> {
   const targets = eslintPluginConfigSchema.parse(config);
 
-  const { audits, groups } = await listAuditsAndGroups(targets);
+  const customGroups = options
+    ? eslintPluginOptionsSchema.parse(options).groups
+    : undefined;
+
+  const { audits, groups } = await listAuditsAndGroups(targets, customGroups);
 
   const runnerScriptPath = path.join(
     fileURLToPath(path.dirname(import.meta.url)),

--- a/packages/plugin-eslint/src/lib/meta/groups.ts
+++ b/packages/plugin-eslint/src/lib/meta/groups.ts
@@ -1,8 +1,10 @@
 import type { Rule } from 'eslint';
 import type { Group, GroupRef } from '@code-pushup/models';
-import { objectToKeys, slugify } from '@code-pushup/utils';
+import { objectToKeys, slugify, ui } from '@code-pushup/utils';
+import type { CustomGroup } from '../config.js';
 import { ruleToSlug } from './hash.js';
 import { type RuleData, parseRuleId } from './parse.js';
+import { expandWildcardRules } from './rules.js';
 
 type RuleType = NonNullable<Rule.RuleMetaData['type']>;
 
@@ -86,4 +88,83 @@ export function groupsFromRuleCategories(rules: RuleData[]): Group[] {
   );
 
   return groups.toSorted((a, b) => a.slug.localeCompare(b.slug));
+}
+
+export function groupsFromCustomConfig(
+  rules: RuleData[],
+  groups: CustomGroup[],
+): Group[] {
+  const rulesMap = createRulesMap(rules);
+
+  return groups.map(group => {
+    const groupRules = Array.isArray(group.rules)
+      ? Object.fromEntries(group.rules.map(rule => [rule, 1]))
+      : group.rules;
+
+    const { refs, invalidRules } = resolveGroupRefs(groupRules, rulesMap);
+
+    if (invalidRules.length > 0 && Object.entries(groupRules).length > 0) {
+      if (refs.length === 0) {
+        throw new Error(
+          `Invalid rule configuration in group ${group.slug}. All rules are invalid.`,
+        );
+      }
+      ui().logger.warning(
+        `Some rules in group ${group.slug} are invalid: ${invalidRules.join(', ')}`,
+      );
+    }
+
+    return {
+      slug: group.slug,
+      title: group.title,
+      refs,
+    };
+  });
+}
+
+export function createRulesMap(rules: RuleData[]): Record<string, RuleData[]> {
+  return rules.reduce<Record<string, RuleData[]>>(
+    (acc, rule) => ({
+      ...acc,
+      [rule.id]: [...(acc[rule.id] || []), rule],
+    }),
+    {},
+  );
+}
+
+export function resolveGroupRefs(
+  groupRules: Record<string, number>,
+  rulesMap: Record<string, RuleData[]>,
+): { refs: Group['refs']; invalidRules: string[] } {
+  const uniqueRuleIds = [...new Set(Object.keys(rulesMap))];
+
+  return Object.entries(groupRules).reduce<{
+    refs: Group['refs'];
+    invalidRules: string[];
+  }>(
+    (acc, [rule, weight]) => {
+      const matchedRuleIds = rule.endsWith('*')
+        ? expandWildcardRules(rule, uniqueRuleIds)
+        : [rule];
+
+      const matchedRefs = matchedRuleIds.flatMap(ruleId => {
+        const matchingRules = rulesMap[ruleId] || [];
+        const weightPerRule = weight / matchingRules.length;
+
+        return matchingRules.map(ruleData => ({
+          slug: ruleToSlug(ruleData),
+          weight: weightPerRule,
+        }));
+      });
+
+      return {
+        refs: [...acc.refs, ...matchedRefs],
+        invalidRules:
+          matchedRefs.length > 0
+            ? acc.invalidRules
+            : [...acc.invalidRules, rule],
+      };
+    },
+    { refs: [], invalidRules: [] },
+  );
 }

--- a/packages/plugin-eslint/src/lib/meta/groups.ts
+++ b/packages/plugin-eslint/src/lib/meta/groups.ts
@@ -136,15 +136,13 @@ export function resolveGroupRefs(
   groupRules: Record<string, number>,
   rulesMap: Record<string, RuleData[]>,
 ): { refs: Group['refs']; invalidRules: string[] } {
-  const uniqueRuleIds = [...new Set(Object.keys(rulesMap))];
-
   return Object.entries(groupRules).reduce<{
     refs: Group['refs'];
     invalidRules: string[];
   }>(
     (acc, [rule, weight]) => {
       const matchedRuleIds = rule.endsWith('*')
-        ? expandWildcardRules(rule, uniqueRuleIds)
+        ? expandWildcardRules(rule, Object.keys(rulesMap))
         : [rule];
 
       const matchedRefs = matchedRuleIds.flatMap(ruleId => {

--- a/packages/plugin-eslint/src/lib/meta/groups.unit.test.ts
+++ b/packages/plugin-eslint/src/lib/meta/groups.unit.test.ts
@@ -288,14 +288,22 @@ describe('groupsFromCustomConfig', () => {
   });
 
   it('should log a warning when some of custom group rules are invalid', () => {
-    groupsFromCustomConfig(eslintRules, [
+    expect(
+      groupsFromCustomConfig(eslintRules, [
+        {
+          slug: 'custom-group',
+          title: 'Custom Group',
+          rules: {
+            'react/jsx-key': 3,
+            'invalid-rule': 3,
+          },
+        },
+      ]),
+    ).toEqual<Group[]>([
       {
         slug: 'custom-group',
         title: 'Custom Group',
-        rules: {
-          'react/jsx-key': 3,
-          'invalid-rule': 3,
-        },
+        refs: [{ slug: 'react-jsx-key', weight: 3 }],
       },
     ]);
     expect(ui()).toHaveLogged(

--- a/packages/plugin-eslint/src/lib/meta/index.ts
+++ b/packages/plugin-eslint/src/lib/meta/index.ts
@@ -1,6 +1,10 @@
 import type { Audit, Group } from '@code-pushup/models';
-import type { ESLintTarget } from '../config.js';
-import { groupsFromRuleCategories, groupsFromRuleTypes } from './groups.js';
+import type { CustomGroup, ESLintTarget } from '../config.js';
+import {
+  groupsFromCustomConfig,
+  groupsFromRuleCategories,
+  groupsFromRuleTypes,
+} from './groups.js';
 import { listRules } from './rules.js';
 import { ruleToAudit } from './transform.js';
 
@@ -9,14 +13,20 @@ export { detectConfigVersion, type ConfigFormat } from './versions/index.js';
 
 export async function listAuditsAndGroups(
   targets: ESLintTarget[],
+  customGroups: CustomGroup[] | undefined,
 ): Promise<{ audits: Audit[]; groups: Group[] }> {
   const rules = await listRules(targets);
+
+  const resolvedCustomGroups = customGroups
+    ? groupsFromCustomConfig(rules, customGroups)
+    : [];
 
   const audits = rules.map(ruleToAudit);
 
   const groups = [
     ...groupsFromRuleTypes(rules),
     ...groupsFromRuleCategories(rules),
+    ...resolvedCustomGroups,
   ];
 
   return { audits, groups };

--- a/packages/plugin-eslint/src/lib/meta/rules.ts
+++ b/packages/plugin-eslint/src/lib/meta/rules.ts
@@ -27,3 +27,11 @@ function mergeRuleIntoMap(map: RulesMap, rule: RuleData): RulesMap {
     },
   };
 }
+
+export function expandWildcardRules(
+  wildcard: string,
+  rules: string[],
+): string[] {
+  const prefix = wildcard.slice(0, -1);
+  return rules.filter(rule => rule.startsWith(prefix));
+}

--- a/packages/plugin-eslint/src/lib/meta/rules.unit.test.ts
+++ b/packages/plugin-eslint/src/lib/meta/rules.unit.test.ts
@@ -1,0 +1,45 @@
+import { expandWildcardRules } from './rules.js';
+
+describe('expandWildcardRules', () => {
+  const rules = [
+    'no-var',
+    'no-const-assign',
+    'no-debugger',
+    'react/jsx-key',
+    'react/react-in-jsx-scope',
+    'react/no-deprecated',
+    '@typescript-eslint/no-array-constructor',
+  ];
+
+  it('should expand wildcard rules correctly', () => {
+    expect(expandWildcardRules('react/*', rules)).toEqual([
+      'react/jsx-key',
+      'react/react-in-jsx-scope',
+      'react/no-deprecated',
+    ]);
+  });
+
+  it('should return an empty array when no rules match the wildcard', () => {
+    expect(expandWildcardRules('non-existent/*', rules)).toEqual([]);
+  });
+
+  it('should handle wildcards matching a single rule', () => {
+    expect(expandWildcardRules('no-var*', rules)).toEqual(['no-var']);
+  });
+
+  it('should return an empty array when the rules are empty', () => {
+    expect(expandWildcardRules('react/*', [])).toEqual([]);
+  });
+
+  it('should return all rules when a wildcard has no valid prefix', () => {
+    expect(expandWildcardRules('*', rules)).toEqual(rules);
+  });
+
+  it('should handle a wildcard with a single-character prefix', () => {
+    expect(expandWildcardRules('n*', rules)).toEqual([
+      'no-var',
+      'no-const-assign',
+      'no-debugger',
+    ]);
+  });
+});

--- a/packages/plugin-eslint/tsconfig.test.json
+++ b/packages/plugin-eslint/tsconfig.test.json
@@ -12,6 +12,7 @@
     "src/**/*.test.tsx",
     "src/**/*.test.js",
     "src/**/*.test.jsx",
-    "src/**/*.d.ts"
+    "src/**/*.d.ts",
+    "../../testing/test-setup/src/vitest.d.ts"
   ]
 }

--- a/packages/plugin-eslint/vite.config.unit.ts
+++ b/packages/plugin-eslint/vite.config.unit.ts
@@ -25,6 +25,8 @@ export default defineConfig({
       '../../testing/test-setup/src/lib/console.mock.ts',
       '../../testing/test-setup/src/lib/fs.mock.ts',
       '../../testing/test-setup/src/lib/reset.mocks.ts',
+      '../../testing/test-setup/src/lib/cliui.mock.ts',
+      '../../testing/test-setup/src/lib/extend/ui-logger.matcher.ts',
     ],
   },
 });

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -37,6 +37,7 @@
     "multi-progress-bars": "^5.0.3",
     "semver": "^7.6.0",
     "simple-git": "^3.20.0",
+    "zod": "^3.23.8",
     "zod-validation-error": "^3.4.0"
   }
 }

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -123,4 +123,4 @@ export type {
   WithRequired,
 } from './lib/types.js';
 export { verboseUtils } from './lib/verbose-utils.js';
-export { zodErrorMessageBuilder } from './lib/zod-validation.js';
+export { parseSchema, SchemaValidationError } from './lib/zod-validation.js';


### PR DESCRIPTION
Closes #897 

This PR introduces support for custom groups in the ESLint plugin, enabling users to define and categorize ESLint rules with custom weights and configurations.