### PR TITLE
ci: invalidate nx cloud cache for different operating system

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -97,7 +97,11 @@
       "!{projectRoot}/code-pushup.config.?(m)[jt]s",
       "!{projectRoot}/zod2md.config.ts"
     ],
-    "sharedGlobals": []
+    "sharedGlobals": [
+      { "runtime": "node -e \"console.log(require('os').platform())\"" },
+      { "runtime": "node -v" },
+      { "runtime": "npm -v" }
+    ]
   },
   "workspaceLayout": {
     "appsDir": "examples",


### PR DESCRIPTION
We run CI jobs on different operating systems to ensure platform compatibility. Now that Nx Cloud is in play, though, we need to make sure cache isn't reused between them - the same source code may pass on Linux and fail on Windows, for example.

I've set the `os.platform()` value (along with `node -v`) as a shared global, so that Nx uses this info in its cache keys. I've tested the command on both Linux and Windows to make sure it works everywhere (not easy to figure out, different shells, quote handling etc. :sweat_smile:), came up with `node -e "console.log(require('os').platform())"`.