### PR TITLE
ci: fix missing permissions in labeler workflow

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -9,7 +9,9 @@ jobs:
     name: Add PR labels
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: write
+      issues: write
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Labeler actions seems to fail when trying to create new labels, recommended solution is to add `issues: write` permission.
- See actions/labeler/issues/870