### PR TITLE
fix: explicitly exit process with successful code to not leave cli hanging

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -4,3 +4,7 @@ import { cli } from './lib/cli.js';
 
 // bootstrap Yargs, parse arguments and execute command
 await cli(hideBin(process.argv)).argv;
+
+// we need to explicitly exit with successful code otherwise we risk hanging process in certain situations
+// eslint-disable-next-line n/no-process-exit
+process.exit(0);


### PR DESCRIPTION
CLI hangs in certain situations, we do open many sub processes and some of them maybe don't exit properly.
For immediate fix we need to explicitly exist with successful code.

closes #468 