### PR TITLE
test: disable parallel install of packages in e2e test

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -16,6 +16,9 @@
     "e2e": {
       "dependsOn": ["^build"]
     },
+    "nxv-pkg-install": {
+      "parallelism": false
+    },
     "@nx/vite:test": {
       "cache": true,
       "inputs": ["default", "^production"],


### PR DESCRIPTION
This PR should fix the error present locally & in CI, that has been caused by parallel `nxv-pkg-install` rewriting the `package.json` when installing dependencies in the per e2e `tmp` folder.

The error was recognizable in the logs as: 
`Cannot find package '@code-pushup/plugin-****' imported from ... code-pushup.config.bundled_****` 
This was happening randomly, only if the "plugin" was not installed last as it did not rewrite any of the important deps (cli, core,...), but if if was installed sooner, the specific package (cli, core, ...) would emit `package.json` without the plugin or any other important dependency.


<details><summary>Detailed examples of failing PRs</summary>
<p>


[Example from recent PR](https://github.com/code-pushup/cli/actions/runs/14183589314/job/39734694752?pr=898)
```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@code-pushup/js-packages-plugin' imported from /Users/runner/work/cli/cli/tmp/e2e/plugin-js-packages-e2e/__test__/npm-repo/code-pushup.config.bundled_rv4w9bp3q0b.mjs
```

[Example from another PR](https://github.com/code-pushup/cli/actions/runs/14067561166/job/39393746780?pr=971)
```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@code-pushup/jsdocs-plugin' imported from /Users/runner/work/cli/cli/tmp/e2e/plugin-jsdocs-e2e/__test__/angular/code-pushup.config.bundled_6o2x8onjd6g.mjs
```

</p>
</details> 

