### PR TITLE
feat(plugin-lighthouse): implement multiple URL support

### DIFF
--- a/code-pushup.preset.ts
+++ b/code-pushup.preset.ts
@@ -20,7 +20,9 @@ import {
 } from './packages/plugin-jsdocs/src/lib/constants.js';
 import { filterGroupsByOnlyAudits } from './packages/plugin-jsdocs/src/lib/utils.js';
 import lighthousePlugin, {
+  type LighthouseUrls,
   lighthouseGroupRef,
+  mergeLighthouseCategories,
 } from './packages/plugin-lighthouse/src/index.js';
 import typescriptPlugin, {
   type TypescriptPluginOptions,
@@ -135,11 +137,14 @@ export const jsPackagesCoreConfig = async (): Promise<CoreConfig> => ({
 });
 
 export const lighthouseCoreConfig = async (
-  url: string,
-): Promise<CoreConfig> => ({
-  plugins: [await lighthousePlugin(url)],
-  categories: lighthouseCategories,
-});
+  urls: LighthouseUrls,
+): Promise<CoreConfig> => {
+  const lhPlugin = await lighthousePlugin(urls);
+  return {
+    plugins: [lhPlugin],
+    categories: mergeLighthouseCategories(lhPlugin, lighthouseCategories),
+  };
+};
 
 export const jsDocsCoreConfig = (
   config: JsDocsPluginConfig | string[],

--- a/e2e/plugin-lighthouse-e2e/tests/__snapshots__/collect.e2e.test.ts.snap
+++ b/e2e/plugin-lighthouse-e2e/tests/__snapshots__/collect.e2e.test.ts.snap
@@ -77,6 +77,12 @@ exports[`PLUGIN collect report with lighthouse-plugin NPM package > should run p
           "title": "Document has a valid \`hreflang\`",
         },
       ],
+      "context": {
+        "urlCount": 1,
+        "weights": {
+          "1": 1,
+        },
+      },
       "groups": [
         {
           "refs": [

--- a/packages/cli/src/lib/implementation/filter.middleware.ts
+++ b/packages/cli/src/lib/implementation/filter.middleware.ts
@@ -116,10 +116,13 @@ function applyPluginFilters(
   options: Pick<FilterOptions, 'skipPlugins' | 'onlyPlugins'>,
 ): CoreConfig['plugins'] {
   const { skipPlugins = [], onlyPlugins = [] } = options;
-  const filteredPlugins = filterPluginsFromCategories({
-    categories,
-    plugins,
-  });
+  const filteredPlugins =
+    onlyPlugins.length === 0
+      ? filterPluginsFromCategories({
+          categories,
+          plugins,
+        })
+      : plugins;
   if (skipPlugins.length === 0 && onlyPlugins.length === 0) {
     return filteredPlugins;
   }

--- a/packages/cli/src/lib/implementation/filter.middleware.unit.test.ts
+++ b/packages/cli/src/lib/implementation/filter.middleware.unit.test.ts
@@ -414,6 +414,44 @@ describe('filterMiddleware', () => {
       ),
     );
   });
+
+  it('should allow onlyPlugins to include plugins not referenced by categories', () => {
+    const { plugins } = filterMiddleware({
+      plugins: [
+        {
+          slug: 'p1',
+          audits: [{ slug: 'a1-p1', isSkipped: false }],
+          groups: [
+            {
+              slug: 'g1-p1',
+              refs: [{ slug: 'a1-p1', weight: 1 }],
+              isSkipped: false,
+            },
+          ],
+        },
+        {
+          slug: 'p2',
+          audits: [{ slug: 'a1-p2', isSkipped: false }],
+          groups: [
+            {
+              slug: 'g1-p2',
+              refs: [{ slug: 'a1-p2', weight: 1 }],
+              isSkipped: false,
+            },
+          ],
+        },
+      ] as PluginConfig[],
+      categories: [
+        {
+          slug: 'c1',
+          refs: [{ type: 'group', plugin: 'p1', slug: 'g1-p1', weight: 1 }],
+        },
+      ] as CategoryConfig[],
+      onlyPlugins: ['p2'],
+    });
+
+    expect(plugins.map(plugin => plugin.slug)).toStrictEqual(['p2']);
+  });
 });
 
 describe('filterSkippedInPlugins', () => {

--- a/packages/models/src/index.ts
+++ b/packages/models/src/index.ts
@@ -67,8 +67,10 @@ export {
 } from './lib/persist-config.js';
 export {
   pluginConfigSchema,
+  pluginContextSchema,
   pluginMetaSchema,
   type PluginConfig,
+  type PluginContext,
   type PluginMeta,
 } from './lib/plugin-config.js';
 export {

--- a/packages/models/src/lib/plugin-config.ts
+++ b/packages/models/src/lib/plugin-config.ts
@@ -10,6 +10,12 @@ import {
 import { errorItems, hasMissingStrings } from './implementation/utils.js';
 import { runnerConfigSchema, runnerFunctionSchema } from './runner-config.js';
 
+export const pluginContextSchema = z
+  .record(z.unknown())
+  .optional()
+  .describe('Plugin-specific context data for helpers');
+export type PluginContext = z.infer<typeof pluginContextSchema>;
+
 export const pluginMetaSchema = packageVersionSchema()
   .merge(
     metaSchema({
@@ -31,6 +37,7 @@ export const pluginDataSchema = z.object({
   runner: z.union([runnerConfigSchema, runnerFunctionSchema]),
   audits: pluginAuditsSchema,
   groups: groupsSchema,
+  context: pluginContextSchema,
 });
 type PluginData = z.infer<typeof pluginDataSchema>;
 

--- a/packages/plugin-lighthouse/src/index.ts
+++ b/packages/plugin-lighthouse/src/index.ts
@@ -6,11 +6,12 @@ export {
   LIGHTHOUSE_PLUGIN_SLUG,
   LIGHTHOUSE_OUTPUT_PATH,
 } from './lib/constants.js';
-export {
-  lighthouseAuditRef,
-  lighthouseGroupRef,
-  type LighthouseGroupSlugs,
-} from './lib/utils.js';
-export type { LighthouseOptions } from './lib/types.js';
+export { lighthouseAuditRef, lighthouseGroupRef } from './lib/utils.js';
+export type {
+  LighthouseGroupSlugs,
+  LighthouseOptions,
+  LighthouseUrls,
+} from './lib/types.js';
 export { lighthousePlugin } from './lib/lighthouse-plugin.js';
 export default lighthousePlugin;
+export { mergeLighthouseCategories } from './lib/merge-categories.js';

--- a/packages/plugin-lighthouse/src/index.ts
+++ b/packages/plugin-lighthouse/src/index.ts
@@ -8,7 +8,7 @@ export {
 } from './lib/constants.js';
 export { lighthouseAuditRef, lighthouseGroupRef } from './lib/utils.js';
 export type {
-  LighthouseGroupSlugs,
+  LighthouseGroupSlug,
   LighthouseOptions,
   LighthouseUrls,
 } from './lib/types.js';

--- a/packages/plugin-lighthouse/src/lib/constants.ts
+++ b/packages/plugin-lighthouse/src/lib/constants.ts
@@ -10,3 +10,13 @@ export const LIGHTHOUSE_OUTPUT_PATH = path.join(
   DEFAULT_PERSIST_OUTPUT_DIR,
   LIGHTHOUSE_PLUGIN_SLUG,
 );
+
+export const LIGHTHOUSE_GROUP_SLUGS = [
+  'performance',
+  'accessibility',
+  'best-practices',
+  'seo',
+  'pwa',
+] as const;
+
+export const SINGLE_URL_THRESHOLD = 1;

--- a/packages/plugin-lighthouse/src/lib/lighthouse-plugin.ts
+++ b/packages/plugin-lighthouse/src/lib/lighthouse-plugin.ts
@@ -13,7 +13,7 @@ export function lighthousePlugin(
   const { skipAudits, onlyAudits, onlyCategories, ...unparsedFlags } =
     normalizeFlags(flags ?? {});
 
-  const normalizedUrls = normalizeUrlInput(urls);
+  const { urls: normalizedUrls, context } = normalizeUrlInput(urls);
 
   const { audits, groups } = processAuditsAndGroups(normalizedUrls, {
     skipAudits,
@@ -39,5 +39,6 @@ export function lighthousePlugin(
       onlyCategories,
       ...unparsedFlags,
     }),
+    context,
   };
 }

--- a/packages/plugin-lighthouse/src/lib/lighthouse-plugin.unit.test.ts
+++ b/packages/plugin-lighthouse/src/lib/lighthouse-plugin.unit.test.ts
@@ -18,6 +18,28 @@ describe('lighthousePlugin-config-object', () => {
     ]);
   });
 
+  it('should create valid plugin config with multiple URLs', () => {
+    const urls = [
+      'https://code-pushup-portal.com',
+      'https://code-pushup-portal.com/about',
+    ];
+    const pluginConfig = lighthousePlugin(urls);
+    expect(() => pluginConfigSchema.parse(pluginConfig)).not.toThrow();
+
+    const { audits, groups } = pluginConfig;
+    expect(audits.length).toBeGreaterThan(100);
+    expect(groups).toStrictEqual([
+      expect.objectContaining({ slug: 'performance-1' }),
+      expect.objectContaining({ slug: 'accessibility-1' }),
+      expect.objectContaining({ slug: 'best-practices-1' }),
+      expect.objectContaining({ slug: 'seo-1' }),
+      expect.objectContaining({ slug: 'performance-2' }),
+      expect.objectContaining({ slug: 'accessibility-2' }),
+      expect.objectContaining({ slug: 'best-practices-2' }),
+      expect.objectContaining({ slug: 'seo-2' }),
+    ]);
+  });
+
   it.each([
     [
       { onlyAudits: ['first-contentful-paint'] },

--- a/packages/plugin-lighthouse/src/lib/lighthouse-plugin.unit.test.ts
+++ b/packages/plugin-lighthouse/src/lib/lighthouse-plugin.unit.test.ts
@@ -19,11 +19,10 @@ describe('lighthousePlugin-config-object', () => {
   });
 
   it('should create valid plugin config with multiple URLs', () => {
-    const urls = [
+    const pluginConfig = lighthousePlugin([
       'https://code-pushup-portal.com',
       'https://code-pushup-portal.com/about',
-    ];
-    const pluginConfig = lighthousePlugin(urls);
+    ]);
     expect(() => pluginConfigSchema.parse(pluginConfig)).not.toThrow();
 
     const { audits, groups } = pluginConfig;
@@ -38,6 +37,18 @@ describe('lighthousePlugin-config-object', () => {
       expect.objectContaining({ slug: 'best-practices-2' }),
       expect.objectContaining({ slug: 'seo-2' }),
     ]);
+  });
+
+  it('should generate context for multiple URLs', () => {
+    const pluginConfig = lighthousePlugin({
+      'https://code-pushup-portal.com': 2,
+      'https://code-pushup-portal.com/about': 1,
+    });
+
+    expect(pluginConfig.context).toStrictEqual({
+      urlCount: 2,
+      weights: { 1: 2, 2: 1 },
+    });
   });
 
   it.each([

--- a/packages/plugin-lighthouse/src/lib/merge-categories.ts
+++ b/packages/plugin-lighthouse/src/lib/merge-categories.ts
@@ -1,0 +1,97 @@
+import type { CategoryConfig, Group, PluginConfig } from '@code-pushup/models';
+import { LIGHTHOUSE_GROUP_SLUGS, LIGHTHOUSE_PLUGIN_SLUG } from './constants.js';
+import { orderSlug, shouldExpandForUrls } from './processing.js';
+import { LIGHTHOUSE_GROUPS } from './runner/constants.js';
+import type { LighthouseGroupSlugs } from './types.js';
+import { isLighthouseGroupSlug } from './utils.js';
+
+export function mergeLighthouseCategories(
+  { groups }: Pick<PluginConfig, 'groups'>,
+  categories?: CategoryConfig[],
+): CategoryConfig[] {
+  if (!groups) {
+    return categories ?? [];
+  }
+  if (!categories) {
+    return createCategories(groups);
+  }
+  return expandCategories(categories, groups);
+}
+
+function createCategories(groups: Group[]): CategoryConfig[] {
+  const urlCount = countUrls(groups);
+  if (!shouldExpandForUrls(urlCount)) {
+    return [];
+  }
+  return extractGroupSlugs(groups)
+    .filter(isLighthouseGroupSlug)
+    .map(slug => createAggregatedCategory(slug, urlCount));
+}
+
+function expandCategories(
+  categories: CategoryConfig[],
+  groups: Group[],
+): CategoryConfig[] {
+  const urlCount = countUrls(groups);
+  if (!shouldExpandForUrls(urlCount)) {
+    return categories;
+  }
+  return categories.map(category =>
+    expandAggregatedCategory(category, urlCount),
+  );
+}
+
+export function createAggregatedCategory(
+  groupSlug: LighthouseGroupSlugs,
+  urlCount: number,
+): CategoryConfig {
+  const group = LIGHTHOUSE_GROUPS.find(({ slug }) => slug === groupSlug);
+  if (!group) {
+    const availableSlugs = LIGHTHOUSE_GROUP_SLUGS.join(', ');
+    throw new Error(
+      `Invalid Lighthouse group slug: "${groupSlug}". Available groups: ${availableSlugs}`,
+    );
+  }
+  return {
+    slug: group.slug,
+    title: group.title,
+    ...(group.description && { description: group.description }),
+    refs: Array.from({ length: urlCount }, (_, i) => ({
+      plugin: LIGHTHOUSE_PLUGIN_SLUG,
+      slug: orderSlug(group.slug, i),
+      type: 'group',
+      weight: 1,
+    })),
+  };
+}
+
+export function expandAggregatedCategory(
+  category: CategoryConfig,
+  urlCount: number,
+): CategoryConfig {
+  return {
+    ...category,
+    refs: category.refs.flatMap(ref => {
+      if (ref.plugin === LIGHTHOUSE_PLUGIN_SLUG) {
+        return Array.from({ length: urlCount }, (_, i) => ({
+          ...ref,
+          slug: orderSlug(ref.slug, i),
+        }));
+      }
+      return [ref];
+    }),
+  };
+}
+
+export function countUrls(groups: Group[]): number {
+  const suffixes = groups
+    .map(({ slug }) => slug.match(/-(\d+)$/)?.[1])
+    .filter(Boolean)
+    .map(Number)
+    .filter(n => !Number.isNaN(n));
+  return suffixes.length > 0 ? Math.max(...suffixes) : 1;
+}
+
+export function extractGroupSlugs(groups: Group[]): string[] {
+  return [...new Set(groups.map(({ slug }) => slug.replace(/-\d+$/, '')))];
+}

--- a/packages/plugin-lighthouse/src/lib/merge-categories.ts
+++ b/packages/plugin-lighthouse/src/lib/merge-categories.ts
@@ -31,11 +31,11 @@ export function mergeLighthouseCategories(
   if (!plugin.groups || plugin.groups.length === 0) {
     return categories ?? [];
   }
-  const validContext = validateContext(plugin.context);
+  validateContext(plugin.context);
   if (!categories) {
-    return createCategories(plugin.groups, validContext);
+    return createCategories(plugin.groups, plugin.context);
   }
-  return expandCategories(categories, validContext);
+  return expandCategories(categories, plugin.context);
 }
 
 function createCategories(
@@ -134,20 +134,20 @@ export class ContextValidationError extends Error {
 
 export function validateContext(
   context: PluginConfig['context'],
-): LighthouseContext {
+): asserts context is LighthouseContext {
   if (!context || typeof context !== 'object') {
     throw new ContextValidationError('must be an object');
   }
-  if (typeof context['urlCount'] !== 'number' || context['urlCount'] < 0) {
+  const { urlCount, weights } = context;
+  if (typeof urlCount !== 'number' || urlCount < 0) {
     throw new ContextValidationError('urlCount must be a non-negative number');
   }
-  if (!context['weights'] || typeof context['weights'] !== 'object') {
+  if (!weights || typeof weights !== 'object') {
     throw new ContextValidationError('weights must be an object');
   }
-  if (Object.keys(context['weights']).length !== context['urlCount']) {
-    throw new ContextValidationError('urlCount and weights length must match');
+  if (Object.keys(weights).length !== urlCount) {
+    throw new ContextValidationError('weights count must match urlCount');
   }
-  return context as LighthouseContext;
 }
 
 function resolveWeight(

--- a/packages/plugin-lighthouse/src/lib/merge-categories.ts
+++ b/packages/plugin-lighthouse/src/lib/merge-categories.ts
@@ -2,7 +2,7 @@ import type { CategoryConfig, Group, PluginConfig } from '@code-pushup/models';
 import { LIGHTHOUSE_GROUP_SLUGS, LIGHTHOUSE_PLUGIN_SLUG } from './constants.js';
 import { orderSlug, shouldExpandForUrls } from './processing.js';
 import { LIGHTHOUSE_GROUPS } from './runner/constants.js';
-import type { LighthouseContext, LighthouseGroupSlugs } from './types.js';
+import type { LighthouseContext, LighthouseGroupSlug } from './types.js';
 import { isLighthouseGroupSlug } from './utils.js';
 
 /**
@@ -67,7 +67,7 @@ function expandCategories(
  * Only used when user categories are not provided.
  */
 export function createAggregatedCategory(
-  groupSlug: LighthouseGroupSlugs,
+  groupSlug: LighthouseGroupSlug,
   context: LighthouseContext,
 ): CategoryConfig {
   const group = LIGHTHOUSE_GROUPS.find(({ slug }) => slug === groupSlug);
@@ -121,7 +121,7 @@ export function expandAggregatedCategory(
  * Extracts unique, unsuffixed group slugs from a list of groups.
  * Useful for deduplicating and normalizing group slugs when generating categories.
  */
-export function extractGroupSlugs(groups: Group[]): LighthouseGroupSlugs[] {
+export function extractGroupSlugs(groups: Group[]): LighthouseGroupSlug[] {
   const slugs = groups.map(({ slug }) => slug.replace(/-\d+$/, ''));
   return [...new Set(slugs)].filter(isLighthouseGroupSlug);
 }

--- a/packages/plugin-lighthouse/src/lib/merge-categories.unit.test.ts
+++ b/packages/plugin-lighthouse/src/lib/merge-categories.unit.test.ts
@@ -1,0 +1,786 @@
+import { describe, expect, it } from 'vitest';
+import type { CategoryConfig, Group } from '@code-pushup/models';
+import { LIGHTHOUSE_PLUGIN_SLUG } from './constants.js';
+import {
+  countUrls,
+  createAggregatedCategory,
+  expandAggregatedCategory,
+  extractGroupSlugs,
+  mergeLighthouseCategories,
+} from './merge-categories.js';
+
+describe('mergeLighthouseCategories', () => {
+  const mockSingleUrlPlugin = {
+    groups: [
+      {
+        slug: 'performance',
+        title: 'Performance',
+        refs: [{ slug: 'first-contentful-paint', weight: 1 }],
+      },
+      {
+        slug: 'accessibility',
+        title: 'Accessibility',
+        refs: [{ slug: 'color-contrast', weight: 1 }],
+      },
+    ],
+  };
+
+  const mockMultiUrlPlugin = {
+    groups: [
+      {
+        slug: 'performance-1',
+        title: 'Performance (example.com)',
+        refs: [{ slug: 'first-contentful-paint-1', weight: 1 }],
+      },
+      {
+        slug: 'accessibility-1',
+        title: 'Accessibility (example.com)',
+        refs: [{ slug: 'color-contrast-1', weight: 1 }],
+      },
+      {
+        slug: 'performance-2',
+        title: 'Performance (example.com/about)',
+        refs: [{ slug: 'first-contentful-paint-2', weight: 1 }],
+      },
+      {
+        slug: 'accessibility-2',
+        title: 'Accessibility (example.com/about)',
+        refs: [{ slug: 'color-contrast-2', weight: 1 }],
+      },
+    ],
+  };
+
+  const mockUserCategories: CategoryConfig[] = [
+    {
+      slug: 'performance',
+      title: 'Website Performance',
+      description: 'Measures how fast your website loads',
+      refs: [
+        {
+          type: 'group',
+          plugin: LIGHTHOUSE_PLUGIN_SLUG,
+          slug: 'performance',
+          weight: 2,
+        },
+      ],
+    },
+    {
+      slug: 'a11y',
+      title: 'Accessibility',
+      refs: [
+        {
+          type: 'group',
+          plugin: LIGHTHOUSE_PLUGIN_SLUG,
+          slug: 'accessibility',
+          weight: 1,
+        },
+      ],
+    },
+  ];
+
+  describe('with no groups', () => {
+    it('should return empty array when no groups and no categories provided', () => {
+      expect(mergeLighthouseCategories({ groups: undefined })).toEqual([]);
+    });
+
+    it('should return provided categories when no groups', () => {
+      expect(
+        mergeLighthouseCategories({ groups: undefined }, mockUserCategories),
+      ).toEqual(mockUserCategories);
+    });
+  });
+
+  describe('with single URL', () => {
+    it('should return empty array when no categories provided', () => {
+      expect(mergeLighthouseCategories(mockSingleUrlPlugin)).toEqual([]);
+    });
+
+    it('should return provided categories unchanged', () => {
+      expect(
+        mergeLighthouseCategories(mockSingleUrlPlugin, mockUserCategories),
+      ).toEqual(mockUserCategories);
+    });
+  });
+
+  describe('with multiple URLs', () => {
+    it('should create default aggregated categories when no categories provided', () => {
+      const result = mergeLighthouseCategories(mockMultiUrlPlugin);
+
+      expect(result).toHaveLength(2);
+      expect(result[0]).toEqual({
+        slug: 'performance',
+        title: 'Performance',
+        refs: [
+          {
+            plugin: LIGHTHOUSE_PLUGIN_SLUG,
+            slug: 'performance-1',
+            type: 'group',
+            weight: 1,
+          },
+          {
+            plugin: LIGHTHOUSE_PLUGIN_SLUG,
+            slug: 'performance-2',
+            type: 'group',
+            weight: 1,
+          },
+        ],
+      });
+      expect(result[1]).toEqual({
+        slug: 'accessibility',
+        title: 'Accessibility',
+        description: expect.any(String),
+        refs: [
+          {
+            plugin: LIGHTHOUSE_PLUGIN_SLUG,
+            slug: 'accessibility-1',
+            type: 'group',
+            weight: 1,
+          },
+          {
+            plugin: LIGHTHOUSE_PLUGIN_SLUG,
+            slug: 'accessibility-2',
+            type: 'group',
+            weight: 1,
+          },
+        ],
+      });
+    });
+
+    it('should expand user-provided categories', () => {
+      const result = mergeLighthouseCategories(
+        mockMultiUrlPlugin,
+        mockUserCategories,
+      );
+
+      expect(result).toHaveLength(2);
+      expect(result[0]).toEqual({
+        slug: 'performance',
+        title: 'Website Performance',
+        description: 'Measures how fast your website loads',
+        refs: [
+          {
+            type: 'group',
+            plugin: LIGHTHOUSE_PLUGIN_SLUG,
+            slug: 'performance-1',
+            weight: 2,
+          },
+          {
+            type: 'group',
+            plugin: LIGHTHOUSE_PLUGIN_SLUG,
+            slug: 'performance-2',
+            weight: 2,
+          },
+        ],
+      });
+      expect(result[1]).toEqual({
+        slug: 'a11y',
+        title: 'Accessibility',
+        refs: [
+          {
+            type: 'group',
+            plugin: LIGHTHOUSE_PLUGIN_SLUG,
+            slug: 'accessibility-1',
+            weight: 1,
+          },
+          {
+            type: 'group',
+            plugin: LIGHTHOUSE_PLUGIN_SLUG,
+            slug: 'accessibility-2',
+            weight: 1,
+          },
+        ],
+      });
+    });
+
+    it('should handle mixed group and audit refs', () => {
+      const categoryWithMixedRefs: CategoryConfig[] = [
+        {
+          slug: 'mixed-performance',
+          title: 'Mixed Performance',
+          refs: [
+            {
+              type: 'group',
+              plugin: LIGHTHOUSE_PLUGIN_SLUG,
+              slug: 'performance',
+              weight: 1,
+            },
+            {
+              type: 'audit',
+              plugin: LIGHTHOUSE_PLUGIN_SLUG,
+              slug: 'first-contentful-paint',
+              weight: 2,
+            },
+          ],
+        },
+      ];
+
+      expect(
+        mergeLighthouseCategories(mockMultiUrlPlugin, categoryWithMixedRefs)[0]
+          ?.refs,
+      ).toEqual([
+        {
+          type: 'group',
+          plugin: LIGHTHOUSE_PLUGIN_SLUG,
+          slug: 'performance-1',
+          weight: 1,
+        },
+        {
+          type: 'group',
+          plugin: LIGHTHOUSE_PLUGIN_SLUG,
+          slug: 'performance-2',
+          weight: 1,
+        },
+        {
+          type: 'audit',
+          plugin: LIGHTHOUSE_PLUGIN_SLUG,
+          slug: 'first-contentful-paint-1',
+          weight: 2,
+        },
+        {
+          type: 'audit',
+          plugin: LIGHTHOUSE_PLUGIN_SLUG,
+          slug: 'first-contentful-paint-2',
+          weight: 2,
+        },
+      ]);
+    });
+
+    it('should preserve non-Lighthouse refs unchanged', () => {
+      const categoryWithOtherRefs: CategoryConfig[] = [
+        {
+          slug: 'mixed-category',
+          title: 'Mixed Category',
+          refs: [
+            {
+              type: 'group',
+              plugin: LIGHTHOUSE_PLUGIN_SLUG,
+              slug: 'performance',
+              weight: 1,
+            },
+            { type: 'group', plugin: 'eslint', slug: 'problems', weight: 1 },
+            {
+              type: 'audit',
+              plugin: 'other-plugin',
+              slug: 'some-audit',
+              weight: 1,
+            },
+          ],
+        },
+      ];
+
+      expect(
+        mergeLighthouseCategories(mockMultiUrlPlugin, categoryWithOtherRefs)[0]
+          ?.refs,
+      ).toEqual([
+        {
+          type: 'group',
+          plugin: LIGHTHOUSE_PLUGIN_SLUG,
+          slug: 'performance-1',
+          weight: 1,
+        },
+        {
+          type: 'group',
+          plugin: LIGHTHOUSE_PLUGIN_SLUG,
+          slug: 'performance-2',
+          weight: 1,
+        },
+        { type: 'group', plugin: 'eslint', slug: 'problems', weight: 1 },
+        {
+          type: 'audit',
+          plugin: 'other-plugin',
+          slug: 'some-audit',
+          weight: 1,
+        },
+      ]);
+    });
+
+    it('should handle categories without Lighthouse refs', () => {
+      const categoryWithoutLighthouse: CategoryConfig[] = [
+        {
+          slug: 'code-quality',
+          title: 'Code Quality',
+          refs: [
+            { type: 'group', plugin: 'eslint', slug: 'problems', weight: 1 },
+            {
+              type: 'group',
+              plugin: 'typescript',
+              slug: 'type-issues',
+              weight: 1,
+            },
+          ],
+        },
+      ];
+
+      expect(
+        mergeLighthouseCategories(
+          mockMultiUrlPlugin,
+          categoryWithoutLighthouse,
+        )[0],
+      ).toEqual(categoryWithoutLighthouse[0]);
+    });
+
+    it('should preserve all category properties', () => {
+      const categoryWithAllProps: CategoryConfig[] = [
+        {
+          slug: 'performance',
+          title: 'Performance',
+          description: 'Website performance metrics',
+          docsUrl: 'https://docs.example.com/performance',
+          isBinary: true,
+          refs: [
+            {
+              type: 'group',
+              plugin: LIGHTHOUSE_PLUGIN_SLUG,
+              slug: 'performance',
+              weight: 1,
+            },
+          ],
+        },
+      ];
+
+      expect(
+        mergeLighthouseCategories(mockMultiUrlPlugin, categoryWithAllProps)[0],
+      ).toEqual({
+        slug: 'performance',
+        title: 'Performance',
+        description: 'Website performance metrics',
+        docsUrl: 'https://docs.example.com/performance',
+        isBinary: true,
+        refs: [
+          {
+            type: 'group',
+            plugin: LIGHTHOUSE_PLUGIN_SLUG,
+            slug: 'performance-1',
+            weight: 1,
+          },
+          {
+            type: 'group',
+            plugin: LIGHTHOUSE_PLUGIN_SLUG,
+            slug: 'performance-2',
+            weight: 1,
+          },
+        ],
+      });
+    });
+  });
+
+  describe('URL count detection', () => {
+    it('should handle 3 URLs correctly', () => {
+      const tripleUrlPlugin = {
+        groups: [
+          { slug: 'performance-1', title: 'Performance 1', refs: [] },
+          { slug: 'performance-2', title: 'Performance 2', refs: [] },
+          { slug: 'performance-3', title: 'Performance 3', refs: [] },
+        ],
+      };
+
+      const userCategories: CategoryConfig[] = [
+        {
+          slug: 'performance',
+          title: 'Performance',
+          refs: [
+            {
+              type: 'group',
+              plugin: LIGHTHOUSE_PLUGIN_SLUG,
+              slug: 'performance',
+              weight: 1,
+            },
+          ],
+        },
+      ];
+
+      const result = mergeLighthouseCategories(tripleUrlPlugin, userCategories);
+
+      expect(result[0]?.refs).toHaveLength(3);
+      expect(result[0]?.refs.map(({ slug }) => slug)).toEqual([
+        'performance-1',
+        'performance-2',
+        'performance-3',
+      ]);
+    });
+
+    it('should handle groups with non-sequential numbering', () => {
+      const nonSequentialPlugin = {
+        groups: [
+          { slug: 'performance-1', title: 'Performance 1', refs: [] },
+          { slug: 'performance-5', title: 'Performance 5', refs: [] },
+          { slug: 'accessibility-1', title: 'Accessibility 1', refs: [] },
+          { slug: 'accessibility-5', title: 'Accessibility 5', refs: [] },
+        ],
+      };
+
+      const result = mergeLighthouseCategories(nonSequentialPlugin);
+
+      expect(result[0]?.refs).toHaveLength(5);
+      expect(result[0]?.refs.map(ref => ref.slug)).toEqual([
+        'performance-1',
+        'performance-2',
+        'performance-3',
+        'performance-4',
+        'performance-5',
+      ]);
+    });
+
+    it('should filter out invalid lighthouse groups', () => {
+      const pluginWithInvalidGroups = {
+        groups: [
+          { slug: 'performance-1', title: 'Performance 1', refs: [] },
+          { slug: 'invalid-group-1', title: 'Invalid Group 1', refs: [] },
+          { slug: 'accessibility-1', title: 'Accessibility 1', refs: [] },
+          { slug: 'another-invalid-1', title: 'Another Invalid 1', refs: [] },
+          { slug: 'performance-2', title: 'Performance 2', refs: [] },
+          { slug: 'invalid-group-2', title: 'Invalid Group 2', refs: [] },
+          { slug: 'accessibility-2', title: 'Accessibility 2', refs: [] },
+          { slug: 'another-invalid-2', title: 'Another Invalid 2', refs: [] },
+        ],
+      };
+
+      const result = mergeLighthouseCategories(pluginWithInvalidGroups);
+
+      expect(result).toHaveLength(2);
+      expect(result[0]).toEqual({
+        slug: 'performance',
+        title: 'Performance',
+        refs: [
+          {
+            plugin: LIGHTHOUSE_PLUGIN_SLUG,
+            slug: 'performance-1',
+            type: 'group',
+            weight: 1,
+          },
+          {
+            plugin: LIGHTHOUSE_PLUGIN_SLUG,
+            slug: 'performance-2',
+            type: 'group',
+            weight: 1,
+          },
+        ],
+      });
+      expect(result[1]).toEqual({
+        slug: 'accessibility',
+        title: 'Accessibility',
+        description: expect.any(String),
+        refs: [
+          {
+            plugin: LIGHTHOUSE_PLUGIN_SLUG,
+            slug: 'accessibility-1',
+            type: 'group',
+            weight: 1,
+          },
+          {
+            plugin: LIGHTHOUSE_PLUGIN_SLUG,
+            slug: 'accessibility-2',
+            type: 'group',
+            weight: 1,
+          },
+        ],
+      });
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle empty categories array', () => {
+      expect(mergeLighthouseCategories(mockMultiUrlPlugin, [])).toEqual([]);
+    });
+
+    it('should handle plugin with empty groups array', () => {
+      expect(
+        mergeLighthouseCategories({ groups: [] }, mockUserCategories),
+      ).toEqual(mockUserCategories);
+    });
+
+    it('should handle categories with empty refs', () => {
+      const emptyRefsCategory: CategoryConfig[] = [
+        {
+          slug: 'empty-category',
+          title: 'Empty Category',
+          refs: [],
+        },
+      ];
+
+      expect(
+        mergeLighthouseCategories(mockMultiUrlPlugin, emptyRefsCategory)[0],
+      ).toEqual(emptyRefsCategory[0]);
+    });
+  });
+});
+
+describe('countUrls', () => {
+  it('should return 1 for single URL groups', () => {
+    const groups: Group[] = [
+      { slug: 'performance', title: 'Performance', refs: [] },
+      { slug: 'accessibility', title: 'Accessibility', refs: [] },
+    ];
+    expect(countUrls(groups)).toBe(1);
+  });
+
+  it('should count URLs from numbered suffixes', () => {
+    const groups: Group[] = [
+      { slug: 'performance-1', title: 'Performance 1', refs: [] },
+      { slug: 'performance-2', title: 'Performance 2', refs: [] },
+      { slug: 'accessibility-1', title: 'Accessibility 1', refs: [] },
+      { slug: 'accessibility-2', title: 'Accessibility 2', refs: [] },
+    ];
+    expect(countUrls(groups)).toBe(2);
+  });
+
+  it('should handle non-sequential numbering', () => {
+    const groups: Group[] = [
+      { slug: 'performance-1', title: 'Performance 1', refs: [] },
+      { slug: 'performance-5', title: 'Performance 5', refs: [] },
+      { slug: 'accessibility-1', title: 'Accessibility 1', refs: [] },
+    ];
+    expect(countUrls(groups)).toBe(5);
+  });
+
+  it('should handle mixed numbered and non-numbered groups', () => {
+    const groups: Group[] = [
+      { slug: 'performance', title: 'Performance', refs: [] },
+      { slug: 'performance-3', title: 'Performance 3', refs: [] },
+      { slug: 'accessibility-1', title: 'Accessibility 1', refs: [] },
+    ];
+    expect(countUrls(groups)).toBe(3);
+  });
+
+  it('should return 1 for empty groups array', () => {
+    expect(countUrls([])).toBe(1);
+  });
+
+  it('should ignore invalid number suffixes', () => {
+    const groups: Group[] = [
+      { slug: 'performance-abc', title: 'Performance ABC', refs: [] },
+      { slug: 'accessibility-2', title: 'Accessibility 2', refs: [] },
+    ];
+    expect(countUrls(groups)).toBe(2);
+  });
+});
+
+describe('extractGroupSlugs', () => {
+  it('should extract unique base slugs from numbered groups', () => {
+    const groups: Group[] = [
+      { slug: 'performance-1', title: 'Performance 1', refs: [] },
+      { slug: 'performance-2', title: 'Performance 2', refs: [] },
+      { slug: 'accessibility-1', title: 'Accessibility 1', refs: [] },
+      { slug: 'accessibility-2', title: 'Accessibility 2', refs: [] },
+    ];
+    expect(extractGroupSlugs(groups)).toEqual(['performance', 'accessibility']);
+  });
+
+  it('should handle non-numbered groups', () => {
+    const groups: Group[] = [
+      { slug: 'performance', title: 'Performance', refs: [] },
+      { slug: 'accessibility', title: 'Accessibility', refs: [] },
+    ];
+    expect(extractGroupSlugs(groups)).toEqual(['performance', 'accessibility']);
+  });
+
+  it('should handle mixed numbered and non-numbered groups', () => {
+    const groups: Group[] = [
+      { slug: 'performance', title: 'Performance', refs: [] },
+      { slug: 'accessibility-1', title: 'Accessibility 1', refs: [] },
+      { slug: 'accessibility-2', title: 'Accessibility 2', refs: [] },
+    ];
+    expect(extractGroupSlugs(groups)).toEqual(['performance', 'accessibility']);
+  });
+
+  it('should return unique slugs only', () => {
+    const groups: Group[] = [
+      { slug: 'performance-1', title: 'Performance 1', refs: [] },
+      { slug: 'performance-2', title: 'Performance 2', refs: [] },
+      { slug: 'performance-3', title: 'Performance 3', refs: [] },
+    ];
+    expect(extractGroupSlugs(groups)).toEqual(['performance']);
+  });
+
+  it('should handle empty groups array', () => {
+    expect(extractGroupSlugs([])).toEqual([]);
+  });
+});
+
+describe('createAggregatedCategory', () => {
+  it("should create category with Lighthouse groups' refs", () => {
+    const result = createAggregatedCategory('performance', 2);
+    expect(result).toEqual({
+      slug: 'performance',
+      title: 'Performance',
+      refs: [
+        {
+          plugin: LIGHTHOUSE_PLUGIN_SLUG,
+          slug: 'performance-1',
+          type: 'group',
+          weight: 1,
+        },
+        {
+          plugin: LIGHTHOUSE_PLUGIN_SLUG,
+          slug: 'performance-2',
+          type: 'group',
+          weight: 1,
+        },
+      ],
+    });
+  });
+
+  it('should throw error for unknown group slug', () => {
+    // @ts-expect-error A safeguard test case; the error should never be thrown
+    expect(() => createAggregatedCategory('unknown-group', 1)).toThrow(
+      'Invalid Lighthouse group slug: "unknown-group". Available groups: performance, accessibility, best-practices, seo',
+    );
+  });
+
+  it('should handle single URL', () => {
+    const result = createAggregatedCategory('accessibility', 1);
+
+    expect(result.refs).toHaveLength(1);
+    expect(result.refs[0]?.slug).toBe('accessibility-1');
+  });
+
+  it('should handle multiple URLs', () => {
+    const result = createAggregatedCategory('seo', 3);
+
+    expect(result.refs).toHaveLength(3);
+    expect(result.refs.map(ref => ref.slug)).toEqual([
+      'seo-1',
+      'seo-2',
+      'seo-3',
+    ]);
+  });
+});
+
+describe('expandAggregatedCategory', () => {
+  it('should expand Lighthouse plugin refs only', () => {
+    const category: CategoryConfig = {
+      slug: 'mixed-category',
+      title: 'Mixed Category',
+      refs: [
+        {
+          type: 'group',
+          plugin: LIGHTHOUSE_PLUGIN_SLUG,
+          slug: 'performance',
+          weight: 2,
+        },
+        { type: 'group', plugin: 'eslint', slug: 'problems', weight: 1 },
+      ],
+    };
+
+    expect(expandAggregatedCategory(category, 2).refs).toEqual([
+      {
+        type: 'group',
+        plugin: LIGHTHOUSE_PLUGIN_SLUG,
+        slug: 'performance-1',
+        weight: 2,
+      },
+      {
+        type: 'group',
+        plugin: LIGHTHOUSE_PLUGIN_SLUG,
+        slug: 'performance-2',
+        weight: 2,
+      },
+      { type: 'group', plugin: 'eslint', slug: 'problems', weight: 1 },
+    ]);
+  });
+
+  it('should expand both group and audit refs', () => {
+    const category: CategoryConfig = {
+      slug: 'mixed-refs',
+      title: 'Mixed Refs',
+      refs: [
+        {
+          type: 'group',
+          plugin: LIGHTHOUSE_PLUGIN_SLUG,
+          slug: 'performance',
+          weight: 1,
+        },
+        {
+          type: 'audit',
+          plugin: LIGHTHOUSE_PLUGIN_SLUG,
+          slug: 'first-contentful-paint',
+          weight: 3,
+        },
+      ],
+    };
+
+    expect(expandAggregatedCategory(category, 2).refs).toEqual([
+      {
+        type: 'group',
+        plugin: LIGHTHOUSE_PLUGIN_SLUG,
+        slug: 'performance-1',
+        weight: 1,
+      },
+      {
+        type: 'group',
+        plugin: LIGHTHOUSE_PLUGIN_SLUG,
+        slug: 'performance-2',
+        weight: 1,
+      },
+      {
+        type: 'audit',
+        plugin: LIGHTHOUSE_PLUGIN_SLUG,
+        slug: 'first-contentful-paint-1',
+        weight: 3,
+      },
+      {
+        type: 'audit',
+        plugin: LIGHTHOUSE_PLUGIN_SLUG,
+        slug: 'first-contentful-paint-2',
+        weight: 3,
+      },
+    ]);
+  });
+
+  it('should preserve category properties', () => {
+    const category: CategoryConfig = {
+      slug: 'performance',
+      title: 'Performance',
+      description: 'Website performance metrics',
+      docsUrl: 'https://docs.example.com',
+      isBinary: true,
+      refs: [
+        {
+          type: 'group',
+          plugin: LIGHTHOUSE_PLUGIN_SLUG,
+          slug: 'performance',
+          weight: 1,
+        },
+      ],
+    };
+
+    expect(expandAggregatedCategory(category, 1)).toEqual({
+      slug: 'performance',
+      title: 'Performance',
+      description: 'Website performance metrics',
+      docsUrl: 'https://docs.example.com',
+      isBinary: true,
+      refs: [
+        {
+          type: 'group',
+          plugin: LIGHTHOUSE_PLUGIN_SLUG,
+          slug: 'performance-1',
+          weight: 1,
+        },
+      ],
+    });
+  });
+
+  it('should handle empty refs array', () => {
+    const category: CategoryConfig = {
+      slug: 'empty-category',
+      title: 'Empty Category',
+      refs: [],
+    };
+
+    expect(expandAggregatedCategory(category, 2)).toEqual(category);
+  });
+
+  it('should handle categories with only non-Lighthouse refs', () => {
+    const category: CategoryConfig = {
+      slug: 'eslint-category',
+      title: 'ESLint Category',
+      refs: [
+        { type: 'group', plugin: 'eslint', slug: 'problems', weight: 1 },
+        { type: 'audit', plugin: 'typescript', slug: 'type-check', weight: 1 },
+      ],
+    };
+
+    expect(expandAggregatedCategory(category, 3)).toEqual(category);
+  });
+});

--- a/packages/plugin-lighthouse/src/lib/merge-categories.unit.test.ts
+++ b/packages/plugin-lighthouse/src/lib/merge-categories.unit.test.ts
@@ -398,24 +398,6 @@ describe('mergeLighthouseCategories', () => {
       ]);
     });
 
-    it('should handle groups with non-sequential numbering', () => {
-      const result = mergeLighthouseCategories({
-        groups: [
-          { slug: 'performance-1', title: 'Performance 1', refs: [] },
-          { slug: 'performance-5', title: 'Performance 5', refs: [] },
-          { slug: 'accessibility-1', title: 'Accessibility 1', refs: [] },
-          { slug: 'accessibility-5', title: 'Accessibility 5', refs: [] },
-        ],
-        context: { urlCount: 2, weights: { 1: 1, 5: 1 } },
-      });
-
-      expect(result[0]?.refs).toHaveLength(2);
-      expect(result[0]?.refs.map(ref => ref.slug)).toEqual([
-        'performance-1',
-        'performance-2',
-      ]);
-    });
-
     it('should filter out invalid Lighthouse groups', () => {
       const result = mergeLighthouseCategories({
         groups: [

--- a/packages/plugin-lighthouse/src/lib/processing.ts
+++ b/packages/plugin-lighthouse/src/lib/processing.ts
@@ -1,0 +1,91 @@
+import type { Audit, Group } from '@code-pushup/models';
+import { SINGLE_URL_THRESHOLD } from './constants.js';
+import {
+  LIGHTHOUSE_GROUPS,
+  LIGHTHOUSE_NAVIGATION_AUDITS,
+} from './runner/constants.js';
+import type { LighthouseUrls } from './types.js';
+import { type FilterOptions, markSkippedAuditsAndGroups } from './utils.js';
+
+export function orderSlug(slug: string, index: number): string {
+  return `${slug}-${index + 1}`;
+}
+
+export function shouldExpandForUrls(urlCount: number): boolean {
+  return urlCount > SINGLE_URL_THRESHOLD;
+}
+
+export function normalizeUrlInput(input: LighthouseUrls): string[] {
+  return Array.isArray(input) ? input : [input];
+}
+
+export function getUrlIdentifier(url: string): string {
+  try {
+    const { host, pathname } = new URL(url);
+    const path = pathname === '/' ? '' : pathname;
+    return `${host}${path}`;
+  } catch {
+    return url;
+  }
+}
+
+export function expandAuditsForUrls(audits: Audit[], urls: string[]): Audit[] {
+  return urls.flatMap((url, index) =>
+    audits.map(audit => ({
+      ...audit,
+      slug: orderSlug(audit.slug, index),
+      title: `${audit.title} (${getUrlIdentifier(url)})`,
+    })),
+  );
+}
+
+export function expandGroupsForUrls(groups: Group[], urls: string[]): Group[] {
+  return urls.flatMap((url, index) =>
+    groups.map(group => ({
+      ...group,
+      slug: orderSlug(group.slug, index),
+      title: `${group.title} (${getUrlIdentifier(url)})`,
+      refs: group.refs.map(ref => ({
+        ...ref,
+        slug: orderSlug(ref.slug, index),
+      })),
+    })),
+  );
+}
+
+export function expandOptionsForUrls(
+  options: FilterOptions,
+  urlCount: number,
+): FilterOptions {
+  return Object.fromEntries(
+    Object.entries(options).map(([key, value]) => [
+      key,
+      Array.isArray(value)
+        ? value.flatMap(slug =>
+            Array.from({ length: urlCount }, (_, i) => orderSlug(slug, i)),
+          )
+        : value,
+    ]),
+  );
+}
+
+export function processAuditsAndGroups(urls: string[], options: FilterOptions) {
+  if (!shouldExpandForUrls(urls.length)) {
+    return markSkippedAuditsAndGroups(
+      LIGHTHOUSE_NAVIGATION_AUDITS,
+      LIGHTHOUSE_GROUPS,
+      options,
+    );
+  }
+  const expandedAudits = expandAuditsForUrls(
+    LIGHTHOUSE_NAVIGATION_AUDITS,
+    urls,
+  );
+  const expandedGroups = expandGroupsForUrls(LIGHTHOUSE_GROUPS, urls);
+  const expandedOptions = expandOptionsForUrls(options, urls.length);
+  return markSkippedAuditsAndGroups(
+    expandedAudits,
+    expandedGroups,
+    expandedOptions,
+  );
+}

--- a/packages/plugin-lighthouse/src/lib/processing.unit.test.ts
+++ b/packages/plugin-lighthouse/src/lib/processing.unit.test.ts
@@ -4,7 +4,10 @@ import {
   expandAuditsForUrls,
   expandGroupsForUrls,
   expandOptionsForUrls,
+  extractUrls,
   getUrlIdentifier,
+  getWeightForUrl,
+  normalizeUrlInput,
   orderSlug,
   processAuditsAndGroups,
 } from './processing.js';
@@ -17,6 +20,24 @@ describe('orderSlug', () => {
     [1, 'cumulative-layout-shift', 'cumulative-layout-shift-2'],
   ])('should append index %d + 1 to slug %j', (index, slug, expected) => {
     expect(orderSlug(slug, index)).toBe(expected);
+  });
+});
+
+describe('extractUrls', () => {
+  it.each([
+    ['single string', 'https://a.com', ['https://a.com']],
+    [
+      'array',
+      ['https://a.com', 'https://b.com'],
+      ['https://a.com', 'https://b.com'],
+    ],
+    [
+      'object',
+      { 'https://a.com': 1, 'https://b.com': 2 },
+      ['https://a.com', 'https://b.com'],
+    ],
+  ])('should extract URLs from %s', (_, input, expected) => {
+    expect(extractUrls(input)).toEqual(expected);
   });
 });
 
@@ -315,5 +336,153 @@ describe('processAuditsAndGroups', () => {
 
     expect(result.audits.length).toBeGreaterThan(0);
     expect(result.groups.length).toBeGreaterThan(0);
+  });
+});
+
+describe('getWeightForUrl', () => {
+  it.each([
+    [1, 'https://example.com', 'https://example.com'],
+    [
+      1,
+      ['https://example.com', 'https://example.com/about'],
+      'https://example.com',
+    ],
+    [2, { 'https://example.com': 2 }, 'https://example.com'],
+    [0, { 'https://example.com/about': 0 }, 'https://example.com/about'],
+    [1, { 'https://example.com': 2 }, 'https://example.com/about'],
+  ])(
+    'should return the weight of %d per input %j for URL %j',
+    (expected, input, url) => {
+      expect(getWeightForUrl(input, url)).toBe(expected);
+    },
+  );
+});
+
+describe('normalizeUrlInput', () => {
+  describe('string input', () => {
+    it('should normalize single URL string', () => {
+      expect(normalizeUrlInput('https://example.com')).toEqual({
+        urls: ['https://example.com'],
+        context: {
+          urlCount: 1,
+          weights: { 1: 1 },
+        },
+      });
+    });
+  });
+
+  describe('array input', () => {
+    it('should normalize array of URLs', () => {
+      expect(
+        normalizeUrlInput(['https://example.com', 'https://example.com/about']),
+      ).toEqual({
+        urls: ['https://example.com', 'https://example.com/about'],
+        context: {
+          urlCount: 2,
+          weights: { 1: 1, 2: 1 },
+        },
+      });
+    });
+
+    it('should handle empty array', () => {
+      expect(normalizeUrlInput([])).toEqual({
+        urls: [],
+        context: {
+          urlCount: 0,
+          weights: {},
+        },
+      });
+    });
+
+    it('should handle single URL in array', () => {
+      expect(normalizeUrlInput(['https://example.com'])).toEqual({
+        urls: ['https://example.com'],
+        context: {
+          urlCount: 1,
+          weights: { 1: 1 },
+        },
+      });
+    });
+  });
+
+  describe('WeightedUrl input', () => {
+    it('should normalize weighted URLs', () => {
+      expect(
+        normalizeUrlInput({
+          'https://example.com': 2,
+          'https://example.com/about': 3,
+          'https://example.com/contact': 1,
+        }),
+      ).toEqual({
+        urls: [
+          'https://example.com',
+          'https://example.com/about',
+          'https://example.com/contact',
+        ],
+        context: {
+          urlCount: 3,
+          weights: { 1: 2, 2: 3, 3: 1 },
+        },
+      });
+    });
+
+    it('should handle single weighted URL', () => {
+      expect(normalizeUrlInput({ 'https://example.com': 5 })).toEqual({
+        urls: ['https://example.com'],
+        context: {
+          urlCount: 1,
+          weights: { 1: 5 },
+        },
+      });
+    });
+
+    it('should preserve zero weights', () => {
+      expect(
+        normalizeUrlInput({
+          'https://example.com': 2,
+          'https://example.com/about': 0,
+        }),
+      ).toEqual({
+        urls: ['https://example.com', 'https://example.com/about'],
+        context: {
+          urlCount: 2,
+          weights: { 1: 2, 2: 0 },
+        },
+      });
+    });
+
+    it('should handle empty WeightedUrl object', () => {
+      expect(normalizeUrlInput({})).toEqual({
+        urls: [],
+        context: {
+          urlCount: 0,
+          weights: {},
+        },
+      });
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle URLs with special characters', () => {
+      const result = normalizeUrlInput({
+        'https://example.com/path?query=test&foo=bar': 2,
+        'https://example.com/path#section': 1,
+      });
+
+      expect(result.urls).toEqual([
+        'https://example.com/path?query=test&foo=bar',
+        'https://example.com/path#section',
+      ]);
+      expect(result.context.weights).toEqual({ 1: 2, 2: 1 });
+    });
+
+    it('should handle numeric weights including decimals', () => {
+      const result = normalizeUrlInput({
+        'https://example.com': 1.5,
+        'https://example.com/about': 2.7,
+      });
+
+      expect(result.context.weights).toEqual({ 1: 1.5, 2: 2.7 });
+    });
   });
 });

--- a/packages/plugin-lighthouse/src/lib/processing.unit.test.ts
+++ b/packages/plugin-lighthouse/src/lib/processing.unit.test.ts
@@ -1,0 +1,319 @@
+import { describe, expect, it } from 'vitest';
+import type { Audit, Group } from '@code-pushup/models';
+import {
+  expandAuditsForUrls,
+  expandGroupsForUrls,
+  expandOptionsForUrls,
+  getUrlIdentifier,
+  orderSlug,
+  processAuditsAndGroups,
+} from './processing.js';
+
+describe('orderSlug', () => {
+  it.each([
+    [0, 'performance', 'performance-1'],
+    [1, 'performance', 'performance-2'],
+    [2, 'best-practices', 'best-practices-3'],
+    [1, 'cumulative-layout-shift', 'cumulative-layout-shift-2'],
+  ])('should append index %d + 1 to slug %j', (index, slug, expected) => {
+    expect(orderSlug(slug, index)).toBe(expected);
+  });
+});
+
+describe('getUrlIdentifier', () => {
+  it.each([
+    ['https://example.com', 'example.com'],
+    ['https://example.com/', 'example.com'],
+    ['http://example.com', 'example.com'],
+    ['https://example.com/about', 'example.com/about'],
+    ['https://example.com/about/', 'example.com/about/'],
+    ['https://example.com/docs/api', 'example.com/docs/api'],
+    ['https://example.com/page?q=test', 'example.com/page'],
+    ['https://example.com/page#section', 'example.com/page'],
+    ['https://example.com/page?q=test#section', 'example.com/page'],
+    ['https://example.com:3000', 'example.com:3000'],
+    ['https://example.com:3000/api', 'example.com:3000/api'],
+    ['https://www.example.com', 'www.example.com'],
+    ['https://api.example.com/v1', 'api.example.com/v1'],
+    ['not-a-url', 'not-a-url'],
+    ['just-text', 'just-text'],
+    ['', ''],
+    ['https://localhost', 'localhost'],
+    ['https://127.0.0.1:8080/test', '127.0.0.1:8080/test'],
+  ])('should convert %j to %j', (input, expected) => {
+    expect(getUrlIdentifier(input)).toBe(expected);
+  });
+});
+
+describe('expandAuditsForUrls', () => {
+  const mockAudits: Audit[] = [
+    {
+      slug: 'first-contentful-paint',
+      title: 'First Contentful Paint',
+      description: 'Measures FCP',
+    },
+    {
+      slug: 'largest-contentful-paint',
+      title: 'Largest Contentful Paint',
+      description: 'Measures LCP',
+    },
+  ];
+
+  it('should expand audits for multiple URLs', () => {
+    const urls = ['https://example.com', 'https://example.com/about'];
+    const result = expandAuditsForUrls(mockAudits, urls);
+
+    expect(result).toHaveLength(4);
+    expect(result.map(({ slug }) => slug)).toEqual([
+      'first-contentful-paint-1',
+      'largest-contentful-paint-1',
+      'first-contentful-paint-2',
+      'largest-contentful-paint-2',
+    ]);
+  });
+
+  it('should update titles with URL identifiers', () => {
+    const urls = ['https://example.com', 'https://example.com/about'];
+    const result = expandAuditsForUrls(mockAudits, urls);
+
+    expect(result[0]?.title).toBe('First Contentful Paint (example.com)');
+    expect(result[2]?.title).toBe('First Contentful Paint (example.com/about)');
+  });
+
+  it('should preserve other audit properties', () => {
+    const auditWithExtra: Audit = {
+      slug: 'test-audit',
+      title: 'Test Audit',
+      description: 'Test description',
+      docsUrl: 'https://docs.example.com',
+    };
+
+    const result = expandAuditsForUrls(
+      [auditWithExtra],
+      ['https://example.com'],
+    );
+
+    expect(result[0]).toEqual({
+      slug: 'test-audit-1',
+      title: 'Test Audit (example.com)',
+      description: 'Test description',
+      docsUrl: 'https://docs.example.com',
+    });
+  });
+
+  it('should handle single URL', () => {
+    const result = expandAuditsForUrls(mockAudits, ['https://example.com']);
+
+    expect(result).toHaveLength(2);
+    expect(result.map(a => a.slug)).toEqual([
+      'first-contentful-paint-1',
+      'largest-contentful-paint-1',
+    ]);
+  });
+
+  it('should handle empty audits array', () => {
+    const result = expandAuditsForUrls([], ['https://example.com']);
+    expect(result).toHaveLength(0);
+  });
+});
+
+describe('expandGroupsForUrls', () => {
+  const mockGroups: Group[] = [
+    {
+      slug: 'performance',
+      title: 'Performance',
+      refs: [
+        { slug: 'first-contentful-paint', weight: 1 },
+        { slug: 'largest-contentful-paint', weight: 2 },
+      ],
+    },
+    {
+      slug: 'accessibility',
+      title: 'Accessibility',
+      refs: [{ slug: 'color-contrast', weight: 1 }],
+    },
+  ];
+
+  it('should expand groups for multiple URLs', () => {
+    const urls = ['https://example.com', 'https://example.com/about'];
+    const result = expandGroupsForUrls(mockGroups, urls);
+
+    expect(result).toHaveLength(4);
+    expect(result.map(({ slug }) => slug)).toEqual([
+      'performance-1',
+      'accessibility-1',
+      'performance-2',
+      'accessibility-2',
+    ]);
+  });
+
+  it('should update group titles with URL identifiers', () => {
+    const urls = ['https://example.com', 'https://example.com/about'];
+    const result = expandGroupsForUrls(mockGroups, urls);
+
+    expect(result[0]?.title).toBe('Performance (example.com)');
+    expect(result[2]?.title).toBe('Performance (example.com/about)');
+  });
+
+  it('should expand refs within groups', () => {
+    const urls = ['https://example.com', 'https://example.com/about'];
+    const result = expandGroupsForUrls(mockGroups, urls);
+
+    expect(result[0]?.refs).toEqual([
+      { slug: 'first-contentful-paint-1', weight: 1 },
+      { slug: 'largest-contentful-paint-1', weight: 2 },
+    ]);
+
+    expect(result[2]?.refs).toEqual([
+      { slug: 'first-contentful-paint-2', weight: 1 },
+      { slug: 'largest-contentful-paint-2', weight: 2 },
+    ]);
+  });
+
+  it('should preserve other group properties', () => {
+    const groupWithExtra: Group = {
+      slug: 'test-group',
+      title: 'Test Group',
+      description: 'Test description',
+      refs: [{ slug: 'test-audit', weight: 1 }],
+    };
+
+    const result = expandGroupsForUrls(
+      [groupWithExtra],
+      ['https://example.com'],
+    );
+
+    expect(result[0]).toEqual({
+      slug: 'test-group-1',
+      title: 'Test Group (example.com)',
+      description: 'Test description',
+      refs: [{ slug: 'test-audit-1', weight: 1 }],
+    });
+  });
+
+  it('should handle empty groups array', () => {
+    const result = expandGroupsForUrls([], ['https://example.com']);
+    expect(result).toHaveLength(0);
+  });
+});
+
+describe('expandOptionsForUrls', () => {
+  it('should expand onlyAudits options', () => {
+    const options = {
+      onlyAudits: ['first-contentful-paint', 'largest-contentful-paint'],
+    };
+    const result = expandOptionsForUrls(options, 2);
+
+    expect(result.onlyAudits).toEqual([
+      'first-contentful-paint-1',
+      'first-contentful-paint-2',
+      'largest-contentful-paint-1',
+      'largest-contentful-paint-2',
+    ]);
+  });
+
+  it('should expand skipAudits options', () => {
+    const options = { skipAudits: ['performance-budget'] };
+    const result = expandOptionsForUrls(options, 3);
+
+    expect(result.skipAudits).toEqual([
+      'performance-budget-1',
+      'performance-budget-2',
+      'performance-budget-3',
+    ]);
+  });
+
+  it('should expand onlyCategories options', () => {
+    const options = { onlyCategories: ['performance', 'accessibility'] };
+    const result = expandOptionsForUrls(options, 2);
+
+    expect(result.onlyCategories).toEqual([
+      'performance-1',
+      'performance-2',
+      'accessibility-1',
+      'accessibility-2',
+    ]);
+  });
+
+  it('should handle mixed filter options', () => {
+    const options = {
+      onlyAudits: ['first-contentful-paint'],
+      skipAudits: ['performance-budget'],
+      onlyCategories: ['performance'],
+    };
+    const result = expandOptionsForUrls(options, 2);
+
+    expect(result).toEqual({
+      onlyAudits: ['first-contentful-paint-1', 'first-contentful-paint-2'],
+      skipAudits: ['performance-budget-1', 'performance-budget-2'],
+      onlyCategories: ['performance-1', 'performance-2'],
+    });
+  });
+
+  it('should handle empty arrays', () => {
+    const options = { onlyAudits: [], skipAudits: [] };
+    const result = expandOptionsForUrls(options, 2);
+
+    expect(result).toEqual({
+      onlyAudits: [],
+      skipAudits: [],
+    });
+  });
+
+  it('should handle single URL count', () => {
+    const options = { onlyAudits: ['test-audit'] };
+    const result = expandOptionsForUrls(options, 1);
+
+    expect(result.onlyAudits).toEqual(['test-audit-1']);
+  });
+});
+
+describe('processAuditsAndGroups', () => {
+  it('should return original audits and groups for single URL', () => {
+    const result = processAuditsAndGroups(['https://example.com'], {});
+
+    expect(result.audits).toBeDefined();
+    expect(result.groups).toBeDefined();
+    expect(result.audits.some(({ slug }) => slug.includes('-1'))).toBe(false);
+    expect(result.groups.some(({ slug }) => slug.includes('-1'))).toBe(false);
+  });
+
+  it('should expand audits and groups for multiple URLs', () => {
+    const urls = ['https://example.com', 'https://example.com/about'];
+    const result = processAuditsAndGroups(urls, {});
+
+    expect(result.audits).toBeDefined();
+    expect(result.groups).toBeDefined();
+
+    expect(result.audits.every(({ slug }) => /-[12]$/.test(slug))).toBe(true);
+    expect(result.groups.every(({ slug }) => /-[12]$/.test(slug))).toBe(true);
+  });
+
+  it('should apply filter options for multiple URLs', () => {
+    const urls = ['https://example.com', 'https://example.com/about'];
+    const options = { onlyCategories: ['performance'] };
+    const result = processAuditsAndGroups(urls, options);
+
+    const performanceGroups = result.groups.filter(({ slug }) =>
+      slug.startsWith('performance-'),
+    );
+    const nonPerformanceGroups = result.groups.filter(
+      ({ slug }) => !slug.startsWith('performance-'),
+    );
+
+    expect(performanceGroups.map(g => g.slug)).toEqual([
+      'performance-1',
+      'performance-2',
+    ]);
+    expect(performanceGroups.every(({ isSkipped }) => !isSkipped)).toBe(true);
+    expect(nonPerformanceGroups.every(({ isSkipped }) => isSkipped)).toBe(true);
+  });
+
+  it('should handle empty options', () => {
+    const urls = ['https://example.com', 'https://example.com/about'];
+    const result = processAuditsAndGroups(urls, {});
+
+    expect(result.audits.length).toBeGreaterThan(0);
+    expect(result.groups.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/plugin-lighthouse/src/lib/runner/runner.ts
+++ b/packages/plugin-lighthouse/src/lib/runner/runner.ts
@@ -1,9 +1,10 @@
-import type { RunnerResult } from 'lighthouse';
+import type { Config, RunnerResult } from 'lighthouse';
 import { runLighthouse } from 'lighthouse/cli/run.js';
 import path from 'node:path';
 import type { AuditOutputs, RunnerFunction } from '@code-pushup/models';
 import { ensureDirectoryExists, ui } from '@code-pushup/utils';
 import { orderSlug, shouldExpandForUrls } from '../processing.js';
+import type { LighthouseOptions } from '../types.js';
 import { DEFAULT_CLI_FLAGS } from './constants.js';
 import type { LighthouseCliFlags } from './types.js';
 import {
@@ -17,76 +18,30 @@ export function createRunnerFunction(
   urls: string[],
   flags: LighthouseCliFlags = DEFAULT_CLI_FLAGS,
 ): RunnerFunction {
-  return !shouldExpandForUrls(urls.length) && urls[0]
-    ? createSingleUrlRunner(urls[0], flags)
-    : createMultipleUrlRunner(urls, flags);
-}
-
-function createSingleUrlRunner(
-  url: string,
-  flags: LighthouseCliFlags,
-): RunnerFunction {
   return async (): Promise<AuditOutputs> => {
     const config = await getConfig(flags);
-
-    if (flags.outputPath) {
-      await ensureDirectoryExists(path.dirname(flags.outputPath));
-    }
-
-    const enrichedFlags = enrichFlags(flags);
-
-    const runnerResult: unknown = await runLighthouse(
-      url,
-      enrichedFlags,
-      config,
-    );
-
-    if (runnerResult == null) {
-      throw new Error('Lighthouse did not produce a result.');
-    }
-
-    const { lhr } = runnerResult as RunnerResult;
-    const auditOutputs = toAuditOutputs(Object.values(lhr.audits), flags);
-
-    return normalizeAuditOutputs(auditOutputs, enrichedFlags);
-  };
-}
-
-function createMultipleUrlRunner(
-  urls: string[],
-  flags: LighthouseCliFlags,
-): RunnerFunction {
-  return async (): Promise<AuditOutputs> => {
-    const config = await getConfig(flags);
+    const normalizationFlags = enrichFlags(flags);
+    const isSingleUrl = !shouldExpandForUrls(urls.length);
 
     const allResults = await urls.reduce(async (prev, url, index) => {
       const acc = await prev;
       try {
-        const enrichedFlags = enrichFlags(flags, index + 1);
+        const enrichedFlags = isSingleUrl
+          ? normalizationFlags
+          : enrichFlags(flags, index + 1);
 
-        if (enrichedFlags.outputPath) {
-          await ensureDirectoryExists(path.dirname(enrichedFlags.outputPath));
-        }
-
-        const runnerResult: unknown = await runLighthouse(
+        const auditOutputs = await runLighthouseForUrl(
           url,
           enrichedFlags,
           config,
         );
 
-        if (runnerResult == null) {
-          throw new Error(
-            `Lighthouse did not produce a result for URL: ${url}`,
-          );
-        }
-
-        const { lhr } = runnerResult as RunnerResult;
-        const auditOutputs = toAuditOutputs(Object.values(lhr.audits), flags);
-
-        const processedOutputs = auditOutputs.map(audit => ({
-          ...audit,
-          slug: orderSlug(audit.slug, index),
-        }));
+        const processedOutputs = isSingleUrl
+          ? auditOutputs
+          : auditOutputs.map(audit => ({
+              ...audit,
+              slug: orderSlug(audit.slug, index),
+            }));
 
         return [...acc, ...processedOutputs];
       } catch (error) {
@@ -96,9 +51,32 @@ function createMultipleUrlRunner(
     }, Promise.resolve<AuditOutputs>([]));
 
     if (allResults.length === 0) {
-      throw new Error('Lighthouse failed to produce results for all URLs.');
+      throw new Error(
+        isSingleUrl
+          ? 'Lighthouse did not produce a result.'
+          : 'Lighthouse failed to produce results for all URLs.',
+      );
     }
-
-    return normalizeAuditOutputs(allResults, flags);
+    return normalizeAuditOutputs(allResults, normalizationFlags);
   };
+}
+
+async function runLighthouseForUrl(
+  url: string,
+  flags: LighthouseOptions,
+  config: Config | undefined,
+): Promise<AuditOutputs> {
+  if (flags.outputPath) {
+    await ensureDirectoryExists(path.dirname(flags.outputPath));
+  }
+
+  const runnerResult: unknown = await runLighthouse(url, flags, config);
+
+  if (runnerResult == null) {
+    throw new Error(`Lighthouse did not produce a result for URL: ${url}`);
+  }
+
+  const { lhr } = runnerResult as RunnerResult;
+
+  return toAuditOutputs(Object.values(lhr.audits), flags);
 }

--- a/packages/plugin-lighthouse/src/lib/runner/runner.ts
+++ b/packages/plugin-lighthouse/src/lib/runner/runner.ts
@@ -2,43 +2,41 @@ import type { RunnerResult } from 'lighthouse';
 import { runLighthouse } from 'lighthouse/cli/run.js';
 import path from 'node:path';
 import type { AuditOutputs, RunnerFunction } from '@code-pushup/models';
-import { ensureDirectoryExists } from '@code-pushup/utils';
+import { ensureDirectoryExists, ui } from '@code-pushup/utils';
+import { orderSlug, shouldExpandForUrls } from '../processing.js';
 import { DEFAULT_CLI_FLAGS } from './constants.js';
 import type { LighthouseCliFlags } from './types.js';
 import {
-  determineAndSetLogLevel,
+  enrichFlags,
   getConfig,
   normalizeAuditOutputs,
   toAuditOutputs,
 } from './utils.js';
 
 export function createRunnerFunction(
-  urlUnderTest: string,
+  urls: string[],
   flags: LighthouseCliFlags = DEFAULT_CLI_FLAGS,
 ): RunnerFunction {
+  return !shouldExpandForUrls(urls.length) && urls[0]
+    ? createSingleUrlRunner(urls[0], flags)
+    : createMultipleUrlRunner(urls, flags);
+}
+
+function createSingleUrlRunner(
+  url: string,
+  flags: LighthouseCliFlags,
+): RunnerFunction {
   return async (): Promise<AuditOutputs> => {
-    const {
-      configPath,
-      preset,
-      outputPath,
-      ...parsedFlags
-    }: Partial<LighthouseCliFlags> = flags;
+    const config = await getConfig(flags);
 
-    const logLevel = determineAndSetLogLevel(parsedFlags);
-
-    const config = await getConfig({ configPath, preset });
-    if (outputPath) {
-      await ensureDirectoryExists(path.dirname(outputPath));
+    if (flags.outputPath) {
+      await ensureDirectoryExists(path.dirname(flags.outputPath));
     }
 
-    const enrichedFlags = {
-      ...parsedFlags,
-      logLevel,
-      outputPath,
-    };
+    const enrichedFlags = enrichFlags(flags);
 
     const runnerResult: unknown = await runLighthouse(
-      urlUnderTest,
+      url,
       enrichedFlags,
       config,
     );
@@ -51,5 +49,56 @@ export function createRunnerFunction(
     const auditOutputs = toAuditOutputs(Object.values(lhr.audits), flags);
 
     return normalizeAuditOutputs(auditOutputs, enrichedFlags);
+  };
+}
+
+function createMultipleUrlRunner(
+  urls: string[],
+  flags: LighthouseCliFlags,
+): RunnerFunction {
+  return async (): Promise<AuditOutputs> => {
+    const config = await getConfig(flags);
+
+    const allResults = await urls.reduce(async (prev, url, index) => {
+      const acc = await prev;
+      try {
+        const enrichedFlags = enrichFlags(flags, index + 1);
+
+        if (enrichedFlags.outputPath) {
+          await ensureDirectoryExists(path.dirname(enrichedFlags.outputPath));
+        }
+
+        const runnerResult: unknown = await runLighthouse(
+          url,
+          enrichedFlags,
+          config,
+        );
+
+        if (runnerResult == null) {
+          throw new Error(
+            `Lighthouse did not produce a result for URL: ${url}`,
+          );
+        }
+
+        const { lhr } = runnerResult as RunnerResult;
+        const auditOutputs = toAuditOutputs(Object.values(lhr.audits), flags);
+
+        const processedOutputs = auditOutputs.map(audit => ({
+          ...audit,
+          slug: orderSlug(audit.slug, index),
+        }));
+
+        return [...acc, ...processedOutputs];
+      } catch (error) {
+        ui().logger.warning((error as Error).message);
+        return acc;
+      }
+    }, Promise.resolve<AuditOutputs>([]));
+
+    if (allResults.length === 0) {
+      throw new Error('Lighthouse failed to produce results for all URLs.');
+    }
+
+    return normalizeAuditOutputs(allResults, flags);
   };
 }

--- a/packages/plugin-lighthouse/src/lib/runner/runner.unit.test.ts
+++ b/packages/plugin-lighthouse/src/lib/runner/runner.unit.test.ts
@@ -2,6 +2,7 @@ import type { Config } from 'lighthouse';
 import { runLighthouse } from 'lighthouse/cli/run.js';
 import type { Result } from 'lighthouse/types/lhr/audit-result';
 import { expect, vi } from 'vitest';
+import { osAgnosticPath } from '@code-pushup/test-utils';
 import { ui } from '@code-pushup/utils';
 import { DEFAULT_CLI_FLAGS } from './constants.js';
 import { createRunnerFunction } from './runner.js';
@@ -138,14 +139,18 @@ describe('createRunnerFunction', () => {
     expect(runLighthouse).toHaveBeenCalledWith(
       'https://localhost:8080',
       expect.objectContaining({
-        outputPath: '.code-pushup/lighthouse/lighthouse-report-1.json',
+        outputPath: osAgnosticPath(
+          '.code-pushup/lighthouse/lighthouse-report-1.json',
+        ),
       }),
       undefined,
     );
     expect(runLighthouse).toHaveBeenCalledWith(
       'https://localhost:8081',
       expect.objectContaining({
-        outputPath: '.code-pushup/lighthouse/lighthouse-report-2.json',
+        outputPath: osAgnosticPath(
+          '.code-pushup/lighthouse/lighthouse-report-2.json',
+        ),
       }),
       undefined,
     );
@@ -214,14 +219,18 @@ describe('createRunnerFunction', () => {
     expect(runLighthouse).toHaveBeenCalledWith(
       'https://localhost:8080',
       expect.objectContaining({
-        outputPath: '.code-pushup/lighthouse/lighthouse-report-1.json',
+        outputPath: osAgnosticPath(
+          '.code-pushup/lighthouse/lighthouse-report-1.json',
+        ),
       }),
       undefined,
     );
     expect(runLighthouse).toHaveBeenCalledWith(
       'https://localhost:8081',
       expect.objectContaining({
-        outputPath: '.code-pushup/lighthouse/lighthouse-report-2.json',
+        outputPath: osAgnosticPath(
+          '.code-pushup/lighthouse/lighthouse-report-2.json',
+        ),
       }),
       undefined,
     );

--- a/packages/plugin-lighthouse/src/lib/runner/runner.unit.test.ts
+++ b/packages/plugin-lighthouse/src/lib/runner/runner.unit.test.ts
@@ -2,25 +2,25 @@ import type { Config } from 'lighthouse';
 import { runLighthouse } from 'lighthouse/cli/run.js';
 import type { Result } from 'lighthouse/types/lhr/audit-result';
 import { expect, vi } from 'vitest';
+import { ui } from '@code-pushup/utils';
 import { DEFAULT_CLI_FLAGS } from './constants.js';
 import { createRunnerFunction } from './runner.js';
 import type { LighthouseCliFlags } from './types.js';
-import { determineAndSetLogLevel, getConfig } from './utils.js';
+import { enrichFlags, getConfig } from './utils.js';
 
 // used for createRunnerMocking
 vi.mock('./utils', async () => {
   // Import the actual 'lighthouse' module
   const actual = await vi.importActual('./utils');
 
-  const actualDetermineAndSetLogLevel = actual['determineAndSetLogLevel'] as (
-    s: string,
+  const actualEnrichFlags = actual['enrichFlags'] as (
+    f: LighthouseCliFlags,
+    i?: number,
   ) => string;
   // Return the mocked module, merging the actual module with overridden parts
   return {
     ...actual,
-    determineAndSetLogLevel: vi
-      .fn()
-      .mockImplementation(actualDetermineAndSetLogLevel),
+    enrichFlags: vi.fn().mockImplementation(actualEnrichFlags),
     getBudgets: vi.fn().mockImplementation((path: string) => [{ path }]),
     getConfig: vi.fn(),
   };
@@ -63,7 +63,7 @@ vi.mock('lighthouse/cli/run.js', async () => {
 
 describe('createRunnerFunction', () => {
   it('should call runLighthouse with defaults when executed with only url given', async () => {
-    const runner = createRunnerFunction('https://localhost:8080');
+    const runner = createRunnerFunction(['https://localhost:8080']);
     await expect(runner(undefined)).resolves.toEqual(
       expect.arrayContaining([
         {
@@ -82,18 +82,24 @@ describe('createRunnerFunction', () => {
     );
   });
 
-  it('should call determineAndSetLogLevel with given verbose and quiet flags', async () => {
-    await createRunnerFunction('https://localhost:8080', {
-      verbose: true,
-      quiet: true,
-    } as LighthouseCliFlags)(undefined);
-    expect(determineAndSetLogLevel).toHaveBeenCalledWith(
-      expect.objectContaining({ verbose: true, quiet: true }),
-    );
+  it('should call enrichFlags with correct parameters for single URL', async () => {
+    await createRunnerFunction(['https://localhost:8080'])(undefined);
+
+    expect(enrichFlags).toHaveBeenCalledWith(DEFAULT_CLI_FLAGS);
+  });
+
+  it('should call enrichFlags with URL index for multiple URLs', async () => {
+    await createRunnerFunction([
+      'https://localhost:8080',
+      'https://localhost:8081',
+    ])(undefined);
+
+    expect(enrichFlags).toHaveBeenCalledWith(DEFAULT_CLI_FLAGS, 1);
+    expect(enrichFlags).toHaveBeenCalledWith(DEFAULT_CLI_FLAGS, 2);
   });
 
   it('should call getConfig with given configPath', async () => {
-    await createRunnerFunction('https://localhost:8080', {
+    await createRunnerFunction(['https://localhost:8080'], {
       configPath: 'lh-config.js',
     } as LighthouseCliFlags)(undefined);
     expect(getConfig).toHaveBeenCalledWith(
@@ -102,9 +108,122 @@ describe('createRunnerFunction', () => {
   });
 
   it('should throw if lighthouse returns an empty result', async () => {
-    const runner = createRunnerFunction('fail');
+    const runner = createRunnerFunction(['fail']);
     await expect(runner(undefined)).rejects.toThrow(
       'Lighthouse did not produce a result.',
+    );
+  });
+
+  it('should handle multiple URLs and add URL index to audit slugs', async () => {
+    const runner = createRunnerFunction([
+      'https://localhost:8080',
+      'https://localhost:8081',
+    ]);
+    await expect(runner(undefined)).resolves.toEqual(
+      expect.arrayContaining([
+        {
+          slug: 'cumulative-layout-shift-1',
+          value: 1200,
+          displayValue: '1.2 s',
+          score: 0.9,
+        },
+        {
+          slug: 'cumulative-layout-shift-2',
+          value: 1200,
+          displayValue: '1.2 s',
+          score: 0.9,
+        },
+      ]),
+    );
+    expect(runLighthouse).toHaveBeenCalledWith(
+      'https://localhost:8080',
+      expect.objectContaining({
+        outputPath: '.code-pushup/lighthouse/lighthouse-report-1.json',
+      }),
+      undefined,
+    );
+    expect(runLighthouse).toHaveBeenCalledWith(
+      'https://localhost:8081',
+      expect.objectContaining({
+        outputPath: '.code-pushup/lighthouse/lighthouse-report-2.json',
+      }),
+      undefined,
+    );
+    expect(runLighthouse).toHaveBeenCalledTimes(2);
+  });
+
+  it('should handle single URL without adding index to audit slugs', async () => {
+    const runner = createRunnerFunction(['https://localhost:8080']);
+    await expect(runner(undefined)).resolves.toEqual(
+      expect.arrayContaining([
+        {
+          slug: 'cumulative-layout-shift',
+          value: 1200,
+          displayValue: '1.2 s',
+          score: 0.9,
+        },
+      ]),
+    );
+  });
+
+  it('should continue with other URLs when one fails in multiple URL scenario', async () => {
+    const runner = createRunnerFunction([
+      'https://localhost:8080',
+      'fail',
+      'https://localhost:8082',
+    ]);
+
+    await expect(runner(undefined)).resolves.toEqual(
+      expect.arrayContaining([
+        {
+          slug: 'cumulative-layout-shift-1',
+          value: 1200,
+          displayValue: '1.2 s',
+          score: 0.9,
+        },
+        {
+          slug: 'cumulative-layout-shift-3',
+          value: 1200,
+          displayValue: '1.2 s',
+          score: 0.9,
+        },
+      ]),
+    );
+
+    expect(ui()).toHaveLogged(
+      'warn',
+      `Lighthouse did not produce a result for URL: fail`,
+    );
+  });
+
+  it('should throw error if all URLs fail in multiple URL scenario', async () => {
+    const runner = createRunnerFunction(['fail1', 'fail2', 'fail3']);
+    await expect(runner(undefined)).rejects.toThrow(
+      'Lighthouse failed to produce results for all URLs.',
+    );
+  });
+
+  it('should generate URL-specific output paths for multiple URLs', async () => {
+    const runner = createRunnerFunction([
+      'https://localhost:8080',
+      'https://localhost:8081',
+    ]);
+
+    await runner(undefined);
+
+    expect(runLighthouse).toHaveBeenCalledWith(
+      'https://localhost:8080',
+      expect.objectContaining({
+        outputPath: '.code-pushup/lighthouse/lighthouse-report-1.json',
+      }),
+      undefined,
+    );
+    expect(runLighthouse).toHaveBeenCalledWith(
+      'https://localhost:8081',
+      expect.objectContaining({
+        outputPath: '.code-pushup/lighthouse/lighthouse-report-2.json',
+      }),
+      undefined,
     );
   });
 });

--- a/packages/plugin-lighthouse/src/lib/runner/runner.unit.test.ts
+++ b/packages/plugin-lighthouse/src/lib/runner/runner.unit.test.ts
@@ -2,7 +2,6 @@ import type { Config } from 'lighthouse';
 import { runLighthouse } from 'lighthouse/cli/run.js';
 import type { Result } from 'lighthouse/types/lhr/audit-result';
 import { expect, vi } from 'vitest';
-import { osAgnosticPath } from '@code-pushup/test-utils';
 import { ui } from '@code-pushup/utils';
 import { DEFAULT_CLI_FLAGS } from './constants.js';
 import { createRunnerFunction } from './runner.js';
@@ -139,7 +138,7 @@ describe('createRunnerFunction', () => {
     expect(runLighthouse).toHaveBeenCalledWith(
       'https://localhost:8080',
       expect.objectContaining({
-        outputPath: osAgnosticPath(
+        outputPath: expect.pathToMatch(
           '.code-pushup/lighthouse/lighthouse-report-1.json',
         ),
       }),
@@ -148,7 +147,7 @@ describe('createRunnerFunction', () => {
     expect(runLighthouse).toHaveBeenCalledWith(
       'https://localhost:8081',
       expect.objectContaining({
-        outputPath: osAgnosticPath(
+        outputPath: expect.pathToMatch(
           '.code-pushup/lighthouse/lighthouse-report-2.json',
         ),
       }),
@@ -219,7 +218,7 @@ describe('createRunnerFunction', () => {
     expect(runLighthouse).toHaveBeenCalledWith(
       'https://localhost:8080',
       expect.objectContaining({
-        outputPath: osAgnosticPath(
+        outputPath: expect.pathToMatch(
           '.code-pushup/lighthouse/lighthouse-report-1.json',
         ),
       }),
@@ -228,7 +227,7 @@ describe('createRunnerFunction', () => {
     expect(runLighthouse).toHaveBeenCalledWith(
       'https://localhost:8081',
       expect.objectContaining({
-        outputPath: osAgnosticPath(
+        outputPath: expect.pathToMatch(
           '.code-pushup/lighthouse/lighthouse-report-2.json',
         ),
       }),

--- a/packages/plugin-lighthouse/src/lib/runner/utils.ts
+++ b/packages/plugin-lighthouse/src/lib/runner/utils.ts
@@ -147,3 +147,23 @@ export async function getConfig(
   }
   return undefined;
 }
+
+export function enrichFlags(
+  flags: LighthouseCliFlags,
+  urlIndex?: number,
+): LighthouseOptions {
+  const { outputPath, ...parsedFlags }: Partial<LighthouseCliFlags> = flags;
+
+  const logLevel = determineAndSetLogLevel(parsedFlags);
+
+  const urlSpecificOutputPath =
+    urlIndex && outputPath
+      ? outputPath.replace(/(\.[^.]+)?$/, `-${urlIndex}$1`)
+      : outputPath;
+
+  return {
+    ...parsedFlags,
+    logLevel,
+    outputPath: urlSpecificOutputPath,
+  };
+}

--- a/packages/plugin-lighthouse/src/lib/types.ts
+++ b/packages/plugin-lighthouse/src/lib/types.ts
@@ -1,5 +1,6 @@
 import type { CliFlags } from 'lighthouse';
 import type { ExcludeNullableProps } from '@code-pushup/utils';
+import type { LIGHTHOUSE_GROUP_SLUGS } from './constants.js';
 
 export type LighthouseOptions = ExcludeNullableProps<
   Partial<
@@ -26,3 +27,7 @@ export type LighthouseOptions = ExcludeNullableProps<
   onlyAudits?: string | string[];
   skipAudits?: string | string[];
 };
+
+export type LighthouseGroupSlugs = (typeof LIGHTHOUSE_GROUP_SLUGS)[number];
+
+export type LighthouseUrls = string | string[];

--- a/packages/plugin-lighthouse/src/lib/types.ts
+++ b/packages/plugin-lighthouse/src/lib/types.ts
@@ -30,4 +30,11 @@ export type LighthouseOptions = ExcludeNullableProps<
 
 export type LighthouseGroupSlugs = (typeof LIGHTHOUSE_GROUP_SLUGS)[number];
 
-export type LighthouseUrls = string | string[];
+export type WeightedUrl = Record<string, number>;
+
+export type LighthouseUrls = string | string[] | WeightedUrl;
+
+export type LighthouseContext = {
+  urlCount: number;
+  weights: Record<number, number>;
+};

--- a/packages/plugin-lighthouse/src/lib/types.ts
+++ b/packages/plugin-lighthouse/src/lib/types.ts
@@ -28,7 +28,7 @@ export type LighthouseOptions = ExcludeNullableProps<
   skipAudits?: string | string[];
 };
 
-export type LighthouseGroupSlugs = (typeof LIGHTHOUSE_GROUP_SLUGS)[number];
+export type LighthouseGroupSlug = (typeof LIGHTHOUSE_GROUP_SLUGS)[number];
 
 export type WeightedUrl = Record<string, number>;
 

--- a/packages/plugin-lighthouse/src/lib/utils.ts
+++ b/packages/plugin-lighthouse/src/lib/utils.ts
@@ -1,14 +1,8 @@
 import type { Audit, CategoryRef, Group } from '@code-pushup/models';
 import { toArray } from '@code-pushup/utils';
-import { LIGHTHOUSE_PLUGIN_SLUG } from './constants.js';
+import { LIGHTHOUSE_GROUP_SLUGS, LIGHTHOUSE_PLUGIN_SLUG } from './constants.js';
 import type { LighthouseCliFlags } from './runner/types.js';
-
-export type LighthouseGroupSlugs =
-  | 'performance'
-  | 'accessibility'
-  | 'best-practices'
-  | 'seo'
-  | 'pwa';
+import type { LighthouseGroupSlugs } from './types.js';
 
 export function lighthouseGroupRef(
   groupSlug: LighthouseGroupSlugs,
@@ -138,4 +132,13 @@ export function markSkippedAuditsAndGroups(
     audits: markedAudits,
     groups: fullyMarkedGroups,
   };
+}
+
+export function isLighthouseGroupSlug(
+  group: unknown,
+): group is LighthouseGroupSlugs {
+  return (
+    typeof group === 'string' &&
+    LIGHTHOUSE_GROUP_SLUGS.includes(group as LighthouseGroupSlugs)
+  );
 }

--- a/packages/plugin-lighthouse/src/lib/utils.ts
+++ b/packages/plugin-lighthouse/src/lib/utils.ts
@@ -2,10 +2,10 @@ import type { Audit, CategoryRef, Group } from '@code-pushup/models';
 import { toArray } from '@code-pushup/utils';
 import { LIGHTHOUSE_GROUP_SLUGS, LIGHTHOUSE_PLUGIN_SLUG } from './constants.js';
 import type { LighthouseCliFlags } from './runner/types.js';
-import type { LighthouseGroupSlugs } from './types.js';
+import type { LighthouseGroupSlug } from './types.js';
 
 export function lighthouseGroupRef(
-  groupSlug: LighthouseGroupSlugs,
+  groupSlug: LighthouseGroupSlug,
   weight = 1,
 ): CategoryRef {
   return {
@@ -136,9 +136,9 @@ export function markSkippedAuditsAndGroups(
 
 export function isLighthouseGroupSlug(
   group: unknown,
-): group is LighthouseGroupSlugs {
+): group is LighthouseGroupSlug {
   return (
     typeof group === 'string' &&
-    LIGHTHOUSE_GROUP_SLUGS.includes(group as LighthouseGroupSlugs)
+    LIGHTHOUSE_GROUP_SLUGS.includes(group as LighthouseGroupSlug)
   );
 }

--- a/packages/plugin-lighthouse/vitest.unit.config.ts
+++ b/packages/plugin-lighthouse/vitest.unit.config.ts
@@ -26,6 +26,7 @@ export default defineConfig({
       '../../testing/test-setup/src/lib/fs.mock.ts',
       '../../testing/test-setup/src/lib/console.mock.ts',
       '../../testing/test-setup/src/lib/reset.mocks.ts',
+      '../../testing/test-setup/src/lib/extend/path.matcher.ts',
       '../../testing/test-setup/src/lib/extend/ui-logger.matcher.ts',
     ],
   },


### PR DESCRIPTION
Closes #1008 

This PR  adds support for running Lighthouse on multiple URLs to provide holistic performance and accessibility analysis across different pages.

##  Key Features

- Multiple URL input: Accept `string | string[] | Record<string, number>` for the `urls` parameter
- Sequential execution: Run Lighthouse on each URL sequentially
- URL-specific audits: Generate distinct audit slugs with numbered suffixes (e.g., `first-contentful-paint-1`, `first-contentful-paint-2`)
- URL-specific groups: Create separate groups for each URL with descriptive titles including the URL and slugs including numbered suffixes
- Category aggregation: Provide `mergeLighthouseCategories` helper to combine results across URLs
- Backward compatibility: Single URL functionality remains unchanged

##   Example Usage

```ts
// Single URL (unchanged)
lighthousePlugin('https://example.com')

// Multiple URLs
lighthousePlugin([
  'https://example.com',
  'https://example.com/about',
  'https://example.com/contact'
])

// Multiple weighted URLs
lighthousePlugin({
  'https://example.com': 3,
  'https://example.com/about': 2,
  'https://example.com/contact': 1
})

// Category merging
const plugin = lighthousePlugin(['https://example.com', 'https://example.com/about']);
const categories = mergeLighthouseCategories(plugin, userCategories);
```