### PR TITLE
fix(plugin-coverage): prevent invalid coverage when lcov has hit > found

### DIFF
--- a/packages/plugin-coverage/src/lib/runner/lcov/lcov-runner.unit.test.ts
+++ b/packages/plugin-coverage/src/lib/runner/lcov/lcov-runner.unit.test.ts
@@ -39,7 +39,7 @@ SF:kw/__init__.py
 DA:1,1,gG9L/J2A/IwO9tZM1raZxQ
 DA:0,0,gG9L/J2A/IwO9tZM1raZxQ
 LF:2
-LH:1
+LH:3
 BRF:0
 BRH:0
 end_of_record
@@ -125,12 +125,14 @@ end_of_record
       parseLcovFiles([path.join('coverage', 'pytest', 'lcov.info')]),
     ).resolves.toEqual([
       expect.objectContaining({
-        lines: expect.objectContaining({
+        lines: {
+          found: 2,
+          hit: 2, // not 3
           details: [
             { hit: 1, line: 1 },
             // no { hit: 0, line: 0 },
           ],
-        }),
+        },
       }),
     ]);
   });


### PR DESCRIPTION
The `pytest` LCOV report can produce records with a higher `hit` than `found`, which results in an invalid coverage percentage :sweat_smile: 

![image](https://github.com/user-attachments/assets/cf8bd845-901d-4ecc-9b92-6be8cba3864b)
