### PR TITLE
fix(ci): prevent ambigious ref when checking head

### DIFF
--- a/e2e/plugin-jsdocs-e2e/tests/__snapshots__/report.txt
+++ b/e2e/plugin-jsdocs-e2e/tests/__snapshots__/report.txt
@@ -1,6 +1,6 @@
 Code PushUp CLI
 [ info ] Run collect...
-Code PushUp Report - @code-pushup/core@0.57.0
+Code PushUp Report - @code-pushup/core@<version>
 
 
 JSDoc coverage audits

--- a/e2e/plugin-jsdocs-e2e/tests/collect.e2e.test.ts
+++ b/e2e/plugin-jsdocs-e2e/tests/collect.e2e.test.ts
@@ -56,9 +56,9 @@ describe('PLUGIN collect report with jsdocs-plugin NPM package', () => {
 
     expect(code).toBe(0);
 
-    expect(removeColorCodes(stdout)).toMatchFileSnapshot(
-      '__snapshots__/report.txt',
-    );
+    expect(
+      removeColorCodes(stdout).replace(/@\d+\.\d+\.\d+/, '@<version>'),
+    ).toMatchFileSnapshot('__snapshots__/report.txt');
 
     const report = await readJsonFile(
       path.join(angularOutputDir, 'report.json'),

--- a/packages/ci/src/lib/run-utils.ts
+++ b/packages/ci/src/lib/run-utils.ts
@@ -225,7 +225,7 @@ export async function loadCachedBaseReport(
 
 export async function ensureHeadBranch({ refs, git }: RunEnv): Promise<void> {
   const { head } = refs;
-  if ((await git.revparse('HEAD')) !== (await git.revparse(head.ref))) {
+  if (head.sha !== (await git.revparse('HEAD'))) {
     await git.checkout(['-f', head.ref]);
   }
 }


### PR DESCRIPTION
- Fixes Git error introduced in #938, discovered when [testing new version in GitLab pipelines](https://gitlab.com/code-pushup/gitlab-pipelines-template/-/jobs/9168638774#L60).
- Also fixes [flaky E2E test assertion in JSDocs plugin](https://github.com/code-pushup/cli/actions/runs/13388341977/job/37390107342?pr=939#step:6:700).