### PR TITLE
feat(ci): add configPatterns as optional performance optimization

### DIFF
--- a/packages/ci/README.md
+++ b/packages/ci/README.md
@@ -103,11 +103,12 @@ Optionally, you can override default options for further customization:
 | `nxProjectsFilter` | `string \| string[]`      | `'--with-target={task}'`         | Arguments passed to [`nx show projects`](https://nx.dev/nx-api/nx/documents/show#projects), only relevant for Nx in [monorepo mode](#monorepo-mode) [^2] |
 | `directory`        | `string`                  | `process.cwd()`                  | Directory in which Code PushUp CLI should run                                                                                                            |
 | `config`           | `string \| null`          | `null` [^1]                      | Path to config file (`--config` option)                                                                                                                  |
-| `silent`           | `boolean`                 | `false`                          | Hides logs from CLI commands (erros will be printed)                                                                                                     |
+| `silent`           | `boolean`                 | `false`                          | Hides logs from CLI commands (errors will be printed)                                                                                                    |
 | `bin`              | `string`                  | `'npx --no-install code-pushup'` | Command for executing Code PushUp CLI                                                                                                                    |
 | `detectNewIssues`  | `boolean`                 | `true`                           | Toggles if new issues should be detected and returned in `newIssues` property                                                                            |
 | `logger`           | `Logger`                  | `console`                        | Logger for reporting progress and encountered problems                                                                                                   |
 | `skipComment`      | `boolean`                 | `false`                          | Toggles if comparison comment is posted to PR                                                                                                            |
+| `configPatterns`   | `ConfigPatterns \| null`  | `null`                           | Additional configuration which enables [faster CI runs](#faster-ci-runs-with-configpatterns)                                                             |
 
 [^1]: By default, the `code-pushup.config` file is autodetected as described in [`@code-pushup/cli` docs](../cli/README.md#configuration).
 
@@ -213,6 +214,32 @@ The maximum number of concurrent tasks can be set by passing in a number instead
 await runInCI(refs, api, {
   monorepo: true,
   parallel: 3,
+});
+```
+
+### Faster CI runs with `configPatterns`
+
+By default, the `print-config` command is run sequentially for each project in order to reliably detect how `code-pushup` is configured - specifically, where to read output files from (`persist` config) and whether portal may be used as a cache (`upload` config). This allows for each project to be configured in its own way without breaking anything, but for large monorepos these extra `code-pushup print-config` executions can accumulate and significantly slow down CI pipelines.
+
+As a more scalable alternative, `configPatterns` may be provided. A user declares upfront how every project is configured, which allows `print-config` to be skipped. It's the user's responsibility to ensure this configuration holds for every project (it won't be checked). The `configPatterns` support string interpolation, substituting `{projectName}` with each project's name. Other than that, each project's `code-pushup.config` must have exactly the same `persist` and `upload` configurations.
+
+```ts
+await runInCI(refs, api, {
+  monorepo: true,
+  configPatterns: {
+    persist: {
+      outputDir: '.code-pushup/{projectName}',
+      filename: 'report',
+      format: ['json', 'md'],
+    },
+    // optional: will use portal as cache when comparing reports in PRs
+    upload: {
+      server: 'https://api.code-pushup.example.com/graphql',
+      apiKey: 'cp_...',
+      organization: 'example',
+      project: '{projectName}',
+    },
+  },
 });
 ```
 

--- a/packages/ci/src/lib/cli/context.unit.test.ts
+++ b/packages/ci/src/lib/cli/context.unit.test.ts
@@ -24,6 +24,7 @@ describe('createCommandContext', () => {
           silent: false,
           task: 'code-pushup',
           skipComment: false,
+          configPatterns: null,
         },
         null,
       ),
@@ -52,6 +53,7 @@ describe('createCommandContext', () => {
           silent: false,
           task: 'code-pushup',
           skipComment: false,
+          configPatterns: null,
         },
         {
           name: 'ui',

--- a/packages/ci/src/lib/constants.ts
+++ b/packages/ci/src/lib/constants.ts
@@ -14,4 +14,5 @@ export const DEFAULT_SETTINGS: Settings = {
   logger: console,
   nxProjectsFilter: '--with-target={task}',
   skipComment: false,
+  configPatterns: null,
 };

--- a/packages/ci/src/lib/models.ts
+++ b/packages/ci/src/lib/models.ts
@@ -1,4 +1,4 @@
-import type { Format } from '@code-pushup/models';
+import type { Format, PersistConfig, UploadConfig } from '@code-pushup/models';
 import type { SourceFileIssue } from './issues.js';
 import type { MonorepoTool } from './monorepo/index.js';
 
@@ -20,6 +20,7 @@ export type Options = {
   detectNewIssues?: boolean;
   logger?: Logger;
   skipComment?: boolean;
+  configPatterns?: ConfigPatterns | null;
 };
 
 /**
@@ -72,6 +73,15 @@ export type Logger = {
   warn: (message: string) => void;
   info: (message: string) => void;
   debug: (message: string) => void;
+};
+
+/**
+ * Code PushUp config patterns which hold for every project in monorepo.
+ * Providing this information upfront makes CI runs faster (skips print-config).
+ */
+export type ConfigPatterns = {
+  persist: Required<PersistConfig>;
+  upload?: UploadConfig;
 };
 
 /**

--- a/packages/ci/src/lib/monorepo/handlers/nx.ts
+++ b/packages/ci/src/lib/monorepo/handlers/nx.ts
@@ -2,6 +2,7 @@ import path from 'node:path';
 import {
   executeProcess,
   fileExists,
+  interpolate,
   stringifyError,
   toArray,
 } from '@code-pushup/utils';
@@ -32,7 +33,7 @@ export const nxHandler: MonorepoToolHandler = {
         'nx',
         'show',
         'projects',
-        ...toArray(nxProjectsFilter).map(arg => arg.replaceAll('{task}', task)),
+        ...toArray(nxProjectsFilter).map(arg => interpolate(arg, { task })),
         '--json',
       ],
       cwd,

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -76,6 +76,7 @@ export {
   isPromiseFulfilledResult,
   isPromiseRejectedResult,
 } from './lib/guards.js';
+export { interpolate } from './lib/interpolate.js';
 export { logMultipleResults } from './lib/log-results.js';
 export { link, ui, type CliUi, type Column } from './lib/logging.js';
 export { mergeConfigs } from './lib/merge-configs.js';

--- a/packages/utils/src/lib/interpolate.ts
+++ b/packages/utils/src/lib/interpolate.ts
@@ -1,0 +1,9 @@
+export function interpolate(
+  text: string,
+  variables: Record<string, string>,
+): string {
+  return Object.entries(variables).reduce(
+    (acc, [key, value]) => acc.replaceAll(`{${key}}`, value),
+    text,
+  );
+}

--- a/packages/utils/src/lib/interpolate.unit.test.ts
+++ b/packages/utils/src/lib/interpolate.unit.test.ts
@@ -1,0 +1,52 @@
+import { interpolate } from './interpolate.js';
+
+describe('interpolate', () => {
+  it('should replace variable in string', () => {
+    expect(
+      interpolate('.code-pushup/{projectName}', { projectName: 'utils' }),
+    ).toBe('.code-pushup/utils');
+  });
+
+  it('should replace multiple variables', () => {
+    expect(
+      interpolate('{workspaceRoot}/coverage/{projectRoot}/lcov.info', {
+        workspaceRoot: '/home/matej/Projects/code-pushup-cli',
+        projectRoot: 'packages/ci',
+      }),
+    ).toBe(
+      '/home/matej/Projects/code-pushup-cli/coverage/packages/ci/lcov.info',
+    );
+  });
+
+  it('should replace same variable multiple times', () => {
+    expect(
+      interpolate('.code-pushup/{projectName}/{projectName}-report.json', {
+        projectName: 'utils',
+      }),
+    ).toBe('.code-pushup/utils/utils-report.json');
+  });
+
+  it('should not replace missing variables', () => {
+    expect(interpolate('{projectRoot}/.code-pushup', {})).toBe(
+      '{projectRoot}/.code-pushup',
+    );
+  });
+
+  it('should support empty string interpolation', () => {
+    expect(interpolate('{prefix}report.json', { prefix: '' })).toBe(
+      'report.json',
+    );
+  });
+
+  it('should support strings with only variable', () => {
+    expect(interpolate('{projectName}', { projectName: 'utils' })).toBe(
+      'utils',
+    );
+  });
+
+  it('should leave strings without variables unchanged', () => {
+    expect(interpolate('.code-pushup', { projectName: 'utils' })).toBe(
+      '.code-pushup',
+    );
+  });
+});

--- a/packages/utils/src/lib/types.ts
+++ b/packages/utils/src/lib/types.ts
@@ -1,6 +1,6 @@
-export type ExcludeNullableProps<T> = {
+export type ExcludeNullableProps<T> = Prettify<{
   [P in keyof T]: NonNullable<T[P]>;
-};
+}>;
 
 export type ItemOrArray<T> = T | T[];
 
@@ -14,7 +14,7 @@ export type WithRequired<T, K extends keyof T> = Prettify<
   Omit<T, K> & Required<Pick<T, K>>
 >;
 
-export type Prettify<T> = { [K in keyof T]: T[K] };
+export type Prettify<T> = { [K in keyof T]: T[K] } & {};
 
 export type CamelCaseToKebabCase<T extends string> =
   T extends `${infer First}${infer Rest}`


### PR DESCRIPTION
1st half of #1043 

Adds `configPatterns` option, which allows skipping per-project `print-config` executions.