### PR TITLE
test(ci-e2e): fix nx pr test from timing out on windows

### DIFF
--- a/e2e/ci-e2e/tests/nx-monorepo.e2e.test.ts
+++ b/e2e/ci-e2e/tests/nx-monorepo.e2e.test.ts
@@ -215,6 +215,6 @@ describe('CI - monorepo mode (Nx)', () => {
       ).toMatchFileSnapshot(
         path.join(TEST_SNAPSHOTS_DIR, 'nx-monorepo-report-diff.md'),
       );
-    });
+    }, 120_000);
   });
 });


### PR DESCRIPTION
We have a flaky test that keeps timing out on Windows, e.g. [here](https://cloud.nx.app/runs/IFBBWixS8i/task/ci-e2e%3Ae2e), [here](https://cloud.nx.app/runs/GVYxUxqCzn), [here](https://cloud.nx.app/runs/KKqqhuAlrc). Hopefully, doubling the timeout should help :crossed_fingers: 