### PR TITLE
docs(cli): document minimal NodeJS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 
 [![version](https://img.shields.io/github/v/release/code-pushup/cli)](https://github.com/code-pushup/cli/releases/latest)
 [![release date](https://img.shields.io/github/release-date/code-pushup/cli)](https://github.com/code-pushup/cli/releases)
+![NodeJS support](https://img.shields.io/node/v/%40code-pushup%2Fcli)
 [![license](https://img.shields.io/github/license/code-pushup/cli)](https://opensource.org/licenses/MIT)
 [![commit activity](https://img.shields.io/github/commit-activity/m/code-pushup/cli)](https://github.com/code-pushup/cli/pulse/monthly)
 [![CI](https://github.com/code-pushup/cli/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/code-pushup/cli/actions/workflows/ci.yml?query=branch%3Amain)

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -41,6 +41,9 @@
   "bin": {
     "code-pushup": "./src/index.js"
   },
+  "engines": {
+    "node": ">=20"
+  },
   "dependencies": {
     "@code-pushup/models": "0.66.2",
     "@code-pushup/core": "0.66.2",


### PR DESCRIPTION
closes #864 

- [x] add minimal node of 20 to engine of the `@code-pushup/cli` `package.json`
- [x] add badge to the Readme
- [x] fix bump node version in the example CI action to v22 and update the actions used to v4 from deprecated v3