### PR TITLE
fix(ci): use absolute path in print-config --output file

### DIFF
--- a/packages/ci/src/lib/cli/commands/print-config.ts
+++ b/packages/ci/src/lib/cli/commands/print-config.ts
@@ -17,7 +17,7 @@ export async function runPrintConfig({
 }: CommandContext): Promise<unknown> {
   // random file name so command can be run in parallel
   const outputFile = `code-pushup.${generateRandomId()}.config.json`;
-  const outputPath = path.join(directory, outputFile);
+  const outputPath = path.resolve(directory, outputFile);
 
   await executeProcess({
     command: bin,
@@ -25,7 +25,7 @@ export async function runPrintConfig({
       ...(config ? [`--config=${config}`] : []),
       'print-config',
       ...(isVerbose() ? ['--verbose'] : []),
-      `--output=${outputFile}`,
+      `--output=${outputPath}`,
     ],
     cwd: directory,
     observer,

--- a/packages/ci/src/lib/run.integration.test.ts
+++ b/packages/ci/src/lib/run.integration.test.ts
@@ -132,7 +132,7 @@ describe('runInCI', () => {
           ?.find(arg => arg.startsWith('--output='))
           ?.split('=')[1];
         if (outputFile) {
-          await writeFile(path.join(cwd as string, outputFile), content);
+          await writeFile(path.resolve(cwd as string, outputFile), content);
         } else {
           stdout = content;
         }


### PR DESCRIPTION
Should fix error from codebase where Nx target is run in project directory :crossed_fingers: 

![image](https://github.com/user-attachments/assets/02cfdeca-d9a3-4020-b76c-ee54b8cce5e3)
