### PR TITLE
feat(ci): make print-config and compare commands nx cache friendly

### DIFF
--- a/packages/ci/src/lib/cli/commands/print-config.ts
+++ b/packages/ci/src/lib/cli/commands/print-config.ts
@@ -2,7 +2,6 @@ import { rm } from 'node:fs/promises';
 import path from 'node:path';
 import {
   executeProcess,
-  generateRandomId,
   isVerbose,
   readJsonFile,
   stringifyError,
@@ -13,11 +12,19 @@ export async function runPrintConfig({
   bin,
   config,
   directory,
+  project,
   observer,
 }: CommandContext): Promise<unknown> {
-  // random file name so command can be run in parallel
-  const outputFile = `code-pushup.${generateRandomId()}.config.json`;
-  const outputPath = path.resolve(directory, outputFile);
+  // unique file name per project so command can be run in parallel
+  const outputFile = ['code-pushup', 'config', project, 'json']
+    .filter(Boolean)
+    .join('.');
+  const outputPath =
+    project && directory === process.cwd()
+      ? // cache-friendly path for Nx projects (assuming {workspaceRoot}/.code-pushup/{projectName})
+        path.join(process.cwd(), '.code-pushup', project, outputFile)
+      : // absolute path
+        path.resolve(directory, '.code-pushup', outputFile);
 
   await executeProcess({
     command: bin,

--- a/packages/ci/src/lib/cli/context.ts
+++ b/packages/ci/src/lib/cli/context.ts
@@ -4,6 +4,7 @@ import type { Settings } from '../models.js';
 import type { ProjectConfig } from '../monorepo/index.js';
 
 export type CommandContext = Pick<Settings, 'bin' | 'config' | 'directory'> & {
+  project?: string;
   observer?: ProcessObserver;
 };
 
@@ -15,6 +16,7 @@ export function createCommandContext(
     bin: project?.bin ?? bin,
     directory: project?.directory ?? directory,
     config,
+    ...(project?.name && { project: project.name }),
     observer: createExecutionObserver({ silent }),
   };
 }

--- a/packages/ci/src/lib/cli/context.unit.test.ts
+++ b/packages/ci/src/lib/cli/context.unit.test.ts
@@ -63,6 +63,7 @@ describe('createCommandContext', () => {
       bin: 'yarn code-pushup',
       directory: '/test/ui',
       config: null,
+      project: 'ui',
       observer: expectedObserver,
     });
   });

--- a/packages/ci/src/lib/monorepo/handlers/nx.ts
+++ b/packages/ci/src/lib/monorepo/handlers/nx.ts
@@ -41,7 +41,7 @@ export const nxHandler: MonorepoToolHandler = {
     const projects = parseProjects(stdout);
     return projects.toSorted().map(project => ({
       name: project,
-      bin: `npx nx run ${project}:${task} --skip-nx-cache --`,
+      bin: `npx nx run ${project}:${task} --`,
     }));
   },
 

--- a/packages/ci/src/lib/monorepo/handlers/nx.unit.test.ts
+++ b/packages/ci/src/lib/monorepo/handlers/nx.unit.test.ts
@@ -56,14 +56,8 @@ describe('nxHandler', () => {
 
     it('should list projects from `nx show projects`', async () => {
       await expect(nxHandler.listProjects(options)).resolves.toEqual([
-        {
-          name: 'backend',
-          bin: 'npx nx run backend:code-pushup --skip-nx-cache --',
-        },
-        {
-          name: 'frontend',
-          bin: 'npx nx run frontend:code-pushup --skip-nx-cache --',
-        },
+        { name: 'backend', bin: 'npx nx run backend:code-pushup --' },
+        { name: 'frontend', bin: 'npx nx run frontend:code-pushup --' },
       ] satisfies ProjectConfig[]);
     });
 
@@ -125,14 +119,8 @@ describe('nxHandler', () => {
   describe('createRunManyCommand', () => {
     const projects: MonorepoHandlerProjectsContext = {
       all: [
-        {
-          name: 'backend',
-          bin: 'npx nx run backend:code-pushup --skip-nx-cache --',
-        },
-        {
-          name: 'frontend',
-          bin: 'npx nx run frontend:code-pushup --skip-nx-cache --',
-        },
+        { name: 'backend', bin: 'npx nx run backend:code-pushup --' },
+        { name: 'frontend', bin: 'npx nx run frontend:code-pushup --' },
       ],
     };
 

--- a/packages/ci/src/lib/monorepo/handlers/turbo.ts
+++ b/packages/ci/src/lib/monorepo/handlers/turbo.ts
@@ -32,7 +32,7 @@ export const turboHandler: MonorepoToolHandler = {
           .map(({ name, directory }) => ({
             name,
             directory,
-            bin: `npx turbo run ${options.task} --no-cache --force --`,
+            bin: `npx turbo run ${options.task} --`,
           }));
       }
     }

--- a/packages/ci/src/lib/monorepo/handlers/turbo.unit.test.ts
+++ b/packages/ci/src/lib/monorepo/handlers/turbo.unit.test.ts
@@ -137,12 +137,12 @@ describe('turboHandler', () => {
           {
             name: '@example/cli',
             directory: path.join(MEMFS_VOLUME, 'packages', 'cli'),
-            bin: 'npx turbo run code-pushup --no-cache --force --',
+            bin: 'npx turbo run code-pushup --',
           },
           {
             name: '@example/core',
             directory: path.join(MEMFS_VOLUME, 'packages', 'core'),
-            bin: 'npx turbo run code-pushup --no-cache --force --',
+            bin: 'npx turbo run code-pushup --',
           },
         ] satisfies ProjectConfig[]);
       },
@@ -171,19 +171,19 @@ describe('turboHandler', () => {
           name: 'api',
           directory: path.join(MEMFS_VOLUME, 'api'),
           bin: 'npx turbo run code-pushup --',
-          binUncached: 'npx turbo run code-pushup --no-cache --force --',
+          binUncached: 'npx turbo run code-pushup --',
         },
         {
           name: 'cms',
           directory: path.join(MEMFS_VOLUME, 'cms'),
           bin: 'npx turbo run code-pushup --',
-          binUncached: 'npx turbo run code-pushup --no-cache --force --',
+          binUncached: 'npx turbo run code-pushup --',
         },
         {
           name: 'web',
           directory: path.join(MEMFS_VOLUME, 'web'),
           bin: 'npx turbo run code-pushup --',
-          binUncached: 'npx turbo run code-pushup --no-cache --force --',
+          binUncached: 'npx turbo run code-pushup --',
         },
       ],
     };

--- a/packages/ci/src/lib/monorepo/list-projects.unit.test.ts
+++ b/packages/ci/src/lib/monorepo/list-projects.unit.test.ts
@@ -58,14 +58,8 @@ describe('listMonorepoProjects', () => {
     await expect(listMonorepoProjects(MONOREPO_SETTINGS)).resolves.toEqual({
       tool: 'nx',
       projects: [
-        {
-          name: 'backend',
-          bin: 'npx nx run backend:code-pushup --skip-nx-cache --',
-        },
-        {
-          name: 'frontend',
-          bin: 'npx nx run frontend:code-pushup --skip-nx-cache --',
-        },
+        { name: 'backend', bin: 'npx nx run backend:code-pushup --' },
+        { name: 'frontend', bin: 'npx nx run frontend:code-pushup --' },
       ],
       runManyCommand: expect.any(Function),
     } satisfies MonorepoProjects);
@@ -126,22 +120,22 @@ describe('listMonorepoProjects', () => {
         {
           name: 'api',
           directory: path.join(MEMFS_VOLUME, 'backend', 'api'),
-          bin: 'npx turbo run code-pushup --no-cache --force --',
+          bin: 'npx turbo run code-pushup --',
         },
         {
           name: 'auth',
           directory: path.join(MEMFS_VOLUME, 'backend', 'auth'),
-          bin: 'npx turbo run code-pushup --no-cache --force --',
+          bin: 'npx turbo run code-pushup --',
         },
         {
           name: 'cms',
           directory: path.join(MEMFS_VOLUME, 'frontend', 'cms'),
-          bin: 'npx turbo run code-pushup --no-cache --force --',
+          bin: 'npx turbo run code-pushup --',
         },
         {
           name: 'web',
           directory: path.join(MEMFS_VOLUME, 'frontend', 'web'),
-          bin: 'npx turbo run code-pushup --no-cache --force --',
+          bin: 'npx turbo run code-pushup --',
         },
       ],
       runManyCommand: expect.any(Function),

--- a/packages/ci/src/lib/run.integration.test.ts
+++ b/packages/ci/src/lib/run.integration.test.ts
@@ -132,7 +132,9 @@ describe('runInCI', () => {
           ?.find(arg => arg.startsWith('--output='))
           ?.split('=')[1];
         if (outputFile) {
-          await writeFile(path.resolve(cwd as string, outputFile), content);
+          const outputPath = path.resolve(cwd as string, outputFile);
+          await mkdir(path.dirname(outputPath), { recursive: true });
+          await writeFile(outputPath, content);
         } else {
           stdout = content;
         }

--- a/packages/ci/src/lib/run.integration.test.ts
+++ b/packages/ci/src/lib/run.integration.test.ts
@@ -534,7 +534,7 @@ describe('runInCI', () => {
       name: 'Nx',
       tool: 'nx',
       run: expect.stringMatching(
-        /^npx nx run (cli|core|utils):code-pushup --skip-nx-cache --$/,
+        /^npx nx run (cli|core|utils):code-pushup --$/,
       ),
       runMany:
         'npx nx run-many --targets=code-pushup --parallel=false --projects=cli,core,utils --',
@@ -542,7 +542,7 @@ describe('runInCI', () => {
     {
       name: 'Turborepo',
       tool: 'turbo',
-      run: 'npx turbo run code-pushup --no-cache --force --',
+      run: 'npx turbo run code-pushup --',
       runMany: 'npx turbo run code-pushup --concurrency=1 --',
     },
     {


### PR DESCRIPTION
Turns out some Nx monorepos need to cache commands like `print-config` and `compare` as well. Previously, `--skip-nx-cache` was added in #942 due to difficulty in configuring Nx cache correctly for these commands. Adjusted the output files to match expected `{workspaceRoot}/.code-pushup/{projectName}` cache configuration.