### PR TITLE
fix(ci): prevent overwriting report artifacts

### DIFF
--- a/e2e/ci-e2e/tests/basic.e2e.test.ts
+++ b/e2e/ci-e2e/tests/basic.e2e.test.ts
@@ -46,15 +46,18 @@ describe('CI - standalone mode', () => {
       ).resolves.toEqual({
         mode: 'standalone',
         files: {
-          report: {
-            json: path.join(repo.baseDir, '.code-pushup/report.json'),
-            md: path.join(repo.baseDir, '.code-pushup/report.md'),
+          current: {
+            json: path.join(
+              repo.baseDir,
+              '.code-pushup/.ci/.current/report.json',
+            ),
+            md: path.join(repo.baseDir, '.code-pushup/.ci/.current/report.md'),
           },
         },
       } satisfies RunResult);
 
       const jsonPromise = readFile(
-        path.join(repo.baseDir, '.code-pushup/report.json'),
+        path.join(repo.baseDir, '.code-pushup/.ci/.current/report.json'),
         'utf8',
       );
       await expect(jsonPromise).resolves.toBeTruthy();
@@ -103,19 +106,35 @@ describe('CI - standalone mode', () => {
         commentId: MOCK_COMMENT.id,
         newIssues: [],
         files: {
-          report: {
-            json: path.join(repo.baseDir, '.code-pushup/report.json'),
-            md: path.join(repo.baseDir, '.code-pushup/report.md'),
+          current: {
+            json: path.join(
+              repo.baseDir,
+              '.code-pushup/.ci/.current/report.json',
+            ),
+            md: path.join(repo.baseDir, '.code-pushup/.ci/.current/report.md'),
           },
-          diff: {
-            json: path.join(repo.baseDir, '.code-pushup/report-diff.json'),
-            md: path.join(repo.baseDir, '.code-pushup/report-diff.md'),
+          previous: {
+            json: path.join(
+              repo.baseDir,
+              '.code-pushup/.ci/.previous/report.json',
+            ),
+            md: path.join(repo.baseDir, '.code-pushup/.ci/.previous/report.md'),
+          },
+          comparison: {
+            json: path.join(
+              repo.baseDir,
+              '.code-pushup/.ci/.comparison/report-diff.json',
+            ),
+            md: path.join(
+              repo.baseDir,
+              '.code-pushup/.ci/.comparison/report-diff.md',
+            ),
           },
         },
       } satisfies RunResult);
 
       const mdPromise = readFile(
-        path.join(repo.baseDir, '.code-pushup/report-diff.md'),
+        path.join(repo.baseDir, '.code-pushup/.ci/.comparison/report-diff.md'),
         'utf8',
       );
       await expect(mdPromise).resolves.toBeTruthy();

--- a/e2e/ci-e2e/tests/npm-workspaces.e2e.test.ts
+++ b/e2e/ci-e2e/tests/npm-workspaces.e2e.test.ts
@@ -52,14 +52,14 @@ describe('CI - monorepo mode (npm workspaces)', () => {
           {
             name: '@example/cli',
             files: {
-              report: {
+              current: {
                 json: path.join(
                   repo.baseDir,
-                  'packages/cli/.code-pushup/report.json',
+                  '.code-pushup/.ci/@example/cli/.current/report.json',
                 ),
                 md: path.join(
                   repo.baseDir,
-                  'packages/cli/.code-pushup/report.md',
+                  '.code-pushup/.ci/@example/cli/.current/report.md',
                 ),
               },
             },
@@ -69,7 +69,10 @@ describe('CI - monorepo mode (npm workspaces)', () => {
 
       await expect(
         readJsonFile(
-          path.join(repo.baseDir, 'packages/cli/.code-pushup/report.json'),
+          path.join(
+            repo.baseDir,
+            '.code-pushup/.ci/@example/cli/.current/report.json',
+          ),
         ),
       ).resolves.toEqual(
         expect.objectContaining({
@@ -120,29 +123,46 @@ describe('CI - monorepo mode (npm workspaces)', () => {
       await expect(runInCI(refs, MOCK_API, options, git)).resolves.toEqual({
         mode: 'monorepo',
         commentId: MOCK_COMMENT.id,
-        diffPath: path.join(repo.baseDir, '.code-pushup/merged-report-diff.md'),
+        files: {
+          comparison: {
+            md: path.join(
+              repo.baseDir,
+              '.code-pushup/.ci/.comparison/report-diff.md',
+            ),
+          },
+        },
         projects: expect.arrayContaining<ProjectRunResult>([
           {
             name: '@example/core',
             files: {
-              report: {
+              current: {
                 json: path.join(
                   repo.baseDir,
-                  'packages/core/.code-pushup/report.json',
+                  '.code-pushup/.ci/@example/core/.current/report.json',
                 ),
                 md: path.join(
                   repo.baseDir,
-                  'packages/core/.code-pushup/report.md',
+                  '.code-pushup/.ci/@example/core/.current/report.md',
                 ),
               },
-              diff: {
+              previous: {
                 json: path.join(
                   repo.baseDir,
-                  'packages/core/.code-pushup/report-diff.json',
+                  '.code-pushup/.ci/@example/core/.previous/report.json',
                 ),
                 md: path.join(
                   repo.baseDir,
-                  'packages/core/.code-pushup/report-diff.md',
+                  '.code-pushup/.ci/@example/core/.previous/report.md',
+                ),
+              },
+              comparison: {
+                json: path.join(
+                  repo.baseDir,
+                  '.code-pushup/.ci/@example/core/.comparison/report-diff.json',
+                ),
+                md: path.join(
+                  repo.baseDir,
+                  '.code-pushup/.ci/@example/core/.comparison/report-diff.md',
                 ),
               },
             },
@@ -152,7 +172,7 @@ describe('CI - monorepo mode (npm workspaces)', () => {
       } satisfies RunResult);
 
       const mdPromise = readFile(
-        path.join(repo.baseDir, '.code-pushup/merged-report-diff.md'),
+        path.join(repo.baseDir, '.code-pushup/.ci/.comparison/report-diff.md'),
         'utf8',
       );
       await expect(mdPromise).resolves.toBeTruthy();

--- a/e2e/ci-e2e/tests/nx-monorepo.e2e.test.ts
+++ b/e2e/ci-e2e/tests/nx-monorepo.e2e.test.ts
@@ -53,12 +53,15 @@ describe('CI - monorepo mode (Nx)', () => {
           {
             name: 'api',
             files: {
-              report: {
+              current: {
                 json: path.join(
                   repo.baseDir,
-                  'apps/api/.code-pushup/report.json',
+                  '.code-pushup/.ci/api/.current/report.json',
                 ),
-                md: path.join(repo.baseDir, 'apps/api/.code-pushup/report.md'),
+                md: path.join(
+                  repo.baseDir,
+                  '.code-pushup/.ci/api/.current/report.md',
+                ),
               },
             },
           },
@@ -67,7 +70,7 @@ describe('CI - monorepo mode (Nx)', () => {
 
       await expect(
         readJsonFile(
-          path.join(repo.baseDir, 'apps/api/.code-pushup/report.json'),
+          path.join(repo.baseDir, '.code-pushup/.ci/api/.current/report.json'),
         ),
       ).resolves.toEqual(
         expect.objectContaining({
@@ -85,7 +88,7 @@ describe('CI - monorepo mode (Nx)', () => {
       );
       await expect(
         readJsonFile(
-          path.join(repo.baseDir, 'libs/ui/.code-pushup/report.json'),
+          path.join(repo.baseDir, '.code-pushup/.ci/ui/.current/report.json'),
         ),
       ).resolves.toEqual(
         expect.objectContaining({
@@ -145,26 +148,46 @@ describe('CI - monorepo mode (Nx)', () => {
       await expect(runInCI(refs, MOCK_API, options, git)).resolves.toEqual({
         mode: 'monorepo',
         commentId: MOCK_COMMENT.id,
-        diffPath: path.join(repo.baseDir, '.code-pushup/merged-report-diff.md'),
+        files: {
+          comparison: {
+            md: path.join(
+              repo.baseDir,
+              '.code-pushup/.ci/.comparison/report-diff.md',
+            ),
+          },
+        },
         projects: expect.arrayContaining<ProjectRunResult>([
           {
             name: 'web',
             files: {
-              report: {
+              current: {
                 json: path.join(
                   repo.baseDir,
-                  'apps/web/.code-pushup/report.json',
-                ),
-                md: path.join(repo.baseDir, 'apps/web/.code-pushup/report.md'),
-              },
-              diff: {
-                json: path.join(
-                  repo.baseDir,
-                  'apps/web/.code-pushup/report-diff.json',
+                  '.code-pushup/.ci/web/.current/report.json',
                 ),
                 md: path.join(
                   repo.baseDir,
-                  'apps/web/.code-pushup/report-diff.md',
+                  '.code-pushup/.ci/web/.current/report.md',
+                ),
+              },
+              previous: {
+                json: path.join(
+                  repo.baseDir,
+                  '.code-pushup/.ci/web/.previous/report.json',
+                ),
+                md: path.join(
+                  repo.baseDir,
+                  '.code-pushup/.ci/web/.previous/report.md',
+                ),
+              },
+              comparison: {
+                json: path.join(
+                  repo.baseDir,
+                  '.code-pushup/.ci/web/.comparison/report-diff.json',
+                ),
+                md: path.join(
+                  repo.baseDir,
+                  '.code-pushup/.ci/web/.comparison/report-diff.md',
                 ),
               },
             },
@@ -182,7 +205,7 @@ describe('CI - monorepo mode (Nx)', () => {
       } satisfies RunResult);
 
       const mdPromise = readFile(
-        path.join(repo.baseDir, '.code-pushup/merged-report-diff.md'),
+        path.join(repo.baseDir, '.code-pushup/.ci/.comparison/report-diff.md'),
         'utf8',
       );
       await expect(mdPromise).resolves.toBeTruthy();

--- a/packages/ci/README.md
+++ b/packages/ci/README.md
@@ -137,7 +137,7 @@ const result = await runInCI(refs, api);
 if (result.mode === 'standalone') {
   const {
     // output files, can be uploaded as job artifact
-    files: { report, diff },
+    files: { current, comparison },
     // ID of created/updated PR comment
     commentId,
     // array of source code issues, can be used to annotate changed files in PR
@@ -231,7 +231,7 @@ if (result.mode === 'monorepo') {
     // ID of created/updated PR comment
     commentId,
     // merged report-diff.md used in PR comment, can also be uploaded as job artifact
-    diffPath,
+    files: { comparison },
   } = result;
 
   for (const project of projects) {
@@ -239,7 +239,7 @@ if (result.mode === 'monorepo') {
       // detected project name (from package.json, project.json or folder name)
       name,
       // output files, can be uploaded as job artifacts
-      files: { report, diff },
+      files: { current, comparison },
       // array of source code issues, can be used to annotate changed files in PR
       newIssues,
     } = project;

--- a/packages/ci/src/lib/models.ts
+++ b/packages/ci/src/lib/models.ts
@@ -94,7 +94,9 @@ export type MonorepoRunResult = {
   mode: 'monorepo';
   projects: ProjectRunResult[];
   commentId?: number;
-  diffPath?: string;
+  files?: {
+    comparison: Pick<OutputFiles, 'md'>;
+  };
 };
 
 /**
@@ -103,8 +105,9 @@ export type MonorepoRunResult = {
 export type ProjectRunResult = {
   name: string;
   files: {
-    report: OutputFiles;
-    diff?: OutputFiles;
+    current: OutputFiles;
+    previous?: OutputFiles | Pick<OutputFiles, 'json'>;
+    comparison?: OutputFiles;
   };
   newIssues?: SourceFileIssue[];
 };

--- a/packages/ci/src/lib/output-files.ts
+++ b/packages/ci/src/lib/output-files.ts
@@ -1,0 +1,53 @@
+import { copyFile, mkdir } from 'node:fs/promises';
+import path from 'node:path';
+import { DEFAULT_PERSIST_FILENAME, type Format } from '@code-pushup/models';
+import { objectFromEntries, objectToKeys } from '@code-pushup/utils';
+import type { OutputFiles, Settings } from './models.js';
+import type { ProjectConfig } from './monorepo/tools.js';
+
+const BASE_DIR = path.join('.code-pushup', '.ci');
+
+type OutputType = 'current' | 'previous' | 'comparison';
+
+export async function saveOutputFiles<T extends Partial<OutputFiles>>({
+  project,
+  type,
+  files,
+  settings: { logger, directory },
+}: {
+  project: Pick<ProjectConfig, 'name'> | null;
+  type: OutputType;
+  files: T;
+  settings: Pick<Settings, 'logger' | 'directory'>;
+}): Promise<T> {
+  const baseDir = project ? path.join(BASE_DIR, project.name) : BASE_DIR;
+  const outputDir = path.join(directory, baseDir, `.${type}`);
+  const name =
+    type === 'comparison'
+      ? `${DEFAULT_PERSIST_FILENAME}-diff`
+      : DEFAULT_PERSIST_FILENAME;
+
+  const formats = objectToKeys(files) as Format[];
+  const outputs = objectFromEntries(
+    formats.map(format => [
+      format,
+      path.join(outputDir, `${name}.${format.toString()}`),
+    ]),
+  );
+
+  if (formats.length > 0) {
+    await mkdir(outputDir, { recursive: true });
+  }
+
+  await Promise.all(
+    formats.map(async format => {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const src = files[format]!;
+      const dest = outputs[format];
+      await copyFile(src, dest);
+      logger.debug(`Copied ${type} report from ${src} to ${dest}`);
+    }),
+  );
+
+  return outputs as T;
+}

--- a/packages/ci/src/lib/output-files.unit.test.ts
+++ b/packages/ci/src/lib/output-files.unit.test.ts
@@ -1,0 +1,231 @@
+import { vol } from 'memfs';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { MEMFS_VOLUME } from '@code-pushup/test-utils';
+import type { Settings } from './models.js';
+import { saveOutputFiles } from './output-files.js';
+
+describe('saveOutputFiles', () => {
+  const settings: Pick<Settings, 'logger' | 'directory'> = {
+    logger: console,
+    directory: MEMFS_VOLUME,
+  };
+
+  beforeEach(() => {
+    vi.spyOn(settings.logger, 'debug').mockImplementation(() => {});
+
+    vol.fromJSON(
+      {
+        'report.json': '{ "score": 1 }',
+        'report.md': '- score: **100**',
+        'report-diff.json': '{ "scoreChange": -0.25 }',
+        'report-diff.md': '- score change: **-25**',
+        'merged-report-diff.md': '- backend: **-5**\n- frontend: **+10**',
+      },
+      MEMFS_VOLUME,
+    );
+  });
+
+  it('should copy current report files', async () => {
+    await expect(
+      saveOutputFiles({
+        project: null,
+        type: 'current',
+        files: {
+          json: path.join(MEMFS_VOLUME, 'report.json'),
+          md: path.join(MEMFS_VOLUME, 'report.md'),
+        },
+        settings,
+      }),
+    ).resolves.toEqual({
+      json: path.join(MEMFS_VOLUME, '.code-pushup/.ci/.current/report.json'),
+      md: path.join(MEMFS_VOLUME, '.code-pushup/.ci/.current/report.md'),
+    });
+
+    await expect(
+      readFile(
+        path.join(MEMFS_VOLUME, '.code-pushup/.ci/.current/report.json'),
+        'utf8',
+      ),
+    ).resolves.toBe('{ "score": 1 }');
+    await expect(
+      readFile(
+        path.join(MEMFS_VOLUME, '.code-pushup/.ci/.current/report.md'),
+        'utf8',
+      ),
+    ).resolves.toBe('- score: **100**');
+  });
+
+  it('should copy comparison files', async () => {
+    await expect(
+      saveOutputFiles({
+        project: null,
+        type: 'comparison',
+        files: {
+          json: path.join(MEMFS_VOLUME, 'report-diff.json'),
+          md: path.join(MEMFS_VOLUME, 'report-diff.md'),
+        },
+        settings,
+      }),
+    ).resolves.toEqual({
+      json: path.join(
+        MEMFS_VOLUME,
+        '.code-pushup/.ci/.comparison/report-diff.json',
+      ),
+      md: path.join(
+        MEMFS_VOLUME,
+        '.code-pushup/.ci/.comparison/report-diff.md',
+      ),
+    });
+
+    await expect(
+      readFile(
+        path.join(
+          MEMFS_VOLUME,
+          '.code-pushup/.ci/.comparison/report-diff.json',
+        ),
+        'utf8',
+      ),
+    ).resolves.toBe('{ "scoreChange": -0.25 }');
+    await expect(
+      readFile(
+        path.join(MEMFS_VOLUME, '.code-pushup/.ci/.comparison/report-diff.md'),
+        'utf8',
+      ),
+    ).resolves.toBe('- score change: **-25**');
+  });
+
+  it('should copy previous report.json file', async () => {
+    await expect(
+      saveOutputFiles({
+        project: null,
+        type: 'previous',
+        files: {
+          json: path.join(MEMFS_VOLUME, 'report.json'),
+        },
+        settings,
+      }),
+    ).resolves.toEqual({
+      json: path.join(MEMFS_VOLUME, '.code-pushup/.ci/.previous/report.json'),
+    });
+  });
+
+  it('should log copied file paths', async () => {
+    await saveOutputFiles({
+      project: null,
+      type: 'current',
+      files: {
+        json: path.join(MEMFS_VOLUME, 'report.json'),
+        md: path.join(MEMFS_VOLUME, 'report.md'),
+      },
+      settings,
+    });
+
+    expect(settings.logger.debug).toHaveBeenCalledWith(
+      `Copied current report from ${path.join(MEMFS_VOLUME, 'report.json')} to ${path.join(MEMFS_VOLUME, '.code-pushup/.ci/.current/report.json')}`,
+    );
+    expect(settings.logger.debug).toHaveBeenCalledWith(
+      `Copied current report from ${path.join(MEMFS_VOLUME, 'report.md')} to ${path.join(MEMFS_VOLUME, '.code-pushup/.ci/.current/report.md')}`,
+    );
+  });
+
+  it("should copy project's current report files to project folder", async () => {
+    await expect(
+      saveOutputFiles({
+        project: { name: 'api' },
+        type: 'current',
+        files: {
+          json: path.join(MEMFS_VOLUME, 'report.json'),
+          md: path.join(MEMFS_VOLUME, 'report.md'),
+        },
+        settings,
+      }),
+    ).resolves.toEqual({
+      json: path.join(
+        MEMFS_VOLUME,
+        '.code-pushup/.ci/api/.current/report.json',
+      ),
+      md: path.join(MEMFS_VOLUME, '.code-pushup/.ci/api/.current/report.md'),
+    });
+
+    await expect(
+      readFile(
+        path.join(MEMFS_VOLUME, '.code-pushup/.ci/api/.current/report.json'),
+        'utf8',
+      ),
+    ).resolves.toBe('{ "score": 1 }');
+    await expect(
+      readFile(
+        path.join(MEMFS_VOLUME, '.code-pushup/.ci/api/.current/report.md'),
+        'utf8',
+      ),
+    ).resolves.toBe('- score: **100**');
+  });
+
+  it("should copy project's comparison files to project folder", async () => {
+    await expect(
+      saveOutputFiles({
+        project: { name: 'utils' },
+        type: 'comparison',
+        files: {
+          json: path.join(MEMFS_VOLUME, 'report-diff.json'),
+          md: path.join(MEMFS_VOLUME, 'report-diff.md'),
+        },
+        settings,
+      }),
+    ).resolves.toEqual({
+      json: path.join(
+        MEMFS_VOLUME,
+        '.code-pushup/.ci/utils/.comparison/report-diff.json',
+      ),
+      md: path.join(
+        MEMFS_VOLUME,
+        '.code-pushup/.ci/utils/.comparison/report-diff.md',
+      ),
+    });
+
+    await expect(
+      readFile(
+        path.join(
+          MEMFS_VOLUME,
+          '.code-pushup/.ci/utils/.comparison/report-diff.json',
+        ),
+        'utf8',
+      ),
+    ).resolves.toBe('{ "scoreChange": -0.25 }');
+    await expect(
+      readFile(
+        path.join(
+          MEMFS_VOLUME,
+          '.code-pushup/.ci/utils/.comparison/report-diff.md',
+        ),
+        'utf8',
+      ),
+    ).resolves.toBe('- score change: **-25**');
+  });
+
+  it('should copy merged comparison markdown file', async () => {
+    await expect(
+      saveOutputFiles({
+        project: null,
+        type: 'comparison',
+        files: {
+          md: path.join(MEMFS_VOLUME, 'merged-report-diff.md'),
+        },
+        settings,
+      }),
+    ).resolves.toEqual({
+      md: path.join(
+        MEMFS_VOLUME,
+        '.code-pushup/.ci/.comparison/report-diff.md',
+      ),
+    });
+
+    await expect(
+      readFile(
+        path.join(MEMFS_VOLUME, '.code-pushup/.ci/.comparison/report-diff.md'),
+        'utf8',
+      ),
+    ).resolves.toBe('- backend: **-5**\n- frontend: **+10**');
+  });
+});

--- a/packages/ci/src/lib/run-standalone.ts
+++ b/packages/ci/src/lib/run-standalone.ts
@@ -12,7 +12,7 @@ export async function runInStandaloneMode(
 
   const { files, newIssues } = await runOnProject(null, env);
 
-  const commentMdPath = files.diff?.md;
+  const commentMdPath = files.comparison?.md;
   if (!settings.skipComment && commentMdPath) {
     const commentId = await commentOnPR(commentMdPath, api, logger);
     return {

--- a/packages/ci/src/lib/run.integration.test.ts
+++ b/packages/ci/src/lib/run.integration.test.ts
@@ -179,6 +179,8 @@ describe('runInCI', () => {
     return { code: 0, stdout, stderr: '' } as utils.ProcessResult;
   }
 
+  const outputDir = path.join(workDir, '.code-pushup', '.ci');
+
   beforeEach(async () => {
     const originalExecuteProcess = utils.executeProcess;
     executeProcessSpy = vi
@@ -220,8 +222,6 @@ describe('runInCI', () => {
   });
 
   describe('standalone mode', () => {
-    const outputDir = path.join(workDir, '.code-pushup');
-
     describe('push event', () => {
       beforeEach(async () => {
         await git.checkout('main');
@@ -238,9 +238,9 @@ describe('runInCI', () => {
         ).resolves.toEqual({
           mode: 'standalone',
           files: {
-            report: {
-              json: path.join(outputDir, 'report.json'),
-              md: path.join(outputDir, 'report.md'),
+            current: {
+              json: path.join(outputDir, '.current/report.json'),
+              md: path.join(outputDir, '.current/report.md'),
             },
           },
         } satisfies RunResult);
@@ -311,13 +311,17 @@ describe('runInCI', () => {
           commentId: mockComment.id,
           newIssues: [],
           files: {
-            report: {
-              json: path.join(outputDir, 'report.json'),
-              md: path.join(outputDir, 'report.md'),
+            current: {
+              json: path.join(outputDir, '.current/report.json'),
+              md: path.join(outputDir, '.current/report.md'),
             },
-            diff: {
-              json: path.join(outputDir, 'report-diff.json'),
-              md: path.join(outputDir, 'report-diff.md'),
+            previous: {
+              json: path.join(outputDir, '.previous/report.json'),
+              md: path.join(outputDir, '.previous/report.md'),
+            },
+            comparison: {
+              json: path.join(outputDir, '.comparison/report-diff.json'),
+              md: path.join(outputDir, '.comparison/report-diff.md'),
             },
           },
         } satisfies RunResult);
@@ -376,8 +380,8 @@ describe('runInCI', () => {
           args: [
             'compare',
             '--verbose',
-            `--before=${path.join(outputDir, 'prev-report.json')}`,
-            `--after=${path.join(outputDir, 'curr-report.json')}`,
+            `--before=${path.join(outputDir, '.previous/report.json')}`,
+            `--after=${path.join(outputDir, '.current/report.json')}`,
             '--persist.format=json',
             '--persist.format=md',
           ],
@@ -409,13 +413,16 @@ describe('runInCI', () => {
           commentId: mockComment.id,
           newIssues: [],
           files: {
-            report: {
-              json: path.join(outputDir, 'report.json'),
-              md: path.join(outputDir, 'report.md'),
+            current: {
+              json: path.join(outputDir, '.current/report.json'),
+              md: path.join(outputDir, '.current/report.md'),
             },
-            diff: {
-              json: path.join(outputDir, 'report-diff.json'),
-              md: path.join(outputDir, 'report-diff.md'),
+            previous: {
+              json: path.join(outputDir, '.previous/report.json'),
+            },
+            comparison: {
+              json: path.join(outputDir, '.comparison/report-diff.json'),
+              md: path.join(outputDir, '.comparison/report-diff.md'),
             },
           },
         } satisfies RunResult);
@@ -455,8 +462,8 @@ describe('runInCI', () => {
           args: [
             'compare',
             '--verbose',
-            `--before=${path.join(outputDir, 'prev-report.json')}`,
-            `--after=${path.join(outputDir, 'curr-report.json')}`,
+            `--before=${path.join(outputDir, '.previous/report.json')}`,
+            `--after=${path.join(outputDir, '.current/report.json')}`,
             '--persist.format=json',
             '--persist.format=md',
           ],
@@ -485,13 +492,17 @@ describe('runInCI', () => {
           commentId: undefined,
           newIssues: [],
           files: {
-            report: {
-              json: path.join(outputDir, 'report.json'),
-              md: path.join(outputDir, 'report.md'),
+            current: {
+              json: path.join(outputDir, '.current/report.json'),
+              md: path.join(outputDir, '.current/report.md'),
             },
-            diff: {
-              json: path.join(outputDir, 'report-diff.json'),
-              md: path.join(outputDir, 'report-diff.md'),
+            previous: {
+              json: path.join(outputDir, '.previous/report.json'),
+              md: path.join(outputDir, '.previous/report.md'),
+            },
+            comparison: {
+              json: path.join(outputDir, '.comparison/report-diff.json'),
+              md: path.join(outputDir, '.comparison/report-diff.md'),
             },
           },
         } satisfies RunResult);
@@ -590,42 +601,27 @@ describe('runInCI', () => {
             {
               name: 'cli',
               files: {
-                report: {
-                  json: path.join(
-                    workDir,
-                    'packages/cli/.code-pushup/report.json',
-                  ),
-                  md: path.join(workDir, 'packages/cli/.code-pushup/report.md'),
+                current: {
+                  json: path.join(outputDir, 'cli/.current/report.json'),
+                  md: path.join(outputDir, 'cli/.current/report.md'),
                 },
               },
             },
             {
               name: 'core',
               files: {
-                report: {
-                  json: path.join(
-                    workDir,
-                    'packages/core/.code-pushup/report.json',
-                  ),
-                  md: path.join(
-                    workDir,
-                    'packages/core/.code-pushup/report.md',
-                  ),
+                current: {
+                  json: path.join(outputDir, 'core/.current/report.json'),
+                  md: path.join(outputDir, 'core/.current/report.md'),
                 },
               },
             },
             {
               name: 'utils',
               files: {
-                report: {
-                  json: path.join(
-                    workDir,
-                    'packages/utils/.code-pushup/report.json',
-                  ),
-                  md: path.join(
-                    workDir,
-                    'packages/utils/.code-pushup/report.md',
-                  ),
+                current: {
+                  json: path.join(outputDir, 'utils/.current/report.json'),
+                  md: path.join(outputDir, 'utils/.current/report.md'),
                 },
               },
             },
@@ -713,27 +709,28 @@ describe('runInCI', () => {
         ).resolves.toEqual({
           mode: 'monorepo',
           commentId: mockComment.id,
-          diffPath: path.join(workDir, '.code-pushup/merged-report-diff.md'),
+          files: {
+            comparison: {
+              md: path.join(outputDir, '.comparison/report-diff.md'),
+            },
+          },
           projects: [
             {
               name: 'cli',
               files: {
-                report: {
-                  json: path.join(
-                    workDir,
-                    'packages/cli/.code-pushup/report.json',
-                  ),
-                  md: path.join(workDir, 'packages/cli/.code-pushup/report.md'),
+                current: {
+                  json: path.join(outputDir, 'cli/.current/report.json'),
+                  md: path.join(outputDir, 'cli/.current/report.md'),
                 },
-                diff: {
+                previous: {
+                  json: path.join(outputDir, 'cli/.previous/report.json'),
+                },
+                comparison: {
                   json: path.join(
-                    workDir,
-                    'packages/cli/.code-pushup/report-diff.json',
+                    outputDir,
+                    'cli/.comparison/report-diff.json',
                   ),
-                  md: path.join(
-                    workDir,
-                    'packages/cli/.code-pushup/report-diff.md',
-                  ),
+                  md: path.join(outputDir, 'cli/.comparison/report-diff.md'),
                 },
               },
               newIssues: [],
@@ -741,25 +738,19 @@ describe('runInCI', () => {
             {
               name: 'core',
               files: {
-                report: {
-                  json: path.join(
-                    workDir,
-                    'packages/core/.code-pushup/report.json',
-                  ),
-                  md: path.join(
-                    workDir,
-                    'packages/core/.code-pushup/report.md',
-                  ),
+                current: {
+                  json: path.join(outputDir, 'core/.current/report.json'),
+                  md: path.join(outputDir, 'core/.current/report.md'),
                 },
-                diff: {
+                previous: {
+                  json: path.join(outputDir, 'core/.previous/report.json'),
+                },
+                comparison: {
                   json: path.join(
-                    workDir,
-                    'packages/core/.code-pushup/report-diff.json',
+                    outputDir,
+                    'core/.comparison/report-diff.json',
                   ),
-                  md: path.join(
-                    workDir,
-                    'packages/core/.code-pushup/report-diff.md',
-                  ),
+                  md: path.join(outputDir, 'core/.comparison/report-diff.md'),
                 },
               },
               newIssues: [],
@@ -767,25 +758,20 @@ describe('runInCI', () => {
             {
               name: 'utils',
               files: {
-                report: {
-                  json: path.join(
-                    workDir,
-                    'packages/utils/.code-pushup/report.json',
-                  ),
-                  md: path.join(
-                    workDir,
-                    'packages/utils/.code-pushup/report.md',
-                  ),
+                current: {
+                  json: path.join(outputDir, 'utils/.current/report.json'),
+                  md: path.join(outputDir, 'utils/.current/report.md'),
                 },
-                diff: {
+                previous: {
+                  json: path.join(outputDir, 'utils/.previous/report.json'),
+                  md: path.join(outputDir, 'utils/.previous/report.md'),
+                },
+                comparison: {
                   json: path.join(
-                    workDir,
-                    'packages/utils/.code-pushup/report-diff.json',
+                    outputDir,
+                    'utils/.comparison/report-diff.json',
                   ),
-                  md: path.join(
-                    workDir,
-                    'packages/utils/.code-pushup/report-diff.md',
-                  ),
+                  md: path.join(outputDir, 'utils/.comparison/report-diff.md'),
                 },
               },
               newIssues: [],
@@ -794,10 +780,7 @@ describe('runInCI', () => {
         } satisfies RunResult);
 
         await expect(
-          readFile(
-            path.join(workDir, '.code-pushup/merged-report-diff.md'),
-            'utf8',
-          ),
+          readFile(path.join(outputDir, '.comparison/report-diff.md'), 'utf8'),
         ).resolves.toBe(diffMdString);
 
         expect(api.listComments).toHaveBeenCalledWith();
@@ -843,8 +826,8 @@ describe('runInCI', () => {
           args: [
             'compare',
             '--verbose',
-            expect.stringMatching(/^--before=.*prev-report.json$/),
-            expect.stringMatching(/^--after=.*curr-report.json$/),
+            expect.stringMatching(/^--before=.*\.previous[/\\]report\.json$/),
+            expect.stringMatching(/^--after=.*\.current[/\\]report\.json$/),
             expect.stringMatching(/^--label=\w+$/),
             '--persist.format=json',
             '--persist.format=md',
@@ -857,9 +840,15 @@ describe('runInCI', () => {
           args: [
             'merge-diffs',
             '--verbose',
-            `--files=${path.join(workDir, 'packages/cli/.code-pushup/report-diff.json')}`,
-            `--files=${path.join(workDir, 'packages/core/.code-pushup/report-diff.json')}`,
-            `--files=${path.join(workDir, 'packages/utils/.code-pushup/report-diff.json')}`,
+            expect.stringMatching(
+              /^--files=.*[/\\]cli[/\\]\.comparison[/\\]report-diff\.json$/,
+            ),
+            expect.stringMatching(
+              /^--files=.*[/\\]core[/\\]\.comparison[/\\]report-diff\.json$/,
+            ),
+            expect.stringMatching(
+              /^--files=.*[/\\]utils[/\\]\.comparison[/\\]report-diff\.json$/,
+            ),
             expect.stringMatching(/^--persist.outputDir=.*\.code-pushup$/),
             '--persist.filename=merged-report',
           ],
@@ -891,7 +880,7 @@ describe('runInCI', () => {
         ).resolves.toEqual({
           mode: 'monorepo',
           commentId: undefined,
-          diffPath: path.join(workDir, '.code-pushup/merged-report-diff.md'),
+          files: expect.any(Object),
           projects: [
             expect.objectContaining({ name: 'cli' }),
             expect.objectContaining({ name: 'core' }),
@@ -900,10 +889,7 @@ describe('runInCI', () => {
         } satisfies RunResult);
 
         await expect(
-          readFile(
-            path.join(workDir, '.code-pushup/merged-report-diff.md'),
-            'utf8',
-          ),
+          readFile(path.join(outputDir, '.comparison/report-diff.md'), 'utf8'),
         ).resolves.toBe(diffMdString);
 
         expect(api.listComments).not.toHaveBeenCalled();
@@ -973,33 +959,35 @@ describe('runInCI', () => {
             {
               name: expect.stringContaining('api'),
               files: {
-                report: {
-                  json: path.join(
-                    workDir,
-                    'backend/api/.code-pushup/report.json',
+                current: {
+                  json: expect.stringContaining(
+                    path.join('api/.current/report.json'),
                   ),
-                  md: path.join(workDir, 'backend/api/.code-pushup/report.md'),
+                  md: expect.stringContaining(
+                    path.join('api/.current/report.md'),
+                  ),
                 },
               },
             },
             {
               name: expect.stringContaining('auth'),
               files: {
-                report: {
-                  json: path.join(
-                    workDir,
-                    'backend/auth/.code-pushup/report.json',
+                current: {
+                  json: expect.stringContaining(
+                    path.join('auth/.current/report.json'),
                   ),
-                  md: path.join(workDir, 'backend/auth/.code-pushup/report.md'),
+                  md: expect.stringContaining(
+                    path.join('auth/.current/report.md'),
+                  ),
                 },
               },
             },
             {
               name: 'frontend',
               files: {
-                report: {
-                  json: path.join(workDir, 'frontend/.code-pushup/report.json'),
-                  md: path.join(workDir, 'frontend/.code-pushup/report.md'),
+                current: {
+                  json: path.join(outputDir, 'frontend/.current/report.json'),
+                  md: path.join(outputDir, 'frontend/.current/report.md'),
                 },
               },
             },
@@ -1083,26 +1071,34 @@ describe('runInCI', () => {
         ).resolves.toEqual({
           mode: 'monorepo',
           commentId: mockComment.id,
-          diffPath: path.join(workDir, '.code-pushup/merged-report-diff.md'),
+          files: {
+            comparison: {
+              md: path.join(outputDir, '.comparison/report-diff.md'),
+            },
+          },
           projects: [
             {
               name: expect.stringContaining('api'),
               files: {
-                report: {
-                  json: path.join(
-                    workDir,
-                    'backend/api/.code-pushup/report.json',
+                current: {
+                  json: expect.stringContaining(
+                    path.join('api/.current/report.json'),
                   ),
-                  md: path.join(workDir, 'backend/api/.code-pushup/report.md'),
+                  md: expect.stringContaining(
+                    path.join('api/.current/report.md'),
+                  ),
                 },
-                diff: {
-                  json: path.join(
-                    workDir,
-                    'backend/api/.code-pushup/report-diff.json',
+                previous: {
+                  json: expect.stringContaining(
+                    path.join('api/.previous/report.json'),
                   ),
-                  md: path.join(
-                    workDir,
-                    'backend/api/.code-pushup/report-diff.md',
+                },
+                comparison: {
+                  json: expect.stringContaining(
+                    path.join('api/.comparison/report-diff.json'),
+                  ),
+                  md: expect.stringContaining(
+                    path.join('api/.comparison/report-diff.md'),
                   ),
                 },
               },
@@ -1111,21 +1107,25 @@ describe('runInCI', () => {
             {
               name: expect.stringContaining('auth'),
               files: {
-                report: {
-                  json: path.join(
-                    workDir,
-                    'backend/auth/.code-pushup/report.json',
+                current: {
+                  json: expect.stringContaining(
+                    path.join('auth/.current/report.json'),
                   ),
-                  md: path.join(workDir, 'backend/auth/.code-pushup/report.md'),
+                  md: expect.stringContaining(
+                    path.join('auth/.current/report.md'),
+                  ),
                 },
-                diff: {
-                  json: path.join(
-                    workDir,
-                    'backend/auth/.code-pushup/report-diff.json',
+                previous: {
+                  json: expect.stringContaining(
+                    path.join('auth/.previous/report.json'),
                   ),
-                  md: path.join(
-                    workDir,
-                    'backend/auth/.code-pushup/report-diff.md',
+                },
+                comparison: {
+                  json: expect.stringContaining(
+                    path.join('auth/.comparison/report-diff.json'),
+                  ),
+                  md: expect.stringContaining(
+                    path.join('auth/.comparison/report-diff.md'),
                   ),
                 },
               },
@@ -1134,18 +1134,21 @@ describe('runInCI', () => {
             {
               name: 'frontend',
               files: {
-                report: {
-                  json: path.join(workDir, 'frontend/.code-pushup/report.json'),
-                  md: path.join(workDir, 'frontend/.code-pushup/report.md'),
+                current: {
+                  json: path.join(outputDir, 'frontend/.current/report.json'),
+                  md: path.join(outputDir, 'frontend/.current/report.md'),
                 },
-                diff: {
+                previous: {
+                  json: path.join(outputDir, 'frontend/.previous/report.json'),
+                },
+                comparison: {
                   json: path.join(
-                    workDir,
-                    'frontend/.code-pushup/report-diff.json',
+                    outputDir,
+                    'frontend/.comparison/report-diff.json',
                   ),
                   md: path.join(
-                    workDir,
-                    'frontend/.code-pushup/report-diff.md',
+                    outputDir,
+                    'frontend/.comparison/report-diff.md',
                   ),
                 },
               },
@@ -1155,10 +1158,7 @@ describe('runInCI', () => {
         } satisfies RunResult);
 
         await expect(
-          readFile(
-            path.join(workDir, '.code-pushup/merged-report-diff.md'),
-            'utf8',
-          ),
+          readFile(path.join(outputDir, '.comparison/report-diff.md'), 'utf8'),
         ).resolves.toBe(diffMdString);
 
         expect(api.listComments).toHaveBeenCalledWith();
@@ -1203,8 +1203,8 @@ describe('runInCI', () => {
           args: [
             'compare',
             '--verbose',
-            expect.stringMatching(/^--before=.*prev-report.json$/),
-            expect.stringMatching(/^--after=.*curr-report.json$/),
+            expect.stringMatching(/^--before=.*\.previous[/\\]report\.json$/),
+            expect.stringMatching(/^--after=.*\.current[/\\]report\.json$/),
             expect.stringMatching(/^--label=\w+$/),
             '--persist.format=json',
             '--persist.format=md',
@@ -1217,9 +1217,15 @@ describe('runInCI', () => {
           args: [
             'merge-diffs',
             '--verbose',
-            `--files=${path.join(workDir, 'backend/api/.code-pushup/report-diff.json')}`,
-            `--files=${path.join(workDir, 'backend/auth/.code-pushup/report-diff.json')}`,
-            `--files=${path.join(workDir, 'frontend/.code-pushup/report-diff.json')}`,
+            expect.stringMatching(
+              /^--files=.*api[/\\]\.comparison[/\\]report-diff\.json$/,
+            ),
+            expect.stringMatching(
+              /^--files=.*auth[/\\]\.comparison[/\\]report-diff\.json$/,
+            ),
+            expect.stringMatching(
+              /^--files=.*frontend[/\\]\.comparison[/\\]report-diff\.json$/,
+            ),
             expect.stringMatching(/^--persist.outputDir=.*\.code-pushup$/),
             '--persist.filename=merged-report',
           ],


### PR DESCRIPTION
Fixes #946 

All output files are now immediately copied to a special `.code-pushup/.ci` folder, to prevent command outputs conflicting with artifact files.

## CI output files structure

### standalone - push

```sh
.code-pushup/
├─ .ci/
│  ├─ .current/
│  │  ├─ report.json
│  │  ├─ report.md
```

### standalone - pull request

```sh
.code-pushup/
├─ .ci/
│  ├─ .comparison/
│  │  ├─ report-diff.json
│  │  ├─ report-diff.md
│  ├─ .current/
│  │  ├─ report.json
│  │  ├─ report.md
│  ├─ .previous/
│  │  ├─ report.json
│  │  ├─ report.md # if cache not used
```

### monorepo - push

```sh
.code-pushup/
├─ .ci/
│  ├─ <project-name>/
│  │  ├─ .current/
│  │  │  ├─ report.json
│  │  │  ├─ report.md
│  ├─ # ... other projects ...
```

### monorepo - pull request

```sh
.code-pushup/
├─ .ci/
│  ├─ <project-name>/
│  │  ├─ .comparison/
│  │  │  ├─ report-diff.json
│  │  │  ├─ report-diff.md
│  │  ├─ .current/
│  │  │  ├─ report.json
│  │  │  ├─ report.md
│  │  ├─ .previous/
│  │  │  ├─ report.json
│  │  │  ├─ report.md # if cache not used
│  ├─ # ... other projects ...
│  ├─ .comparison/
│  │  ├─ report-diff.md
```