### PR TITLE
docs: add category badges from portal

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,16 @@
 
 ---
 
+![Type safety](https://api.staging.code-pushup.dev/badges/code-pushup/cli/type-safety?apiKey=cp_def67c4efe558a9149061d0c62de893e1689ad793071db332790238446173fef)
+![Bug prevention](https://api.staging.code-pushup.dev/badges/code-pushup/cli/bug-prevention?apiKey=cp_def67c4efe558a9149061d0c62de893e1689ad793071db332790238446173fef)
+![Code style](https://api.staging.code-pushup.dev/badges/code-pushup/cli/code-style?apiKey=cp_def67c4efe558a9149061d0c62de893e1689ad793071db332790238446173fef)
+![Code coverage](https://api.staging.code-pushup.dev/badges/code-pushup/cli/code-coverage?apiKey=cp_def67c4efe558a9149061d0c62de893e1689ad793071db332790238446173fef)
+![Security](https://api.staging.code-pushup.dev/badges/code-pushup/cli/security?apiKey=cp_def67c4efe558a9149061d0c62de893e1689ad793071db332790238446173fef)
+![Updates](https://api.staging.code-pushup.dev/badges/code-pushup/cli/updates?apiKey=cp_def67c4efe558a9149061d0c62de893e1689ad793071db332790238446173fef)
+![Documentation](https://api.staging.code-pushup.dev/badges/code-pushup/cli/docs?apiKey=cp_def67c4efe558a9149061d0c62de893e1689ad793071db332790238446173fef)
+
+---
+
 ### 🔌 Code quality tools are like phone chargers. Everyone has a different plug.
 
 _Common problems with keeping track of technical quality:_


### PR DESCRIPTION
Uses portal's new badges API to render live category scores for this repo. For security, the API key is restricted to `read:reports` scope and has access only to the Code PushUp CLI project in the portal.

<img width="1035" height="113" alt="image" src="https://github.com/user-attachments/assets/67d77919-467a-4064-a254-fa7539139683" />
