### PR TITLE
test: rename nxv-e2e target to e2e-test

### DIFF
--- a/.github/ISSUE_TEMPLATE/plugin-request.yaml
+++ b/.github/ISSUE_TEMPLATE/plugin-request.yaml
@@ -37,7 +37,7 @@ body:
       placeholder: |
         For example:
         - [ ] All packages have a comprehensive documentation in place.
-        - [ ] All unit, integration and e2e tests for the plugin.
+        - [ ] All unit, integration and E2E tests for the plugin.
         - [ ] Cross references to relevant models or files are added as links.
     validations:
       required: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: E2E test affected projects
-        run: npx nx affected -t nxv-e2e --parallel=1
+        run: npx nx affected -t e2e-test --parallel=1
 
   build:
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ npx nx run-many -t unit-test
 npx nx run-many -t int-test
 
 # run E2E tests for CLI
-npx nx e2e cli-e2e
+npx nx e2e-test cli-e2e
 
 # build CLI along with packages it depends on
 npx nx build cli

--- a/nx.json
+++ b/nx.json
@@ -91,7 +91,10 @@
       "options": {
         "environments": {
           "environmentsDir": "tmp/e2e",
-          "targetNames": ["e2e"]
+          "targetNames": ["e2e"],
+          "inferredTargets": {
+            "e2e": "e2e-test"
+          }
         },
         "packages": {
           "filterByTags": ["publishable"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "@nx/react": "19.8.13",
         "@nx/vite": "19.8.13",
         "@nx/workspace": "19.8.13",
-        "@push-based/nx-verdaccio": "0.0.0-alpha.30",
+        "@push-based/nx-verdaccio": "^0.0.0",
         "@swc-node/register": "1.9.2",
         "@swc/cli": "0.3.14",
         "@swc/core": "1.5.7",
@@ -5671,10 +5671,11 @@
       }
     },
     "node_modules/@push-based/nx-verdaccio": {
-      "version": "0.0.0-alpha.30",
-      "resolved": "https://registry.npmjs.org/@push-based/nx-verdaccio/-/nx-verdaccio-0.0.0-alpha.30.tgz",
-      "integrity": "sha512-PB/WpfcqmyypyXkWKJBVinIgvOgYJV3ckXdQXKBHJuEKyUnfiUObmgnGqmlQqCgFlv5tvPkNGEFXDPTGL9JyGw==",
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/@push-based/nx-verdaccio/-/nx-verdaccio-0.0.0.tgz",
+      "integrity": "sha512-uQTjzSnnRKGqViegKcE42a/Rn1OQnsbEeG/xgoRIu+9SwNBItLvWMigSXGfbU6IgIYb3TUzbD7w7V18TAwwXmA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@nx/devkit": "19.8.0",
         "@nx/vite": "19.8.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@nx/react": "19.8.13",
     "@nx/vite": "19.8.13",
     "@nx/workspace": "19.8.13",
-    "@push-based/nx-verdaccio": "0.0.0-alpha.30",
+    "@push-based/nx-verdaccio": "^0.0.0",
     "@swc-node/register": "1.9.2",
     "@swc/cli": "0.3.14",
     "@swc/core": "1.5.7",


### PR DESCRIPTION
Follow-up to:

- #1018
- push-based/nx-verdaccio#79

Now all test targets follow the `<type>-test` naming pattern:

- `unit-test` - execute unit tests
- `int-test` - execute integration tests
- `e2e-test` - execute end-to-end tests