### PR TITLE
feat(models): auto-generate JSDoc annotations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@code-pushup/portal-client": "^0.9.0",
         "@isaacs/cliui": "^8.0.2",
         "@nx/devkit": "19.8.13",
-        "@poppinss/cliui": "^6.4.1",
+        "@poppinss/cliui": "6.4.1",
         "@swc/helpers": "0.5.13",
         "ansis": "^3.3.2",
         "build-md": "^0.4.2",
@@ -95,6 +95,7 @@
         "prettier": "^3.4.1",
         "react": "18.3.1",
         "react-dom": "18.3.1",
+        "ts-patch": "^3.3.0",
         "tsconfig-paths": "^4.2.0",
         "tsx": "^4.19.0",
         "type-fest": "^4.26.1",
@@ -19361,6 +19362,16 @@
         "json-buffer": "3.0.1"
       }
     },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/kleur": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
@@ -24977,6 +24988,165 @@
         "@swc/wasm": {
           "optional": true
         }
+      }
+    },
+    "node_modules/ts-patch": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/ts-patch/-/ts-patch-3.3.0.tgz",
+      "integrity": "sha512-zAOzDnd5qsfEnjd9IGy1IRuvA7ygyyxxdxesbhMdutt8AHFjD8Vw8hU2rMF89HX1BKRWFYqKHrO8Q6lw0NeUZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "global-prefix": "^4.0.0",
+        "minimist": "^1.2.8",
+        "resolve": "^1.22.2",
+        "semver": "^7.6.3",
+        "strip-ansi": "^6.0.1"
+      },
+      "bin": {
+        "ts-patch": "bin/ts-patch.js",
+        "tspc": "bin/tspc.js"
+      }
+    },
+    "node_modules/ts-patch/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/ts-patch/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/ts-patch/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/ts-patch/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ts-patch/node_modules/global-prefix": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-4.0.0.tgz",
+      "integrity": "sha512-w0Uf9Y9/nyHinEk5vMJKRie+wa4kR5hmDbEhGGds/kG1PwGLLHKRoNMeJOyCQjjBkANlnScqgzcFwGHgmgLkVA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ini": "^4.1.3",
+        "kind-of": "^6.0.3",
+        "which": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/ts-patch/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ts-patch/node_modules/ini": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.3.tgz",
+      "integrity": "sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/ts-patch/node_modules/isexe": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
+      "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/ts-patch/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ts-patch/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ts-patch/node_modules/which": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
+      "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^3.1.1"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/tsconfig-paths": {

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "prettier": "^3.4.1",
     "react": "18.3.1",
     "react-dom": "18.3.1",
+    "ts-patch": "^3.3.0",
     "tsconfig-paths": "^4.2.0",
     "tsx": "^4.19.0",
     "type-fest": "^4.26.1",

--- a/packages/models/eslint.config.js
+++ b/packages/models/eslint.config.js
@@ -4,7 +4,7 @@ import baseConfig from '../../eslint.config.js';
 export default tseslint.config(
   ...baseConfig,
   {
-    files: ['**/*.ts'],
+    files: ['/**/*.ts'],
     languageOptions: {
       parserOptions: {
         projectService: true,
@@ -17,5 +17,8 @@ export default tseslint.config(
     rules: {
       '@nx/dependency-checks': 'error',
     },
+  },
+  {
+    ignores: ['packages/models/transformers/**/*.ts'],
   },
 );

--- a/packages/models/project.json
+++ b/packages/models/project.json
@@ -3,6 +3,7 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "packages/models/src",
   "projectType": "library",
+  "implicitDependencies": ["models-transformers"],
   "targets": {
     "build": {
       "executor": "@nx/js:tsc",

--- a/packages/models/transformers/eslint.config.cjs
+++ b/packages/models/transformers/eslint.config.cjs
@@ -1,0 +1,11 @@
+const baseConfig = require('../../../eslint.config.js').default;
+
+module.exports = [
+  ...baseConfig,
+  {
+    files: ['**/*.json'],
+    rules: {
+      '@nx/dependency-checks': 'error',
+    },
+  },
+];

--- a/packages/models/transformers/package.json
+++ b/packages/models/transformers/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@code-pushup/models-transformers",
+  "version": "0.0.0",
+  "description": "TypeScript transformers enhancing models with JSDoc and schema metadata",
+  "type": "commonjs",
+  "main": "./src/index.js",
+  "dependencies": {
+    "typescript": "^5.5.4",
+    "ts-patch": "^3.3.0"
+  }
+}

--- a/packages/models/transformers/project.json
+++ b/packages/models/transformers/project.json
@@ -1,0 +1,24 @@
+{
+  "name": "models-transformers",
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/models/transformers/src",
+  "projectType": "library",
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": ["{options.outputPath}"],
+      "dependsOn": [{ "target": "pre-build" }],
+      "options": {
+        "outputPath": "dist/packages/models-transformers",
+        "main": "packages/models/transformers/src/index.ts",
+        "tsConfig": "packages/models/transformers/tsconfig.lib.json"
+      }
+    },
+    "pre-build": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "npx ts-patch install"
+      }
+    }
+  }
+}

--- a/packages/models/transformers/src/index.ts
+++ b/packages/models/transformers/src/index.ts
@@ -1,0 +1,4 @@
+const transformers = require('./lib/transformers.js');
+
+module.exports = transformers;
+module.exports.default = transformers;

--- a/packages/models/transformers/src/lib/transformers.ts
+++ b/packages/models/transformers/src/lib/transformers.ts
@@ -1,0 +1,50 @@
+import type { PluginConfig, TransformerExtras } from 'ts-patch';
+import type * as ts from 'typescript';
+
+const tsInstance: typeof ts = require('typescript');
+
+const BASE_URL =
+  'https://github.com/code-pushup/cli/blob/main/packages/models/docs/models-reference.md';
+
+function generateJSDocComment(typeName: string): string {
+  const markdownLink = `${BASE_URL}#${typeName.toLowerCase()}`;
+  return `*
+ * Type Definition: \`${typeName}\`
+ * 
+ * This type is derived from a Zod schema and represents 
+ * the validated structure of \`${typeName}\` used within the application.
+ * 
+ * @see {@link ${markdownLink}}
+ `;
+}
+
+function annotateTypeDefinitions(
+  _program: ts.Program,
+  _pluginConfig: PluginConfig,
+  extras?: TransformerExtras,
+): ts.TransformerFactory<ts.SourceFile> {
+  const tsLib = extras?.ts ?? tsInstance;
+  return (context: ts.TransformationContext) => {
+    const visitor = (node: ts.Node): ts.Node => {
+      if (
+        tsLib.isTypeAliasDeclaration(node) ||
+        tsLib.isInterfaceDeclaration(node)
+      ) {
+        const jsDocComment = generateJSDocComment(node.name.text);
+        tsLib.addSyntheticLeadingComment(
+          node,
+          tsLib.SyntaxKind.MultiLineCommentTrivia,
+          jsDocComment,
+          true,
+        );
+        return node;
+      }
+      return tsLib.visitEachChild(node, visitor, context);
+    };
+    return (sourceFile: ts.SourceFile) => {
+      return tsLib.visitNode(sourceFile, visitor, tsLib.isSourceFile);
+    };
+  };
+}
+
+module.exports = annotateTypeDefinitions;

--- a/packages/models/transformers/tsconfig.json
+++ b/packages/models/transformers/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "verbatimModuleSyntax": false
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/models/transformers/tsconfig.lib.json
+++ b/packages/models/transformers/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/packages/models-transformers",
+    "rootDir": "./",
+    "module": "commonjs",
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/models/tsconfig.lib.json
+++ b/packages/models/tsconfig.lib.json
@@ -3,7 +3,13 @@
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
     "declaration": true,
-    "types": ["node"]
+    "types": ["node"],
+    "plugins": [
+      {
+        "transform": "./dist/packages/models-transformers",
+        "afterDeclarations": true
+      }
+    ]
   },
   "include": ["src/**/*.ts"],
   "exclude": [


### PR DESCRIPTION
Closes #827 

This PR introduces a TypeScript transformer that automatically generates JSDoc annotations for type definitions within the `models` package. The transformer ensures that all Zod-based schemas are documented with reference links, providing easy navigation to Markdown documentation.

<details>
  <summary>Demo</summary>
  <img width="822" src="https://github.com/user-attachments/assets/40c1a2e2-b340-4a5d-a9a3-16074defb913" />
</details>