### PR TITLE
feat(ci): add skipComment option, ensure head ref is checked out

### DIFF
--- a/packages/ci/README.md
+++ b/packages/ci/README.md
@@ -107,6 +107,7 @@ Optionally, you can override default options for further customization:
 | `bin`              | `string`                  | `'npx --no-install code-pushup'` | Command for executing Code PushUp CLI                                                                                                                    |
 | `detectNewIssues`  | `boolean`                 | `true`                           | Toggles if new issues should be detected and returned in `newIssues` property                                                                            |
 | `logger`           | `Logger`                  | `console`                        | Logger for reporting progress and encountered problems                                                                                                   |
+| `skipComment`      | `boolean`                 | `false`                          | Toggles if comparison comment is posted to PR                                                                                                            |
 
 [^1]: By default, the `code-pushup.config` file is autodetected as described in [`@code-pushup/cli` docs](../cli/README.md#configuration).
 

--- a/packages/ci/src/lib/constants.ts
+++ b/packages/ci/src/lib/constants.ts
@@ -13,4 +13,5 @@ export const DEFAULT_SETTINGS: Settings = {
   detectNewIssues: true,
   logger: console,
   nxProjectsFilter: '--with-target={task}',
+  skipComment: false,
 };

--- a/packages/ci/src/lib/models.ts
+++ b/packages/ci/src/lib/models.ts
@@ -19,6 +19,7 @@ export type Options = {
   debug?: boolean;
   detectNewIssues?: boolean;
   logger?: Logger;
+  skipComment?: boolean;
 };
 
 /**

--- a/packages/ci/src/lib/run-monorepo.ts
+++ b/packages/ci/src/lib/run-monorepo.ts
@@ -33,6 +33,7 @@ import {
   type RunEnv,
   checkPrintConfig,
   compareReports,
+  ensureHeadBranch,
   loadCachedBaseReport,
   printPersistConfig,
   runInBaseBranch,
@@ -46,6 +47,8 @@ export async function runInMonorepoMode(
   const { logger, directory } = settings;
 
   logger.info('Running Code PushUp in monorepo mode');
+
+  await ensureHeadBranch(env);
 
   const { projects, runManyCommand } = await listMonorepoProjects(settings);
   const projectResults = runManyCommand

--- a/packages/ci/src/lib/run-monorepo.ts
+++ b/packages/ci/src/lib/run-monorepo.ts
@@ -58,6 +58,7 @@ export async function runInMonorepoMode(
   const diffJsonPaths = projectResults
     .map(({ files }) => files.diff?.json)
     .filter((file): file is string => file != null);
+
   if (diffJsonPaths.length > 0) {
     const tmpDiffPath = await runMergeDiffs(
       diffJsonPaths,
@@ -73,12 +74,14 @@ export async function runInMonorepoMode(
       await copyFile(tmpDiffPath, diffPath);
       logger.debug(`Copied ${tmpDiffPath} to ${diffPath}`);
     }
-    const commentId = await commentOnPR(tmpDiffPath, api, logger);
+    const commentId = settings.skipComment
+      ? null
+      : await commentOnPR(tmpDiffPath, api, logger);
     return {
       mode: 'monorepo',
       projects: projectResults,
-      commentId,
       diffPath,
+      ...(commentId != null && { commentId }),
     };
   }
 

--- a/packages/ci/src/lib/run-standalone.ts
+++ b/packages/ci/src/lib/run-standalone.ts
@@ -1,6 +1,6 @@
 import { commentOnPR } from './comment.js';
 import type { StandaloneRunResult } from './models.js';
-import { type RunEnv, runOnProject } from './run-utils.js';
+import { type RunEnv, ensureHeadBranch, runOnProject } from './run-utils.js';
 
 export async function runInStandaloneMode(
   env: RunEnv,
@@ -11,6 +11,8 @@ export async function runInStandaloneMode(
   } = env;
 
   logger.info('Running Code PushUp in standalone project mode');
+
+  await ensureHeadBranch(env);
 
   const { files, newIssues } = await runOnProject(null, env);
 

--- a/packages/ci/src/lib/run-standalone.ts
+++ b/packages/ci/src/lib/run-standalone.ts
@@ -5,10 +5,8 @@ import { type RunEnv, ensureHeadBranch, runOnProject } from './run-utils.js';
 export async function runInStandaloneMode(
   env: RunEnv,
 ): Promise<StandaloneRunResult> {
-  const {
-    api,
-    settings: { logger },
-  } = env;
+  const { api, settings } = env;
+  const { logger } = settings;
 
   logger.info('Running Code PushUp in standalone project mode');
 
@@ -17,7 +15,7 @@ export async function runInStandaloneMode(
   const { files, newIssues } = await runOnProject(null, env);
 
   const commentMdPath = files.diff?.md;
-  if (commentMdPath) {
+  if (!settings.skipComment && commentMdPath) {
     const commentId = await commentOnPR(commentMdPath, api, logger);
     return {
       mode: 'standalone',

--- a/packages/ci/src/lib/run-utils.ts
+++ b/packages/ci/src/lib/run-utils.ts
@@ -223,6 +223,13 @@ export async function loadCachedBaseReport(
   return null;
 }
 
+export async function ensureHeadBranch({ refs, git }: RunEnv): Promise<void> {
+  const { head } = refs;
+  if ((await git.revparse('HEAD')) !== (await git.revparse(head.ref))) {
+    await git.checkout(['-f', head.ref]);
+  }
+}
+
 export async function runInBaseBranch<T>(
   base: GitBranch,
   env: RunEnv,


### PR DESCRIPTION
- Runs `git checkout -f ${refs.head.ref}` in case set to other than current HEAD. This is a preparation for new custom source ref GitLab input.
- New `skipComment` option added (`false` by default), so that PR/MR comment can be turned off easily. Will follow-up with exposing this as input for GitLab and GitHub.