### PR TITLE
fix(plugin-js-packages): parse yarn 4 audit output correctly

### DIFF
--- a/packages/plugin-js-packages/src/lib/package-managers/package-managers.ts
+++ b/packages/plugin-js-packages/src/lib/package-managers/package-managers.ts
@@ -2,12 +2,12 @@ import type { PackageManagerId } from '../config.js';
 import { npmPackageManager } from './npm/npm.js';
 import { pnpmPackageManager } from './pnpm/pnpm.js';
 import type { PackageManager } from './types.js';
-import { yarnv1PackageManager } from './yarn-classic/yarn-classic.js';
-import { yarnv2PackageManager } from './yarn-modern/yarn-modern.js';
+import { yarnClassicPackageManager } from './yarn-classic/yarn-classic.js';
+import { yarnModernPackageManager } from './yarn-modern/yarn-modern.js';
 
 export const packageManagers: Record<PackageManagerId, PackageManager> = {
   npm: npmPackageManager,
-  'yarn-classic': yarnv1PackageManager,
-  'yarn-modern': yarnv2PackageManager,
+  'yarn-classic': yarnClassicPackageManager,
+  'yarn-modern': yarnModernPackageManager,
   pnpm: pnpmPackageManager,
 };

--- a/packages/plugin-js-packages/src/lib/package-managers/yarn-classic/audit-result.unit.test.ts
+++ b/packages/plugin-js-packages/src/lib/package-managers/yarn-classic/audit-result.unit.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it } from 'vitest';
 import { toJsonLines } from '@code-pushup/utils';
 import type { AuditResult } from '../../runner/audit/types.js';
-import { yarnv1ToAuditResult } from './audit-result.js';
-import type { Yarnv1AuditAdvisory, Yarnv1AuditSummary } from './types.js';
+import { yarnClassicToAuditResult } from './audit-result.js';
+import type {
+  YarnClassicAuditAdvisory,
+  YarnClassicAuditSummary,
+} from './types.js';
 
-describe('yarnv1ToAuditResult', () => {
+describe('yarnClassicToAuditResult', () => {
   it('should transform Yarn v1 audit to unified audit result', () => {
     const advisory = {
       type: 'auditAdvisory',
@@ -19,7 +22,7 @@ describe('yarnv1ToAuditResult', () => {
           url: 'https://github.com/advisories',
         },
       },
-    } satisfies Yarnv1AuditAdvisory;
+    } satisfies YarnClassicAuditAdvisory;
     const summary = {
       type: 'auditSummary',
       data: {
@@ -31,10 +34,10 @@ describe('yarnv1ToAuditResult', () => {
           info: 0,
         },
       },
-    } satisfies Yarnv1AuditSummary;
+    } satisfies YarnClassicAuditSummary;
 
     expect(
-      yarnv1ToAuditResult(toJsonLines([advisory, summary])),
+      yarnClassicToAuditResult(toJsonLines([advisory, summary])),
     ).toEqual<AuditResult>({
       vulnerabilities: [
         {
@@ -57,7 +60,7 @@ describe('yarnv1ToAuditResult', () => {
       data: {},
       type: 'auditAdvisory',
     };
-    expect(() => yarnv1ToAuditResult(toJsonLines([advisory]))).toThrow(
+    expect(() => yarnClassicToAuditResult(toJsonLines([advisory]))).toThrow(
       'no summary found',
     );
   });

--- a/packages/plugin-js-packages/src/lib/package-managers/yarn-classic/constants.ts
+++ b/packages/plugin-js-packages/src/lib/package-managers/yarn-classic/constants.ts
@@ -1,9 +1,9 @@
 import type { OutdatedDependency } from '../../runner/outdated/types.js';
-import type { Yarnv1FieldName } from './types.js';
+import type { YarnClassicFieldName } from './types.js';
 
 export const outdatedtoFieldMapper: Record<
   keyof OutdatedDependency,
-  Yarnv1FieldName
+  YarnClassicFieldName
 > = {
   name: 'Package',
   current: 'Current',
@@ -12,7 +12,7 @@ export const outdatedtoFieldMapper: Record<
   url: 'URL',
 };
 
-export const REQUIRED_OUTDATED_FIELDS: Yarnv1FieldName[] = [
+export const REQUIRED_OUTDATED_FIELDS: YarnClassicFieldName[] = [
   'Package',
   'Current',
   'Latest',

--- a/packages/plugin-js-packages/src/lib/package-managers/yarn-classic/outdated-result.ts
+++ b/packages/plugin-js-packages/src/lib/package-managers/yarn-classic/outdated-result.ts
@@ -13,15 +13,15 @@ import {
   outdatedtoFieldMapper,
 } from './constants.js';
 import {
-  type Yarnv1FieldName,
-  type Yarnv1OutdatedResultJson,
-  yarnv1FieldNames,
+  type YarnClassicFieldName,
+  type YarnClassicOutdatedResultJson,
+  yarnClassicFieldNames,
 } from './types.js';
 
-export function yarnv1ToOutdatedResult(output: string): OutdatedResult {
-  const yarnv1Outdated = fromJsonLines<Yarnv1OutdatedResultJson>(output);
-  const fields = yarnv1Outdated[1]?.data.head ?? [];
-  const dependencies = yarnv1Outdated[1]?.data.body ?? [];
+export function yarnClassicToOutdatedResult(output: string): OutdatedResult {
+  const yarnOutdated = fromJsonLines<YarnClassicOutdatedResultJson>(output);
+  const fields = yarnOutdated[1]?.data.head ?? [];
+  const dependencies = yarnOutdated[1]?.data.body ?? [];
 
   // no outdated dependencies
   if (dependencies.length === 0) {
@@ -46,7 +46,7 @@ export function yarnv1ToOutdatedResult(output: string): OutdatedResult {
 }
 
 export function validateOutdatedFields(head: string[]) {
-  const relevantFields = head.filter(isYarnv1FieldName);
+  const relevantFields = head.filter(isYarnClassicFieldName);
   if (hasAllRequiredFields(relevantFields)) {
     return true;
   }
@@ -54,16 +54,16 @@ export function validateOutdatedFields(head: string[]) {
   throw new Error(
     `Yarn v1 outdated: Template [${head.join(
       ', ',
-    )}] does not contain all required fields [${yarnv1FieldNames.join(', ')}]`,
+    )}] does not contain all required fields [${yarnClassicFieldNames.join(', ')}]`,
   );
 }
 
-function isYarnv1FieldName(value: string): value is Yarnv1FieldName {
-  const names: readonly string[] = yarnv1FieldNames;
+function isYarnClassicFieldName(value: string): value is YarnClassicFieldName {
+  const names: readonly string[] = yarnClassicFieldNames;
   return names.includes(value);
 }
 
-function hasAllRequiredFields(head: Yarnv1FieldName[]) {
+function hasAllRequiredFields(head: YarnClassicFieldName[]) {
   return REQUIRED_OUTDATED_FIELDS.every(field => head.includes(field));
 }
 

--- a/packages/plugin-js-packages/src/lib/package-managers/yarn-classic/outdated-result.unit.test.ts
+++ b/packages/plugin-js-packages/src/lib/package-managers/yarn-classic/outdated-result.unit.test.ts
@@ -8,11 +8,11 @@ import { REQUIRED_OUTDATED_FIELDS } from './constants.js';
 import {
   getOutdatedFieldIndexes,
   validateOutdatedFields,
-  yarnv1ToOutdatedResult,
+  yarnClassicToOutdatedResult,
 } from './outdated-result.js';
-import type { Yarnv1FieldName } from './types.js';
+import type { YarnClassicFieldName } from './types.js';
 
-describe('yarnv1ToOutdatedResult', () => {
+describe('yarnClassicToOutdatedResult', () => {
   const yarnInfo = { type: 'info', data: 'Colours' };
 
   it('should transform Yarn v1 outdated to unified outdated result', () => {
@@ -25,13 +25,13 @@ describe('yarnv1ToOutdatedResult', () => {
           'Latest',
           'Package Type',
           'URL',
-        ] satisfies Yarnv1FieldName[],
+        ] satisfies YarnClassicFieldName[],
         body: [['nx', '16.8.1', '17.0.0', 'dependencies', 'https://nx.dev/']],
       },
     };
 
     expect(
-      yarnv1ToOutdatedResult(toJsonLines([yarnInfo, table])),
+      yarnClassicToOutdatedResult(toJsonLines([yarnInfo, table])),
     ).toEqual<OutdatedResult>([
       {
         name: 'nx',
@@ -62,7 +62,7 @@ describe('yarnv1ToOutdatedResult', () => {
     };
 
     expect(
-      yarnv1ToOutdatedResult(toJsonLines([yarnInfo, table])),
+      yarnClassicToOutdatedResult(toJsonLines([yarnInfo, table])),
     ).toEqual<OutdatedResult>([
       {
         name: 'cypress',
@@ -76,7 +76,9 @@ describe('yarnv1ToOutdatedResult', () => {
   it('should transform no dependencies to empty array', () => {
     const table = { type: 'table', data: { head: [], body: [] } };
 
-    expect(yarnv1ToOutdatedResult(toJsonLines([yarnInfo, table]))).toEqual([]);
+    expect(yarnClassicToOutdatedResult(toJsonLines([yarnInfo, table]))).toEqual(
+      [],
+    );
   });
 });
 

--- a/packages/plugin-js-packages/src/lib/package-managers/yarn-classic/types.ts
+++ b/packages/plugin-js-packages/src/lib/package-managers/yarn-classic/types.ts
@@ -1,7 +1,7 @@
 import type { PackageAuditLevel } from '../../config.js';
 
 // Subset of Yarn v1 audit JSON type
-export type Yarnv1AuditAdvisory = {
+export type YarnClassicAuditAdvisory = {
   type: 'auditAdvisory';
   data: {
     resolution: {
@@ -19,20 +19,19 @@ export type Yarnv1AuditAdvisory = {
   };
 };
 
-export type Yarnv1AuditSummary = {
+export type YarnClassicAuditSummary = {
   type: 'auditSummary';
   data: {
     vulnerabilities: Record<PackageAuditLevel, number>;
   };
 };
 
-// NOTE: When rest operator can be at the beginning, the process will be much simpler
-export type Yarnv1AuditResultJson = [
-  ...Yarnv1AuditAdvisory[],
-  Yarnv1AuditSummary,
+export type YarnClassicAuditResultJson = [
+  ...YarnClassicAuditAdvisory[],
+  YarnClassicAuditSummary,
 ];
 
-export const yarnv1FieldNames = [
+export const yarnClassicFieldNames = [
   'Package',
   'Current',
   'Latest',
@@ -40,10 +39,10 @@ export const yarnv1FieldNames = [
   'URL',
 ] as const;
 
-export type Yarnv1FieldName = (typeof yarnv1FieldNames)[number];
+export type YarnClassicFieldName = (typeof yarnClassicFieldNames)[number];
 
-type Yarnv1Info = { type: 'info' };
-type Yarnv1Table = {
+type YarnClassicInfo = { type: 'info' };
+type YarnClassicTable = {
   type: 'table';
   data: {
     head: string[];
@@ -51,4 +50,6 @@ type Yarnv1Table = {
   };
 };
 
-export type Yarnv1OutdatedResultJson = [Yarnv1Info, Yarnv1Table] | [];
+export type YarnClassicOutdatedResultJson =
+  | [YarnClassicInfo, YarnClassicTable]
+  | [];

--- a/packages/plugin-js-packages/src/lib/package-managers/yarn-classic/yarn-classic.ts
+++ b/packages/plugin-js-packages/src/lib/package-managers/yarn-classic/yarn-classic.ts
@@ -1,10 +1,10 @@
 import { dependencyGroupToLong } from '../../constants.js';
 import { COMMON_AUDIT_ARGS, COMMON_OUTDATED_ARGS } from '../constants.js';
 import type { PackageManager } from '../types.js';
-import { yarnv1ToAuditResult } from './audit-result.js';
-import { yarnv1ToOutdatedResult } from './outdated-result.js';
+import { yarnClassicToAuditResult } from './audit-result.js';
+import { yarnClassicToOutdatedResult } from './outdated-result.js';
 
-export const yarnv1PackageManager: PackageManager = {
+export const yarnClassicPackageManager: PackageManager = {
   slug: 'yarn-classic',
   name: 'Yarn v1',
   command: 'yarn',
@@ -21,10 +21,10 @@ export const yarnv1PackageManager: PackageManager = {
       dependencyGroupToLong[groupDep],
     ],
     ignoreExitCode: true,
-    unifyResult: yarnv1ToAuditResult,
+    unifyResult: yarnClassicToAuditResult,
   },
   outdated: {
     commandArgs: COMMON_OUTDATED_ARGS,
-    unifyResult: yarnv1ToOutdatedResult,
+    unifyResult: yarnClassicToOutdatedResult,
   },
 };

--- a/packages/plugin-js-packages/src/lib/package-managers/yarn-modern/outdated-result.ts
+++ b/packages/plugin-js-packages/src/lib/package-managers/yarn-modern/outdated-result.ts
@@ -1,8 +1,8 @@
 import type { OutdatedResult } from '../../runner/outdated/types.js';
-import type { Yarnv2OutdatedResultJson } from './types.js';
+import type { YarnBerryOutdatedResultJson } from './types.js';
 
-export function yarnv2ToOutdatedResult(output: string): OutdatedResult {
-  const npmOutdated = JSON.parse(output) as Yarnv2OutdatedResultJson;
+export function yarnBerryToOutdatedResult(output: string): OutdatedResult {
+  const npmOutdated = JSON.parse(output) as YarnBerryOutdatedResultJson;
 
   return npmOutdated.map(({ name, current, latest, type }) => ({
     name,

--- a/packages/plugin-js-packages/src/lib/package-managers/yarn-modern/outdated-result.unit.test.ts
+++ b/packages/plugin-js-packages/src/lib/package-managers/yarn-modern/outdated-result.unit.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { yarnv2ToOutdatedResult } from './outdated-result.js';
-import type { Yarnv2OutdatedResultJson } from './types.js';
+import { yarnBerryToOutdatedResult } from './outdated-result.js';
+import type { YarnBerryOutdatedResultJson } from './types.js';
 
-describe('yarnv2ToOutdatedResult', () => {
+describe('yarnBerryToOutdatedResult', () => {
   it('should transform Yarn v2 outdated to unified outdated result', () => {
     const outdated = [
       {
@@ -17,14 +17,14 @@ describe('yarnv2ToOutdatedResult', () => {
         latest: '5.1.4',
         type: 'devDependencies',
       },
-    ] satisfies Yarnv2OutdatedResultJson;
+    ] satisfies YarnBerryOutdatedResultJson;
 
-    expect(yarnv2ToOutdatedResult(JSON.stringify(outdated))).toStrictEqual(
+    expect(yarnBerryToOutdatedResult(JSON.stringify(outdated))).toStrictEqual(
       outdated,
     );
   });
 
   it('should transform no dependencies to empty array', () => {
-    expect(yarnv2ToOutdatedResult('[]')).toEqual([]);
+    expect(yarnBerryToOutdatedResult('[]')).toEqual([]);
   });
 });

--- a/packages/plugin-js-packages/src/lib/package-managers/yarn-modern/types.ts
+++ b/packages/plugin-js-packages/src/lib/package-managers/yarn-modern/types.ts
@@ -1,8 +1,7 @@
-// Subset of Yarn v2+ audit JSON type
 import type { PackageAuditLevel } from '../../config.js';
 import type { DependencyGroupLong } from '../../runner/outdated/types.js';
 
-export type Yarnv2AuditAdvisory = {
+export type YarnBerry2or3AuditAdvisory = {
   module_name: string;
   severity: PackageAuditLevel;
   vulnerable_versions: string;
@@ -12,13 +11,28 @@ export type Yarnv2AuditAdvisory = {
   findings: { paths: string[] }[]; // TODO indirect?
 };
 
-export type Yarnv2AuditResultJson = {
-  advisories: Record<string, Yarnv2AuditAdvisory>;
+export type YarnBerry2or3AuditResultJson = {
+  advisories: Record<string, YarnBerry2or3AuditAdvisory>;
   metadata: { vulnerabilities: Record<PackageAuditLevel, number> };
 };
 
+export type YarnBerry4AuditVulnerability = {
+  value: string;
+  children: {
+    ID: number;
+    Issue: string;
+    URL: string;
+    Severity: PackageAuditLevel;
+    'Vulnerable Versions': string;
+    'Tree Versions': string[];
+    Dependents: string[];
+  };
+};
+
+export type YarnBerry4AuditResultJson = YarnBerry4AuditVulnerability[];
+
 // Subset of Yarn v2 outdated JSON type
-export type Yarnv2VersionOverview = {
+export type YarnBerryOutdatedPackage = {
   current: string;
   latest: string;
   name: string;
@@ -26,4 +40,4 @@ export type Yarnv2VersionOverview = {
   workspace?: string;
 };
 
-export type Yarnv2OutdatedResultJson = Yarnv2VersionOverview[];
+export type YarnBerryOutdatedResultJson = YarnBerryOutdatedPackage[];

--- a/packages/plugin-js-packages/src/lib/package-managers/yarn-modern/yarn-modern.ts
+++ b/packages/plugin-js-packages/src/lib/package-managers/yarn-modern/yarn-modern.ts
@@ -2,17 +2,17 @@
 import type { DependencyGroup } from '../../config.js';
 import { COMMON_AUDIT_ARGS, COMMON_OUTDATED_ARGS } from '../constants.js';
 import type { PackageManager } from '../types.js';
-import { yarnv2ToAuditResult } from './audit-result.js';
-import { yarnv2ToOutdatedResult } from './outdated-result.js';
+import { yarnBerryToAuditResult } from './audit-result.js';
+import { yarnBerryToOutdatedResult } from './outdated-result.js';
 
 // see https://github.com/yarnpkg/berry/blob/master/packages/plugin-npm-cli/sources/npmAuditTypes.ts#L5
-const yarnv2EnvironmentOptions: Record<DependencyGroup, string> = {
+const yarnModernEnvironmentOptions: Record<DependencyGroup, string> = {
   prod: 'production',
   dev: 'development',
   optional: '',
 };
 
-export const yarnv2PackageManager: PackageManager = {
+export const yarnModernPackageManager: PackageManager = {
   slug: 'yarn-modern',
   name: 'yarn-modern',
   command: 'yarn',
@@ -27,14 +27,14 @@ export const yarnv2PackageManager: PackageManager = {
       'npm',
       ...COMMON_AUDIT_ARGS,
       '--environment',
-      yarnv2EnvironmentOptions[groupDep],
+      yarnModernEnvironmentOptions[groupDep],
     ],
     supportedDepGroups: ['prod', 'dev'], // Yarn v2 does not support audit for optional dependencies
-    unifyResult: yarnv2ToAuditResult,
+    unifyResult: yarnBerryToAuditResult,
     ignoreExitCode: true,
   },
   outdated: {
     commandArgs: [...COMMON_OUTDATED_ARGS, '--workspace=.'], // filter out other packages in case of Yarn workspaces
-    unifyResult: yarnv2ToOutdatedResult,
+    unifyResult: yarnBerryToOutdatedResult,
   },
 };

--- a/packages/plugin-js-packages/src/lib/runner/audit/types.ts
+++ b/packages/plugin-js-packages/src/lib/runner/audit/types.ts
@@ -9,7 +9,7 @@ export type Vulnerability = {
   severity: PackageAuditLevel;
   versionRange: string;
   directDependency: string | true; // either name of direct dependency this one affects or true
-  fixInformation: string | false; // either guide on how to fix the vulnerability or false
+  fixInformation?: string | false; // either guide on how to fix the vulnerability or false
 };
 export type AuditSummary = Record<PackageAuditLevel | 'total', number>;
 export type AuditResult = {

--- a/packages/plugin-js-packages/src/lib/runner/audit/utils.ts
+++ b/packages/plugin-js-packages/src/lib/runner/audit/utils.ts
@@ -1,7 +1,25 @@
-import type { PackageAuditLevel } from '../../config.js';
+import { objectFromEntries } from '@code-pushup/utils';
+import { type PackageAuditLevel, packageAuditLevels } from '../../config.js';
+import type { AuditSummary } from './types.js';
 
 export function getVulnerabilitiesTotal(
   summary: Record<PackageAuditLevel, number>,
 ): number {
   return Object.values(summary).reduce((acc, value) => acc + value, 0);
+}
+
+export function summaryStatsFromVulnerabilities(
+  vulnerabilities: { severity: PackageAuditLevel }[],
+): AuditSummary {
+  const initial: AuditSummary = objectFromEntries(
+    ([...packageAuditLevels, 'total'] as const).map(key => [key, 0]),
+  );
+  return vulnerabilities.reduce(
+    (acc, { severity }) => ({
+      ...acc,
+      [severity]: acc[severity] + 1,
+      total: acc.total + 1,
+    }),
+    initial,
+  );
 }

--- a/packages/plugin-js-packages/src/lib/runner/audit/utils.unit.test.ts
+++ b/packages/plugin-js-packages/src/lib/runner/audit/utils.unit.test.ts
@@ -1,0 +1,23 @@
+import type { AuditSummary } from './types.js';
+import { summaryStatsFromVulnerabilities } from './utils.js';
+
+describe('summaryStatsFromVulnerabilities', () => {
+  it('should count severity occurences and total', () => {
+    expect(
+      summaryStatsFromVulnerabilities([
+        { severity: 'high' },
+        { severity: 'moderate' },
+        { severity: 'low' },
+        { severity: 'moderate' },
+        { severity: 'high' },
+      ]),
+    ).toEqual({
+      critical: 0,
+      high: 2,
+      moderate: 2,
+      low: 1,
+      info: 0,
+      total: 5,
+    } satisfies AuditSummary);
+  });
+});


### PR DESCRIPTION
Fixes bug reported by customer trying to integrate packages audit in Yarn v4.

Found out that in Yarn version 4, the output format of `yarn npm audit --json` changed completely compared to versions 2 and 3. Adjusted the stdout parsing logic to support both formats. Tested in `rx-angular` workspace.