### PR TITLE
fix(plugin-js-packages): handle empty output from yarn outdated

### DIFF
--- a/packages/plugin-js-packages/src/lib/package-managers/yarn-classic/outdated-result.ts
+++ b/packages/plugin-js-packages/src/lib/package-managers/yarn-classic/outdated-result.ts
@@ -20,8 +20,8 @@ import {
 
 export function yarnv1ToOutdatedResult(output: string): OutdatedResult {
   const yarnv1Outdated = fromJsonLines<Yarnv1OutdatedResultJson>(output);
-  const fields = yarnv1Outdated[1].data.head;
-  const dependencies = yarnv1Outdated[1].data.body;
+  const fields = yarnv1Outdated[1]?.data.head ?? [];
+  const dependencies = yarnv1Outdated[1]?.data.body ?? [];
 
   // no outdated dependencies
   if (dependencies.length === 0) {

--- a/packages/plugin-js-packages/src/lib/package-managers/yarn-classic/types.ts
+++ b/packages/plugin-js-packages/src/lib/package-managers/yarn-classic/types.ts
@@ -51,4 +51,4 @@ type Yarnv1Table = {
   };
 };
 
-export type Yarnv1OutdatedResultJson = [Yarnv1Info, Yarnv1Table];
+export type Yarnv1OutdatedResultJson = [Yarnv1Info, Yarnv1Table] | [];


### PR DESCRIPTION
Fixes error in for Yarn v1 repo where there are no outdated packages, so `yarn oudated --json` doesn't print any JSON lines.

```
[ warn ] Plugins failed: 
[ warn ] Error: - Plugin JS Packages (js-packages) produced the following error:
  - file:///REDACTED/node_modules/@code-pushup/js-packages-plugin/src/lib/package-managers/yarn-classic/outdated-result.js:6
    const fields = yarnv1Outdated[1].data.head;
                                     ^
TypeError: Cannot read properties of undefined (reading 'data')
    at Object.yarnv1ToOutdatedResult [as unifyResult] (file:///REDACTED/node_modules/@code-pushup/js-packages-plugin/src/lib/package-managers/yarn-classic/outdated-result.js:6:38)
    at processOutdated (file:///REDACTED/node_modules/@code-pushup/js-packages-plugin/src/lib/runner/index.js:47:42)
    at async executeRunner (file:///REDACTED/node_modules/@code-pushup/js-packages-plugin/src/lib/runner/index.js:28:11)
    at async file:///REDACTED/node_modules/@code-pushup/js-packages-plugin/src/bin.js:5:1
Node.js v22.14.0
```
