### PR TITLE
fix(utils): replace misleading commit labels in markdown diff

### DIFF
--- a/e2e/ci-e2e/tests/__snapshots__/basic-report-diff.md
+++ b/e2e/ci-e2e/tests/__snapshots__/basic-report-diff.md
@@ -1,6 +1,6 @@
 # Code PushUp
 
-🥳 Code PushUp report has **improved** – compared target commit `<commit-sha>` with source commit `<commit-sha>`.
+🥳 Code PushUp report has **improved** – compared current commit `<commit-sha>` with previous commit `<commit-sha>`.
 
 <details>
 <summary>👍 <strong>1</strong> audit improved</summary>

--- a/e2e/ci-e2e/tests/__snapshots__/npm-workspaces-report-diff.md
+++ b/e2e/ci-e2e/tests/__snapshots__/npm-workspaces-report-diff.md
@@ -1,6 +1,6 @@
 # Code PushUp
 
-🥳 Code PushUp report has **improved** – compared target commit `<commit-sha>` with source commit `<commit-sha>`.
+🥳 Code PushUp report has **improved** – compared current commit `<commit-sha>` with previous commit `<commit-sha>`.
 
 ## 💼 Project `@example/core`
 

--- a/e2e/ci-e2e/tests/__snapshots__/nx-monorepo-report-diff.md
+++ b/e2e/ci-e2e/tests/__snapshots__/nx-monorepo-report-diff.md
@@ -1,6 +1,6 @@
 # Code PushUp
 
-🤨 Code PushUp report has both **improvements and regressions** – compared target commit `<commit-sha>` with source commit `<commit-sha>`.
+🤨 Code PushUp report has both **improvements and regressions** – compared current commit `<commit-sha>` with previous commit `<commit-sha>`.
 
 ## 💼 Project `api`
 

--- a/e2e/cli-e2e/tests/__snapshots__/compare.report-diff.md
+++ b/e2e/cli-e2e/tests/__snapshots__/compare.report-diff.md
@@ -1,6 +1,6 @@
 # Code PushUp
 
-🥳 Code PushUp report has **improved** – compared target commit `<commit-sha>` with source commit `<commit-sha>`.
+🥳 Code PushUp report has **improved** – compared current commit `<commit-sha>` with previous commit `<commit-sha>`.
 
 ## 🏷️ Categories
 

--- a/packages/utils/src/lib/reports/__snapshots__/report-diff-added.md
+++ b/packages/utils/src/lib/reports/__snapshots__/report-diff-added.md
@@ -1,6 +1,6 @@
 # Code PushUp
 
-😟 Code PushUp report has **regressed** – compared target commit 0123456789abcdef0123456789abcdef01234567 with source commit abcdef0123456789abcdef0123456789abcdef01.
+😟 Code PushUp report has **regressed** – compared current commit 0123456789abcdef0123456789abcdef01234567 with previous commit abcdef0123456789abcdef0123456789abcdef01.
 
 ## 🏷️ Categories
 

--- a/packages/utils/src/lib/reports/__snapshots__/report-diff-changed.md
+++ b/packages/utils/src/lib/reports/__snapshots__/report-diff-changed.md
@@ -1,6 +1,6 @@
 # Code PushUp
 
-🤨 Code PushUp report has both **improvements and regressions** – compared target commit 0123456789abcdef0123456789abcdef01234567 with source commit abcdef0123456789abcdef0123456789abcdef01.
+🤨 Code PushUp report has both **improvements and regressions** – compared current commit 0123456789abcdef0123456789abcdef01234567 with previous commit abcdef0123456789abcdef0123456789abcdef01.
 
 ## 🏷️ Categories
 

--- a/packages/utils/src/lib/reports/__snapshots__/report-diff-improved.md
+++ b/packages/utils/src/lib/reports/__snapshots__/report-diff-improved.md
@@ -1,6 +1,6 @@
 # Code PushUp
 
-🥳 Code PushUp report has **improved** – compared target commit 0123456789abcdef0123456789abcdef01234567 with source commit abcdef0123456789abcdef0123456789abcdef01.
+🥳 Code PushUp report has **improved** – compared current commit 0123456789abcdef0123456789abcdef01234567 with previous commit abcdef0123456789abcdef0123456789abcdef01.
 
 ## 🏷️ Categories
 

--- a/packages/utils/src/lib/reports/__snapshots__/report-diff-many-audits.md
+++ b/packages/utils/src/lib/reports/__snapshots__/report-diff-many-audits.md
@@ -1,6 +1,6 @@
 # Code PushUp
 
-😟 Code PushUp report has **regressed** – compared target commit 0123456789abcdef0123456789abcdef01234567 with source commit abcdef0123456789abcdef0123456789abcdef01.
+😟 Code PushUp report has **regressed** – compared current commit 0123456789abcdef0123456789abcdef01234567 with previous commit abcdef0123456789abcdef0123456789abcdef01.
 
 <details>
 <summary>👎 <strong>123</strong> audits regressed</summary>

--- a/packages/utils/src/lib/reports/__snapshots__/report-diff-minimal.md
+++ b/packages/utils/src/lib/reports/__snapshots__/report-diff-minimal.md
@@ -1,6 +1,6 @@
 # Code PushUp
 
-😟 Code PushUp report has **regressed** – compared target commit 0123456789abcdef0123456789abcdef01234567 with source commit abcdef0123456789abcdef0123456789abcdef01.
+😟 Code PushUp report has **regressed** – compared current commit 0123456789abcdef0123456789abcdef01234567 with previous commit abcdef0123456789abcdef0123456789abcdef01.
 
 <details>
 <summary>👎 <strong>1</strong> audit regressed</summary>

--- a/packages/utils/src/lib/reports/__snapshots__/report-diff-mixed.md
+++ b/packages/utils/src/lib/reports/__snapshots__/report-diff-mixed.md
@@ -1,6 +1,6 @@
 # Code PushUp
 
-🤨 Code PushUp report has both **improvements and regressions** – compared target commit 0123456789abcdef0123456789abcdef01234567 with source commit abcdef0123456789abcdef0123456789abcdef01.
+🤨 Code PushUp report has both **improvements and regressions** – compared current commit 0123456789abcdef0123456789abcdef01234567 with previous commit abcdef0123456789abcdef0123456789abcdef01.
 
 ## 🏷️ Categories
 

--- a/packages/utils/src/lib/reports/__snapshots__/report-diff-monorepo-changed.md
+++ b/packages/utils/src/lib/reports/__snapshots__/report-diff-monorepo-changed.md
@@ -1,6 +1,6 @@
 # Code PushUp
 
-🤨 Code PushUp report has both **improvements and regressions** – compared target commit 0123456789abcdef0123456789abcdef01234567 with source commit abcdef0123456789abcdef0123456789abcdef01.
+🤨 Code PushUp report has both **improvements and regressions** – compared current commit 0123456789abcdef0123456789abcdef01234567 with previous commit abcdef0123456789abcdef0123456789abcdef01.
 
 ## 💼 Project `web`
 

--- a/packages/utils/src/lib/reports/__snapshots__/report-diff-monorepo-unchanged.md
+++ b/packages/utils/src/lib/reports/__snapshots__/report-diff-monorepo-unchanged.md
@@ -1,6 +1,6 @@
 # Code PushUp
 
-😐 Code PushUp report is **unchanged** – compared target commit 0123456789abcdef0123456789abcdef01234567 with source commit abcdef0123456789abcdef0123456789abcdef01.
+😐 Code PushUp report is **unchanged** – compared current commit 0123456789abcdef0123456789abcdef01234567 with previous commit abcdef0123456789abcdef0123456789abcdef01.
 
 ---
 

--- a/packages/utils/src/lib/reports/__snapshots__/report-diff-monorepo-with-portal.md
+++ b/packages/utils/src/lib/reports/__snapshots__/report-diff-monorepo-with-portal.md
@@ -1,6 +1,6 @@
 # Code PushUp
 
-🥳 Code PushUp report has **improved** – compared target commit 0123456789abcdef0123456789abcdef01234567 with source commit abcdef0123456789abcdef0123456789abcdef01.
+🥳 Code PushUp report has **improved** – compared current commit 0123456789abcdef0123456789abcdef01234567 with previous commit abcdef0123456789abcdef0123456789abcdef01.
 
 ## 💼 Project `frontoffice`
 

--- a/packages/utils/src/lib/reports/__snapshots__/report-diff-monorepo.md
+++ b/packages/utils/src/lib/reports/__snapshots__/report-diff-monorepo.md
@@ -1,6 +1,6 @@
 # Code PushUp
 
-🤨 Code PushUp report has both **improvements and regressions** – compared target commit 0123456789abcdef0123456789abcdef01234567 with source commit abcdef0123456789abcdef0123456789abcdef01.
+🤨 Code PushUp report has both **improvements and regressions** – compared current commit 0123456789abcdef0123456789abcdef01234567 with previous commit abcdef0123456789abcdef0123456789abcdef01.
 
 ## 💼 Project `console`
 

--- a/packages/utils/src/lib/reports/__snapshots__/report-diff-unchanged.md
+++ b/packages/utils/src/lib/reports/__snapshots__/report-diff-unchanged.md
@@ -1,6 +1,6 @@
 # Code PushUp
 
-😐 Code PushUp report is **unchanged** – compared target commit 0123456789abcdef0123456789abcdef01234567 with source commit abcdef0123456789abcdef0123456789abcdef01.
+😐 Code PushUp report is **unchanged** – compared current commit 0123456789abcdef0123456789abcdef01234567 with previous commit abcdef0123456789abcdef0123456789abcdef01.
 
 ## 🏷️ Categories
 

--- a/packages/utils/src/lib/reports/__snapshots__/report-diff-with-portal.md
+++ b/packages/utils/src/lib/reports/__snapshots__/report-diff-with-portal.md
@@ -1,6 +1,6 @@
 # Code PushUp
 
-🤨 Code PushUp report has both **improvements and regressions** – compared target commit 0123456789abcdef0123456789abcdef01234567 with source commit abcdef0123456789abcdef0123456789abcdef01.
+🤨 Code PushUp report has both **improvements and regressions** – compared current commit 0123456789abcdef0123456789abcdef01234567 with previous commit abcdef0123456789abcdef0123456789abcdef01.
 
 [🕵️ See full comparison in Code PushUp portal 🔍](https://app.code-pushup.dev/portal/dunder-mifflin/website/comparison/abcdef0123456789abcdef0123456789abcdef01/0123456789abcdef0123456789abcdef01234567)
 

--- a/packages/utils/src/lib/reports/generate-md-reports-diff-utils.ts
+++ b/packages/utils/src/lib/reports/generate-md-reports-diff-utils.ts
@@ -166,7 +166,7 @@ export function formatReportOutcome(
   };
 
   if (commits) {
-    const commitsText = `compared target commit ${commits.after.hash} with source commit ${commits.before.hash}`;
+    const commitsText = `compared current commit ${commits.after.hash} with previous commit ${commits.before.hash}`;
     return md`${outcomeTexts[outcome]} – ${commitsText}.`;
   }
 


### PR DESCRIPTION
The _source_ and _target_ terminology was the wrong way around :man_facepalming: Replaced with _current_ and _previous_, which is clearer.