### PR TITLE
fix(plugin-js-packages): for modern yarn, include transitive deps in audit and urls in outdated

### DIFF
--- a/packages/plugin-js-packages/src/lib/package-managers/constants.ts
+++ b/packages/plugin-js-packages/src/lib/package-managers/constants.ts
@@ -1,2 +1,0 @@
-export const COMMON_AUDIT_ARGS = ['audit', '--json'];
-export const COMMON_OUTDATED_ARGS = ['outdated', '--json'];

--- a/packages/plugin-js-packages/src/lib/package-managers/npm/npm.ts
+++ b/packages/plugin-js-packages/src/lib/package-managers/npm/npm.ts
@@ -1,7 +1,6 @@
 import { objectToKeys } from '@code-pushup/utils';
 import type { DependencyGroup } from '../../config.js';
 import { filterAuditResult } from '../../runner/utils.js';
-import { COMMON_AUDIT_ARGS, COMMON_OUTDATED_ARGS } from '../constants.js';
 import type { AuditResults, PackageManager } from '../types.js';
 import { npmToAuditResult } from './audit-result.js';
 import { npmToOutdatedResult } from './outdated-result.js';
@@ -24,9 +23,10 @@ export const npmPackageManager: PackageManager = {
   },
   audit: {
     getCommandArgs: groupDep => [
-      ...COMMON_AUDIT_ARGS,
+      'audit',
       ...npmDependencyOptions[groupDep],
       '--audit-level=none',
+      '--json',
     ],
     unifyResult: npmToAuditResult,
     // prod dependencies need to be filtered out manually since v10
@@ -49,7 +49,7 @@ export const npmPackageManager: PackageManager = {
     },
   },
   outdated: {
-    commandArgs: [...COMMON_OUTDATED_ARGS, '--long'],
+    commandArgs: ['outdated', '--long', '--json'],
     unifyResult: npmToOutdatedResult,
   },
 };

--- a/packages/plugin-js-packages/src/lib/package-managers/pnpm/pnpm.ts
+++ b/packages/plugin-js-packages/src/lib/package-managers/pnpm/pnpm.ts
@@ -1,7 +1,6 @@
 import { objectToKeys } from '@code-pushup/utils';
 import type { DependencyGroup } from '../../config.js';
 import { filterAuditResult } from '../../runner/utils.js';
-import { COMMON_AUDIT_ARGS, COMMON_OUTDATED_ARGS } from '../constants.js';
 import type { AuditResults, PackageManager } from '../types.js';
 import { pnpmToAuditResult } from './audit-result.js';
 import { pnpmToOutdatedResult } from './outdated-result.js';
@@ -24,8 +23,9 @@ export const pnpmPackageManager: PackageManager = {
   },
   audit: {
     getCommandArgs: groupDep => [
-      ...COMMON_AUDIT_ARGS,
+      'audit',
       ...pnpmDependencyOptions[groupDep],
+      '--json',
     ],
     ignoreExitCode: true,
     unifyResult: pnpmToAuditResult,
@@ -49,7 +49,7 @@ export const pnpmPackageManager: PackageManager = {
     },
   },
   outdated: {
-    commandArgs: COMMON_OUTDATED_ARGS,
+    commandArgs: ['outdated', '--json'],
     unifyResult: pnpmToOutdatedResult,
   },
 };

--- a/packages/plugin-js-packages/src/lib/package-managers/yarn-classic/yarn-classic.ts
+++ b/packages/plugin-js-packages/src/lib/package-managers/yarn-classic/yarn-classic.ts
@@ -1,5 +1,4 @@
 import { dependencyGroupToLong } from '../../constants.js';
-import { COMMON_AUDIT_ARGS, COMMON_OUTDATED_ARGS } from '../constants.js';
 import type { PackageManager } from '../types.js';
 import { yarnClassicToAuditResult } from './audit-result.js';
 import { yarnClassicToOutdatedResult } from './outdated-result.js';
@@ -16,15 +15,15 @@ export const yarnClassicPackageManager: PackageManager = {
   },
   audit: {
     getCommandArgs: groupDep => [
-      ...COMMON_AUDIT_ARGS,
-      '--groups',
-      dependencyGroupToLong[groupDep],
+      'audit',
+      `--groups=${dependencyGroupToLong[groupDep]}`,
+      '--json',
     ],
     ignoreExitCode: true,
     unifyResult: yarnClassicToAuditResult,
   },
   outdated: {
-    commandArgs: COMMON_OUTDATED_ARGS,
+    commandArgs: ['outdated', '--json'],
     unifyResult: yarnClassicToOutdatedResult,
   },
 };

--- a/packages/plugin-js-packages/src/lib/package-managers/yarn-modern/outdated-result.ts
+++ b/packages/plugin-js-packages/src/lib/package-managers/yarn-modern/outdated-result.ts
@@ -4,10 +4,11 @@ import type { YarnBerryOutdatedResultJson } from './types.js';
 export function yarnBerryToOutdatedResult(output: string): OutdatedResult {
   const npmOutdated = JSON.parse(output) as YarnBerryOutdatedResultJson;
 
-  return npmOutdated.map(({ name, current, latest, type }) => ({
+  return npmOutdated.map(({ name, current, latest, type, url }) => ({
     name,
     current,
     latest,
     type,
+    ...(url && { url }),
   }));
 }

--- a/packages/plugin-js-packages/src/lib/package-managers/yarn-modern/outdated-result.unit.test.ts
+++ b/packages/plugin-js-packages/src/lib/package-managers/yarn-modern/outdated-result.unit.test.ts
@@ -10,6 +10,7 @@ describe('yarnBerryToOutdatedResult', () => {
         current: '16.8.1',
         latest: '17.0.0',
         type: 'dependencies',
+        url: 'https://nx.dev/',
       },
       {
         name: 'vite',

--- a/packages/plugin-js-packages/src/lib/package-managers/yarn-modern/types.ts
+++ b/packages/plugin-js-packages/src/lib/package-managers/yarn-modern/types.ts
@@ -36,7 +36,9 @@ export type YarnBerryOutdatedPackage = {
   current: string;
   latest: string;
   name: string;
+  range?: string;
   type: DependencyGroupLong;
+  url?: string;
   workspace?: string;
 };
 

--- a/packages/plugin-js-packages/src/lib/package-managers/yarn-modern/yarn-modern.ts
+++ b/packages/plugin-js-packages/src/lib/package-managers/yarn-modern/yarn-modern.ts
@@ -1,6 +1,5 @@
 // Yarn v2 does not currently audit optional dependencies
 import type { DependencyGroup } from '../../config.js';
-import { COMMON_AUDIT_ARGS, COMMON_OUTDATED_ARGS } from '../constants.js';
 import type { PackageManager } from '../types.js';
 import { yarnBerryToAuditResult } from './audit-result.js';
 import { yarnBerryToOutdatedResult } from './outdated-result.js';
@@ -23,18 +22,25 @@ export const yarnModernPackageManager: PackageManager = {
     outdated: 'https://github.com/mskelton/yarn-plugin-outdated',
   },
   audit: {
-    getCommandArgs: groupDep => [
-      'npm',
-      ...COMMON_AUDIT_ARGS,
-      '--environment',
-      yarnModernEnvironmentOptions[groupDep],
-    ],
+    getCommandArgs: groupDep => {
+      const environment = yarnModernEnvironmentOptions[groupDep];
+      return [
+        'npm',
+        'audit',
+        ...(environment ? [`--environment=${environment}`] : []),
+        '--json',
+      ];
+    },
     supportedDepGroups: ['prod', 'dev'], // Yarn v2 does not support audit for optional dependencies
     unifyResult: yarnBerryToAuditResult,
     ignoreExitCode: true,
   },
   outdated: {
-    commandArgs: [...COMMON_OUTDATED_ARGS, '--workspace=.'], // filter out other packages in case of Yarn workspaces
+    commandArgs: [
+      'outdated',
+      '--workspace=.', // filter out other packages in case of Yarn workspaces
+      '--json',
+    ],
     unifyResult: yarnBerryToOutdatedResult,
   },
 };

--- a/packages/plugin-js-packages/src/lib/package-managers/yarn-modern/yarn-modern.ts
+++ b/packages/plugin-js-packages/src/lib/package-managers/yarn-modern/yarn-modern.ts
@@ -39,6 +39,7 @@ export const yarnModernPackageManager: PackageManager = {
     commandArgs: [
       'outdated',
       '--workspace=.', // filter out other packages in case of Yarn workspaces
+      '--url',
       '--json',
     ],
     unifyResult: yarnBerryToOutdatedResult,

--- a/packages/plugin-js-packages/src/lib/package-managers/yarn-modern/yarn-modern.ts
+++ b/packages/plugin-js-packages/src/lib/package-managers/yarn-modern/yarn-modern.ts
@@ -27,6 +27,7 @@ export const yarnModernPackageManager: PackageManager = {
       return [
         'npm',
         'audit',
+        '--recursive',
         ...(environment ? [`--environment=${environment}`] : []),
         '--json',
       ];


### PR DESCRIPTION
Yarn Berry's [`yarn npm audit`](https://yarnpkg.com/cli/npm/audit) command by default only reports vulnerabilities in direct dependencies, not transitive dependencies. Adding `--recursive` flag brings it in line with audit commands from other package managers.

Also, found out that it's possible to get outdated package URLs in [`yarn-plugin-outdated`](https://github.com/mskelton/yarn-plugin-outdated?tab=readme-ov-file#display-homepage-urls---url) by adding `--url` flag. So reported issues for Yarn Berry should now include Markdown links, not just the package name.