### PR TITLE
chore: add lint report target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: E2E test affected projects
-        run: npx nx affected -t e2e-test --skipNxCache --parallel=1
+        run: npx nx affected -t e2e-test --parallel=1
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: E2E test affected projects
-        run: npx nx affected -t e2e-test --parallel=1
+        run: npx nx affected -t e2e-test --skipNxCache --parallel=1
 
   build:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -43,8 +43,11 @@ testem.log
 .DS_Store
 Thumbs.db
 
+# generated eslint reports
+.eslint
+
 # generated Code PushUp reports
-/.code-pushup
+.code-pushup
 
 # Nx workspace cache
 .nx

--- a/code-pushup.preset.ts
+++ b/code-pushup.preset.ts
@@ -7,9 +7,10 @@ import coveragePlugin, {
   getNxCoveragePaths,
 } from './packages/plugin-coverage/src/index.js';
 import eslintPlugin, {
-  eslintConfigFromAllNxProjects,
   eslintConfigFromNxProject,
 } from './packages/plugin-eslint/src/index.js';
+import type { ESLintTarget } from './packages/plugin-eslint/src/lib/config.js';
+import { nxProjectsToConfig } from './packages/plugin-eslint/src/lib/nx/projects-to-config.js';
 import jsPackagesPlugin from './packages/plugin-js-packages/src/index.js';
 import jsDocsPlugin from './packages/plugin-jsdocs/src/index.js';
 import type { JsDocsPluginTransformedConfig } from './packages/plugin-jsdocs/src/lib/config.js';
@@ -156,6 +157,17 @@ export const jsDocsCoreConfig = (
   ),
 });
 
+export async function eslintConfigFromPublishableNxProjects(): Promise<
+  ESLintTarget[]
+> {
+  const { createProjectGraphAsync } = await import('@nx/devkit');
+  const projectGraph = await createProjectGraphAsync({ exitOnError: false });
+  return nxProjectsToConfig(
+    projectGraph,
+    project => project.tags?.includes('publishable') ?? false,
+  );
+}
+
 export const eslintCoreConfigNx = async (
   projectName?: string,
 ): Promise<CoreConfig> => ({
@@ -163,7 +175,7 @@ export const eslintCoreConfigNx = async (
     await eslintPlugin(
       await (projectName
         ? eslintConfigFromNxProject(projectName)
-        : eslintConfigFromAllNxProjects()),
+        : eslintConfigFromPublishableNxProjects()),
     ),
   ],
   categories: eslintCategories,

--- a/nx.json
+++ b/nx.json
@@ -46,10 +46,26 @@
     "lint": {
       "inputs": ["default", "{workspaceRoot}/eslint.config.?(c)js"],
       "executor": "@nx/linter:eslint",
-      "outputs": ["{options.outputFile}"],
       "cache": true,
       "options": {
+        "errorOnUnmatchedPattern": false,
         "maxWarnings": 0,
+        "lintFilePatterns": [
+          "{projectRoot}/**/*.ts",
+          "{projectRoot}/package.json"
+        ]
+      }
+    },
+    "lint-report": {
+      "inputs": ["default", "{workspaceRoot}/eslint.config.?(c)js"],
+      "outputs": ["{projectRoot}/.eslint/eslint-report*.json"],
+      "cache": true,
+      "executor": "@nx/linter:eslint",
+      "options": {
+        "errorOnUnmatchedPattern": false,
+        "maxWarnings": 0,
+        "format": "json",
+        "outputFile": "{projectRoot}/.eslint/eslint-report.json",
         "lintFilePatterns": [
           "{projectRoot}/**/*.ts",
           "{projectRoot}/package.json"

--- a/packages/ci/project.json
+++ b/packages/ci/project.json
@@ -6,6 +6,7 @@
   "targets": {
     "build": {},
     "lint": {},
+    "lint-report": {},
     "unit-test": {},
     "int-test": {}
   },

--- a/packages/cli/project.json
+++ b/packages/cli/project.json
@@ -6,6 +6,7 @@
   "targets": {
     "build": {},
     "lint": {},
+    "lint-report": {},
     "unit-test": {},
     "int-test": {},
     "run-help": {

--- a/packages/core/project.json
+++ b/packages/core/project.json
@@ -6,6 +6,7 @@
   "targets": {
     "build": {},
     "lint": {},
+    "lint-report": {},
     "unit-test": {},
     "int-test": {}
   },

--- a/packages/create-cli/project.json
+++ b/packages/create-cli/project.json
@@ -6,6 +6,7 @@
   "targets": {
     "build": {},
     "lint": {},
+    "lint-report": {},
     "unit-test": {},
     "exec-node": {
       "dependsOn": ["build"],

--- a/packages/models/project.json
+++ b/packages/models/project.json
@@ -18,6 +18,7 @@
       ]
     },
     "lint": {},
+    "lint-report": {},
     "unit-test": {}
   },
   "tags": ["scope:shared", "type:util", "publishable"]

--- a/packages/nx-plugin/project.json
+++ b/packages/nx-plugin/project.json
@@ -41,6 +41,15 @@
         ]
       }
     },
+    "lint-report": {
+      "options": {
+        "lintFilePatterns": [
+          "packages/nx-plugin/**/*.ts",
+          "packages/nx-plugin/package.json",
+          "packages/nx-plugin/generators.json"
+        ]
+      }
+    },
     "unit-test": {},
     "int-test": {}
   },

--- a/packages/plugin-coverage/project.json
+++ b/packages/plugin-coverage/project.json
@@ -6,6 +6,7 @@
   "targets": {
     "build": {},
     "lint": {},
+    "lint-report": {},
     "unit-test": {},
     "int-test": {}
   },

--- a/packages/plugin-eslint/project.json
+++ b/packages/plugin-eslint/project.json
@@ -6,6 +6,7 @@
   "targets": {
     "build": {},
     "lint": {},
+    "lint-report": {},
     "unit-test": {},
     "int-test": {}
   },

--- a/packages/plugin-js-packages/project.json
+++ b/packages/plugin-js-packages/project.json
@@ -6,6 +6,7 @@
   "targets": {
     "build": {},
     "lint": {},
+    "lint-report": {},
     "unit-test": {},
     "int-test": {}
   },

--- a/packages/plugin-jsdocs/project.json
+++ b/packages/plugin-jsdocs/project.json
@@ -7,6 +7,7 @@
   "targets": {
     "build": {},
     "lint": {},
+    "lint-report": {},
     "unit-test": {},
     "int-test": {}
   }

--- a/packages/plugin-lighthouse/project.json
+++ b/packages/plugin-lighthouse/project.json
@@ -6,6 +6,7 @@
   "targets": {
     "build": {},
     "lint": {},
+    "lint-report": {},
     "unit-test": {}
   },
   "tags": ["scope:plugin", "type:feature", "publishable"]

--- a/packages/plugin-typescript/project.json
+++ b/packages/plugin-typescript/project.json
@@ -6,6 +6,7 @@
   "targets": {
     "build": {},
     "lint": {},
+    "lint-report": {},
     "unit-test": {},
     "int-test": {}
   },

--- a/packages/utils/project.json
+++ b/packages/utils/project.json
@@ -6,6 +6,7 @@
   "targets": {
     "build": {},
     "lint": {},
+    "lint-report": {},
     "perf": {
       "command": "npx tsx --tsconfig=../tsconfig.perf.json",
       "options": {


### PR DESCRIPTION
This PR includes:
- adjust existing `lint` target in `nx.json#defaultTargtets`
- add `lint-report` target `nx.json#defaultTargtets`
- add empty `lint-report` target to all projects

Related:
- #1068 