### PR TITLE
ci: fix codecov workflow - projects and targets inferred from nx graph

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -9,21 +9,8 @@ env:
   NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
 
 jobs:
-  coverage:
-    strategy:
-      fail-fast: false
-      matrix:
-        lib:
-          - cli
-          - core
-          - models
-          - utils
-          - plugin-eslint
-          - plugin-coverage
-          - plugin-js-packages
-          - plugin-lighthouse
-        scope: [unit, int]
-    name: Update code coverage
+  list-packages:
+    name: List packages
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository
@@ -35,13 +22,38 @@ jobs:
           cache: npm
       - name: Install dependencies
         run: npm ci
-      - name: Execute all tests and generate coverage reports
-        run: npx nx run ${{ matrix.lib }}:${{ matrix.scope }}-test --coverage.enabled
+      - name: List packages using Nx CLI
+        id: list-packages
+        run: |
+          matrix=$(node tools/scripts/create-codecov-matrix.js)
+          echo "matrix=$matrix" >> $GITHUB_OUTPUT
+    outputs:
+      matrix: ${{ steps.list-packages.outputs.matrix }}
+
+  coverage:
+    needs: [list-packages]
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.list-packages.outputs.matrix) }}
+    name: Collect code coverage
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Execute tests with coverage
+        run: npx nx run ${{ matrix.project }}:${{ matrix.target }} --coverage.enabled
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4
         with:
-          directory: coverage/${{ matrix.lib }}/${{ matrix.scope }}-tests/
+          directory: coverage/${{ matrix.project }}/${{ matrix.target }}s/
           files: ./lcov.info
-          flags: ${{ matrix.lib }}-${{ matrix.scope }}
+          flags: ${{ matrix.project }}-${{ matrix.target }}
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true

--- a/tools/scripts/create-codecov-matrix.js
+++ b/tools/scripts/create-codecov-matrix.js
@@ -1,0 +1,25 @@
+// @ts-check
+import { createProjectGraphAsync } from '@nx/devkit';
+
+const graph = await createProjectGraphAsync({
+  exitOnError: true,
+  resetDaemonClient: true,
+});
+
+const projects = Object.values(graph.nodes)
+  .filter(project => project.data.root === `packages/${project.name}`)
+  .sort((a, b) => a.name.localeCompare(b.name));
+const targets = ['unit-test', 'int-test'];
+const excludes = targets.flatMap(target =>
+  projects
+    .filter(project => project.data.targets?.[target] == null)
+    .map(project => ({ project: project.name, target })),
+);
+
+const matrix = {
+  project: projects.map(project => project.name),
+  target: targets,
+  exclude: excludes,
+};
+
+console.info(JSON.stringify(matrix));


### PR DESCRIPTION
Fixes a couple of problems with Codecov job:
- since #1061 was merged, some jobs have been [failing in `main`](https://github.com/code-pushup/cli/actions/workflows/code-coverage.yml?query=branch%3Amain) because `int-test` target was removed from a few projects
- the list of projects was out-of-date, missing newer packages (`nx-plugin`, `create-cli`, `plugin-jsdocs`, `plugin-typescript`)

To make the workflow more robust and require less maintenance, I've added a script which generates the GitHub Actions [`matrix` strategy](https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/run-job-variations) from our Nx graph. Currently, that's:

```yml
project:
- ci
- cli
- core
- create-cli
- models
- nx-plugin
- plugin-coverage
- plugin-eslint
- plugin-js-packages
- plugin-jsdocs
- plugin-lighthouse
- plugin-typescript
- utils
target:
- unit-test
- int-test
exclude:
- project: create-cli
  target: int-test
- project: models
  target: int-test
- project: plugin-lighthouse
  target: int-test
```

I've tested the workflow via temporary trigger [here](https://github.com/code-pushup/cli/actions/runs/17270634755/job/49014223373).
