### PR TITLE
feat(ci): skip persist.format args if defaults already configured

### DIFF
--- a/e2e/ci-e2e/global-setup.ts
+++ b/e2e/ci-e2e/global-setup.ts
@@ -1,0 +1,16 @@
+/* eslint-disable functional/immutable-data */
+
+const originalCI = process.env['CI'];
+
+export function setup() {
+  // package is expected to run in CI environment
+  process.env['CI'] = 'true';
+}
+
+export function teardown() {
+  if (originalCI === undefined) {
+    delete process.env['CI'];
+  } else {
+    process.env['CI'] = originalCI;
+  }
+}

--- a/e2e/ci-e2e/tsconfig.test.json
+++ b/e2e/ci-e2e/tsconfig.test.json
@@ -8,6 +8,7 @@
     "vitest.e2e.config.ts",
     "tests/**/*.e2e.test.ts",
     "tests/**/*.d.ts",
-    "mocks/**/*.ts"
+    "mocks/**/*.ts",
+    "global-setup.ts"
   ]
 }

--- a/e2e/ci-e2e/vitest.e2e.config.ts
+++ b/e2e/ci-e2e/vitest.e2e.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
     },
     environment: 'node',
     include: ['tests/**/*.e2e.test.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    globalSetup: './global-setup.ts',
     setupFiles: ['../../testing/test-setup/src/lib/reset.mocks.ts'],
   },
 });

--- a/packages/ci/src/lib/cli/commands/collect.ts
+++ b/packages/ci/src/lib/cli/commands/collect.ts
@@ -2,18 +2,18 @@ import { DEFAULT_PERSIST_FORMAT } from '@code-pushup/models';
 import { executeProcess, isVerbose } from '@code-pushup/utils';
 import type { CommandContext } from '../context.js';
 
-export async function runCollect({
-  bin,
-  config,
-  directory,
-  observer,
-}: CommandContext): Promise<void> {
+export async function runCollect(
+  { bin, config, directory, observer }: CommandContext,
+  { hasFormats }: { hasFormats: boolean },
+): Promise<void> {
   await executeProcess({
     command: bin,
     args: [
       ...(isVerbose() ? ['--verbose'] : []),
       ...(config ? [`--config=${config}`] : []),
-      ...DEFAULT_PERSIST_FORMAT.map(format => `--persist.format=${format}`),
+      ...(hasFormats
+        ? []
+        : DEFAULT_PERSIST_FORMAT.map(format => `--persist.format=${format}`)),
     ],
     cwd: directory,
     observer,

--- a/packages/ci/src/lib/run-utils.ts
+++ b/packages/ci/src/lib/run-utils.ts
@@ -1,7 +1,12 @@
 /* eslint-disable max-lines */
 import { readFile } from 'node:fs/promises';
 import type { SimpleGit } from 'simple-git';
-import type { CoreConfig, Report, ReportsDiff } from '@code-pushup/models';
+import {
+  type CoreConfig,
+  DEFAULT_PERSIST_FORMAT,
+  type Report,
+  type ReportsDiff,
+} from '@code-pushup/models';
 import {
   removeUndefinedAndEmptyProps,
   stringifyError,
@@ -112,7 +117,7 @@ export async function runOnProject(
     `Loaded persist config from print-config command - ${JSON.stringify(config.persist)}`,
   );
 
-  await runCollect(ctx);
+  await runCollect(ctx, { hasFormats: hasDefaultPersistFormats(config) });
   const currReport = await saveReportFiles({
     project,
     type: 'current',
@@ -221,7 +226,7 @@ export async function collectPreviousReport(
       return null;
     }
 
-    await runCollect(ctx);
+    await runCollect(ctx, { hasFormats: hasDefaultPersistFormats(config) });
     const report = await saveReportFiles({
       project,
       type: 'previous',
@@ -327,6 +332,16 @@ export async function printPersistConfig(
 ): Promise<Pick<CoreConfig, 'persist'>> {
   const json = await runPrintConfig(ctx);
   return parsePersistConfig(json);
+}
+
+export function hasDefaultPersistFormats(
+  config: Pick<CoreConfig, 'persist'>,
+): boolean {
+  const formats = config.persist?.format;
+  return (
+    formats == null ||
+    DEFAULT_PERSIST_FORMAT.every(format => formats.includes(format))
+  );
 }
 
 export async function findNewIssues(

--- a/packages/ci/src/lib/run.int.test.ts
+++ b/packages/ci/src/lib/run.int.test.ts
@@ -256,7 +256,7 @@ describe('runInCI', () => {
         } satisfies utils.ProcessConfig);
         expect(utils.executeProcess).toHaveBeenNthCalledWith(2, {
           command: options.bin,
-          args: ['--persist.format=json', '--persist.format=md'],
+          args: [],
           cwd: workDir,
           observer: expectedObserver,
         } satisfies utils.ProcessConfig);
@@ -334,7 +334,7 @@ describe('runInCI', () => {
         } satisfies utils.ProcessConfig);
         expect(utils.executeProcess).toHaveBeenNthCalledWith(2, {
           command: options.bin,
-          args: ['--persist.format=json', '--persist.format=md'],
+          args: [],
           cwd: workDir,
           observer: expectedObserver,
         } satisfies utils.ProcessConfig);
@@ -346,7 +346,7 @@ describe('runInCI', () => {
         } satisfies utils.ProcessConfig);
         expect(utils.executeProcess).toHaveBeenNthCalledWith(4, {
           command: options.bin,
-          args: ['--persist.format=json', '--persist.format=md'],
+          args: [],
           cwd: workDir,
           observer: expectedObserver,
         } satisfies utils.ProcessConfig);
@@ -418,7 +418,7 @@ describe('runInCI', () => {
         } satisfies utils.ProcessConfig);
         expect(utils.executeProcess).toHaveBeenNthCalledWith(2, {
           command: options.bin,
-          args: ['--persist.format=json', '--persist.format=md'],
+          args: [],
           cwd: workDir,
           observer: expectedObserver,
         } satisfies utils.ProcessConfig);
@@ -605,7 +605,7 @@ describe('runInCI', () => {
         } satisfies utils.ProcessConfig);
         expect(utils.executeProcess).toHaveBeenCalledWith({
           command: runMany,
-          args: ['--persist.format=json', '--persist.format=md'],
+          args: [],
           cwd: expect.stringContaining(workDir),
           observer: expectedObserver,
         } satisfies utils.ProcessConfig);
@@ -763,7 +763,7 @@ describe('runInCI', () => {
         } satisfies utils.ProcessConfig);
         expect(utils.executeProcess).toHaveBeenCalledWith({
           command: runMany,
-          args: ['--persist.format=json', '--persist.format=md'],
+          args: [],
           cwd: expect.stringContaining(workDir),
           observer: expectedObserver,
         } satisfies utils.ProcessConfig);
@@ -951,7 +951,7 @@ describe('runInCI', () => {
         } satisfies utils.ProcessConfig);
         expect(utils.executeProcess).toHaveBeenCalledWith({
           command: options.bin,
-          args: ['--persist.format=json', '--persist.format=md'],
+          args: [],
           cwd: expect.stringContaining(workDir),
           observer: expectedObserver,
         } satisfies utils.ProcessConfig);
@@ -1120,7 +1120,7 @@ describe('runInCI', () => {
         } satisfies utils.ProcessConfig);
         expect(utils.executeProcess).toHaveBeenCalledWith({
           command: options.bin,
-          args: ['--persist.format=json', '--persist.format=md'],
+          args: [],
           cwd: expect.stringContaining(workDir),
           observer: expectedObserver,
         } satisfies utils.ProcessConfig);


### PR DESCRIPTION
Final piece from larger effort to avoid CLI arguments which reduce chances of Nx cache hits in default setup. See also:
- #1040
- #1041

The CLI arguments `--persist.format=json --persist.format=md` were being set in case user-defined config omitted report formats which `@code-pushup/ci` relies on. After this refactor, the configured formats are first checked in `print-config` output, and then only set if some format is missing - in monorepo mode with bulk collect, every project must have default formats configured in order to skip the CLI arguments.

TLDR: `--persist.format` args are now skipped unless user has some unusual config.
