### PR TITLE
feat(nx-cloud): set up nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -23,9 +23,7 @@
       "options": {
         "configFile": "{projectRoot}/vitest.unit.config.ts",
         "passWithNoTests": true,
-        "coverage": {
-          "enabled": true
-        }
+        "coverage": { "enabled": true }
       }
     },
     "int-test": {
@@ -35,14 +33,10 @@
       "options": {
         "configFile": "{projectRoot}/vitest.int.config.ts",
         "passWithNoTests": true,
-        "coverage": {
-          "enabled": true
-        }
+        "coverage": { "enabled": true }
       }
     },
-    "e2e": {
-      "dependsOn": ["^build"]
-    },
+    "e2e": { "dependsOn": ["^build"] },
     "lint": {
       "inputs": ["default", "{workspaceRoot}/eslint.config.?(c)js"],
       "executor": "@nx/linter:eslint",
@@ -56,16 +50,11 @@
         ]
       }
     },
-    "nxv-pkg-install": {
-      "parallelism": false
-    },
+    "nxv-pkg-install": { "parallelism": false },
     "@nx/vite:test": {
       "cache": true,
       "inputs": ["default", "^production"],
-      "options": {
-        "passWithNoTests": true,
-        "watch": false
-      }
+      "options": { "passWithNoTests": true, "watch": false }
     },
     "nx-release-publish": {
       "dependsOn": ["build"],
@@ -99,10 +88,7 @@
     ],
     "sharedGlobals": []
   },
-  "workspaceLayout": {
-    "appsDir": "examples",
-    "libsDir": "packages"
-  },
+  "workspaceLayout": { "appsDir": "examples", "libsDir": "packages" },
   "generators": {},
   "release": {
     "projects": ["packages/*"],
@@ -110,9 +96,7 @@
     "changelog": {
       "automaticFromRef": true,
       "projectChangelogs": false,
-      "workspaceChangelog": {
-        "createRelease": "github"
-      }
+      "workspaceChangelog": { "createRelease": "github" }
     },
     "git": {
       "commit": true,
@@ -123,9 +107,7 @@
     },
     "version": {
       "conventionalCommits": true,
-      "generatorOptions": {
-        "skipLockFileUpdate": true
-      }
+      "generatorOptions": { "skipLockFileUpdate": true }
     },
     "releaseTagPattern": "v{version}"
   },
@@ -136,14 +118,11 @@
         "environments": {
           "environmentsDir": "tmp/e2e",
           "targetNames": ["e2e"],
-          "inferredTargets": {
-            "e2e": "e2e-test"
-          }
+          "inferredTargets": { "e2e": "e2e-test" }
         },
-        "packages": {
-          "filterByTags": ["publishable"]
-        }
+        "packages": { "filterByTags": ["publishable"] }
       }
     }
-  ]
+  ],
+  "nxCloudId": "65d4d862d2adb16a45a4bc7c"
 }


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace

This commit sets up Nx Cloud for your Nx workspace, enabling distributed caching and the Nx Cloud GitHub integration for fast CI and improved developer experience.

You can access your Nx Cloud workspace by going to
https://cloud.nx.app/orgs/65d4d8449e4953a5ed64ff4a/workspaces/65d4d862d2adb16a45a4bc7c

**Note:** This commit attempts to maintain formatting of the nx.json file, however you may need to correct formatting by running an nx format command and committing the changes.