### PR TITLE
feat(models): do not throw if docs url invalid, treat as missing and log warning

### DIFF
--- a/packages/models/src/lib/audit.unit.test.ts
+++ b/packages/models/src/lib/audit.unit.test.ts
@@ -23,14 +23,18 @@ describe('auditSchema', () => {
     ).not.toThrow();
   });
 
-  it('should throw for an invalid URL', () => {
-    expect(() =>
+  it('should ignore invalid docs URL', () => {
+    expect(
       auditSchema.parse({
         slug: 'consistent-test-it',
         title: 'Use a consistent test function.',
         docsUrl: 'invalid-url',
       } satisfies Audit),
-    ).toThrow('Invalid url');
+    ).toEqual<Audit>({
+      slug: 'consistent-test-it',
+      title: 'Use a consistent test function.',
+      docsUrl: '',
+    });
   });
 });
 

--- a/packages/models/src/lib/implementation/schemas.ts
+++ b/packages/models/src/lib/implementation/schemas.ts
@@ -53,8 +53,21 @@ export const urlSchema = z.string().url();
 /**  Schema for a docsUrl */
 export const docsUrlSchema = urlSchema
   .optional()
-  .or(z.literal(''))
-  .describe('Documentation site'); // allow empty string (no URL validation)
+  .or(z.literal('')) // allow empty string (no URL validation)
+  // eslint-disable-next-line unicorn/prefer-top-level-await, unicorn/catch-error-name
+  .catch(ctx => {
+    // if only URL validation fails, supress error since this metadata is optional anyway
+    if (
+      ctx.error.errors.length === 1 &&
+      ctx.error.errors[0]?.code === 'invalid_string' &&
+      ctx.error.errors[0].validation === 'url'
+    ) {
+      console.warn(`Ignoring invalid docsUrl: ${ctx.input}`);
+      return '';
+    }
+    throw ctx.error;
+  })
+  .describe('Documentation site');
 
 /** Schema for a title of a plugin, category and audit */
 export const titleSchema = z

--- a/packages/models/src/lib/implementation/schemas.unit.test.ts
+++ b/packages/models/src/lib/implementation/schemas.unit.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   type TableCellValue,
+  docsUrlSchema,
   tableCellValueSchema,
   weightSchema,
 } from './schemas.js';
@@ -32,5 +33,34 @@ describe('weightSchema', () => {
 
   it('should throw for negative number', () => {
     expect(() => weightSchema.parse(-1)).toThrow('too_small');
+  });
+});
+
+describe('docsUrlSchema', () => {
+  it('should accept a valid URL', () => {
+    expect(() =>
+      docsUrlSchema.parse(
+        'https://eslint.org/docs/latest/rules/no-unused-vars',
+      ),
+    ).not.toThrow();
+  });
+
+  it('should accept an empty string', () => {
+    expect(() => docsUrlSchema.parse('')).not.toThrow();
+  });
+
+  it('should tolerate invalid URL - treat as missing and log warning', () => {
+    expect(
+      docsUrlSchema.parse(
+        '/home/user/project/tools/eslint-rules/rules/my-custom-rule.ts',
+      ),
+    ).toBe('');
+    expect(console.warn).toHaveBeenCalledWith(
+      'Ignoring invalid docsUrl: /home/user/project/tools/eslint-rules/rules/my-custom-rule.ts',
+    );
+  });
+
+  it('should throw if not a string', () => {
+    expect(() => docsUrlSchema.parse(false)).toThrow('invalid_type');
   });
 });


### PR DESCRIPTION
The [`@nx/eslint:workspace-rule` generator](https://nx.dev/nx-api/eslint/generators/workspace-rule) uses `__filename` as `meta.docs.url` by default. This causes a validation error for the plugin config's `audit.docsUrl`, as a file path doesn't pass our `z.string().url()` validation. 

To reduce friction for users, the validation has been tweaked to tolerate invalid URLs. A warning is logged, and the invalid URL is removed from the metadata to prevent broken links.

Implemented using Zod's [`.catch()`](https://zod.dev/?id=catch) method.