### PR TITLE
fix: add `toSorted` polyfill as hotfix for bug in GitHub actions runner

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,6 +1,9 @@
 #! /usr/bin/env node
 import { hideBin } from 'yargs/helpers';
 import { cli } from './lib/cli.js';
+// FIXME: this is a hot fix for github action running in node 18 instead of node 20
+// eslint-disable-next-line import/no-unassigned-import
+import './lib/polyfills.js';
 
 // bootstrap Yargs, parse arguments and execute command
 await cli(hideBin(process.argv)).argv;

--- a/packages/cli/src/lib/polyfills.ts
+++ b/packages/cli/src/lib/polyfills.ts
@@ -1,0 +1,9 @@
+if (!Array.prototype.toSorted) {
+  // eslint-disable-next-line functional/immutable-data
+  Array.prototype.toSorted = function <T>(
+    this: T[],
+    compareFn?: (a: T, b: T) => number,
+  ): T[] {
+    return [...this].sort(compareFn);
+  };
+}


### PR DESCRIPTION
The runner with `use: 'node20'` in our GitHub action does not respect the Node 20 requirement and runs on Node 18 anyway, GitHub did not release a Node 22 runner for quite some time now and they do not communicate their plans at all, thus only reasonable thing we can do right now it to include a polyfill as execution of our code in action runner does not work and fails with no error in CI