### PR TITLE
fix(ci): prevent unknown pathspec error for custom base ref

### DIFF
--- a/packages/ci/src/lib/run-utils.ts
+++ b/packages/ci/src/lib/run-utils.ts
@@ -241,7 +241,7 @@ export async function runInBaseBranch<T>(
   } = env;
 
   await git.fetch('origin', base.ref, ['--depth=1']);
-  await git.checkout(['-f', base.ref]);
+  await git.checkout(['-f', base.sha]);
   logger.info(`Switched to base branch ${base.ref}`);
 
   const result = await fn();


### PR DESCRIPTION
The [`git checkout` command errors for custom target refs](https://gitlab.com/code-pushup/gitlab-pipelines-template/-/jobs/9170064748#L110) (shallow fetch) specified by branch/tag name, so the commit SHA must be used.