### PR TITLE
fix: handle repos without git gracefully

### DIFF
--- a/packages/utils/src/lib/git/git.commits-and-tags.ts
+++ b/packages/utils/src/lib/git/git.commits-and-tags.ts
@@ -14,8 +14,8 @@ export async function getLatestCommit(
       format: { hash: '%H', message: '%s', author: '%an', date: '%aI' },
     });
     return commitSchema.parse(log.latest);
-  } catch (e) {
-    ui().logger.error(stringifyError(e));
+  } catch (error) {
+    ui().logger.error(stringifyError(error));
     return null;
   }
 }

--- a/packages/utils/src/lib/git/git.commits-and-tags.ts
+++ b/packages/utils/src/lib/git/git.commits-and-tags.ts
@@ -1,16 +1,23 @@
 import { type LogOptions as SimpleGitLogOptions, simpleGit } from 'simple-git';
 import { type Commit, commitSchema } from '@code-pushup/models';
+import { stringifyError } from '../errors.js';
+import { ui } from '../logging.js';
 import { isSemver } from '../semver.js';
 
 export async function getLatestCommit(
   git = simpleGit(),
 ): Promise<Commit | null> {
-  const log = await git.log({
-    maxCount: 1,
-    // git log -1 --pretty=format:"%H %s %an %aI" - See: https://git-scm.com/docs/pretty-formats
-    format: { hash: '%H', message: '%s', author: '%an', date: '%aI' },
-  });
-  return commitSchema.parse(log.latest);
+  try {
+    const log = await git.log({
+      maxCount: 1,
+      // git log -1 --pretty=format:"%H %s %an %aI" - See: https://git-scm.com/docs/pretty-formats
+      format: { hash: '%H', message: '%s', author: '%an', date: '%aI' },
+    });
+    return commitSchema.parse(log.latest);
+  } catch (e) {
+    ui().logger.error(stringifyError(e));
+    return null;
+  }
 }
 
 export async function getCurrentBranchOrTag(


### PR DESCRIPTION
This error:

```bash
Error: fatal: not a git repository (or any of the parent directories): .git
```

occurred while executing code-pushup code in a MCP server. But in general we should not throw an error if someone executes the tool without git.