### PR TITLE
build: fix nx release packageRoot after build outputs moved

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -45,7 +45,7 @@
       "dependsOn": ["build"],
       "executor": "@nx/js:release-publish",
       "options": {
-        "packageRoot": "dist/{projectRoot}",
+        "packageRoot": "{projectRoot}/dist",
         "registry": "https://registry.npmjs.org/"
       }
     }

--- a/nx.json
+++ b/nx.json
@@ -51,7 +51,11 @@
     }
   },
   "namedInputs": {
-    "default": ["{projectRoot}/**/*", "sharedGlobals"],
+    "default": [
+      "{projectRoot}/**/*",
+      "sharedGlobals",
+      "!{projectRoot}/dist/**/*"
+    ],
     "production": [
       "default",
       "!{projectRoot}/eslint.config.?(c)js",


### PR DESCRIPTION
Required change after #1052, needed for `nx release` to work properly. Also explicitly excluded `dist` from cache inputs, just in case it interferes.