### PR TITLE
fix(ci): prevent invalid startLine 0 when downloading from portal

### DIFF
--- a/packages/ci/src/lib/portal/transform.ts
+++ b/packages/ci/src/lib/portal/transform.ts
@@ -150,18 +150,20 @@ function transformGQLIssue(issue: IssueFragment): Issue {
     ...(issue.source?.__typename === 'SourceCodeLocation' && {
       source: {
         file: issue.source.filePath,
-        position: {
-          startLine: issue.source.startLine ?? 0,
-          ...(issue.source.startColumn != null && {
-            startColumn: issue.source.startColumn,
-          }),
-          ...(issue.source.endLine != null && {
-            endLine: issue.source.endLine,
-          }),
-          ...(issue.source.endColumn != null && {
-            endColumn: issue.source.endColumn,
-          }),
-        },
+        ...(issue.source.startLine != null && {
+          position: {
+            startLine: issue.source.startLine,
+            ...(issue.source.startColumn != null && {
+              startColumn: issue.source.startColumn,
+            }),
+            ...(issue.source.endLine != null && {
+              endLine: issue.source.endLine,
+            }),
+            ...(issue.source.endColumn != null && {
+              endColumn: issue.source.endColumn,
+            }),
+          },
+        }),
       },
     }),
   };


### PR DESCRIPTION
Bug reported by customer - `startLine: 0` causes validation errors when comparing cached portal report.