### PR TITLE
refactor: remove target generator in favour of task inference

### DIFF
--- a/e2e/nx-plugin-e2e/tests/__snapshots__/plugin-create-nodes.e2e.test.ts.snap
+++ b/e2e/nx-plugin-e2e/tests/__snapshots__/plugin-create-nodes.e2e.test.ts.snap
@@ -17,7 +17,7 @@ exports[`nx-plugin > should add configuration target dynamically 1`] = `
     "configurations": {},
     "executor": "nx:run-commands",
     "options": {
-      "command": "nx g @code-pushup/nx-plugin:configuration --skipTarget --targetName="code-pushup" --project="my-lib"",
+      "command": "nx g @code-pushup/nx-plugin:configuration --project="my-lib"",
     },
     "parallelism": true,
   },

--- a/e2e/nx-plugin-e2e/tests/generator-configuration.e2e.test.ts
+++ b/e2e/nx-plugin-e2e/tests/generator-configuration.e2e.test.ts
@@ -35,7 +35,7 @@ describe('nx-plugin g configuration', () => {
     await teardownTestFolder(testFileDir);
   });
 
-  it('should generate code-pushup.config.ts file and add target to project.json', async () => {
+  it('should generate code-pushup.config.ts file', async () => {
     const cwd = path.join(testFileDir, 'configure');
     await materializeTree(tree, cwd);
 
@@ -64,22 +64,7 @@ describe('nx-plugin g configuration', () => {
       'NX  Generating @code-pushup/nx-plugin:configuration',
     );
     expect(cleanedStdout).toMatch(/^CREATE.*code-pushup.config.ts/m);
-    expect(cleanedStdout).toMatch(/^UPDATE.*project.json/m);
 
-    const projectJson = await readFile(
-      path.join(cwd, 'libs', project, 'project.json'),
-      'utf8',
-    );
-
-    expect(JSON.parse(projectJson)).toStrictEqual(
-      expect.objectContaining({
-        targets: expect.objectContaining({
-          'code-pushup': {
-            executor: '@code-pushup/nx-plugin:cli',
-          },
-        }),
-      }),
-    );
     await expect(
       readFile(
         path.join(cwd, 'libs', project, 'code-pushup.config.ts'),

--- a/e2e/nx-plugin-e2e/tests/generator-configuration.e2e.test.ts
+++ b/e2e/nx-plugin-e2e/tests/generator-configuration.e2e.test.ts
@@ -96,21 +96,6 @@ describe('nx-plugin g configuration', () => {
       'NX  Generating @code-pushup/nx-plugin:configuration',
     );
     expect(cleanedStdout).not.toMatch(/^CREATE.*code-pushup.config.ts/m);
-    expect(cleanedStdout).toMatch(/^UPDATE.*project.json/m);
-
-    const projectJson = await readFile(
-      path.join(cwd, 'libs', project, 'project.json'),
-      'utf8',
-    );
-    expect(JSON.parse(projectJson)).toStrictEqual(
-      expect.objectContaining({
-        targets: expect.objectContaining({
-          'code-pushup': {
-            executor: '@code-pushup/nx-plugin:cli',
-          },
-        }),
-      }),
-    );
   });
 
   it('should NOT create a code-pushup.config.ts file if skipConfig is given', async () => {
@@ -137,21 +122,6 @@ describe('nx-plugin g configuration', () => {
       'NX  Generating @code-pushup/nx-plugin:configuration',
     );
     expect(cleanedStdout).not.toMatch(/^CREATE.*code-pushup.config.ts/m);
-    expect(cleanedStdout).toMatch(/^UPDATE.*project.json/m);
-
-    const projectJson = await readFile(
-      path.join(cwd, 'libs', project, 'project.json'),
-      'utf8',
-    );
-    expect(JSON.parse(projectJson)).toStrictEqual(
-      expect.objectContaining({
-        targets: expect.objectContaining({
-          'code-pushup': {
-            executor: '@code-pushup/nx-plugin:cli',
-          },
-        }),
-      }),
-    );
 
     await expect(
       readFile(
@@ -159,53 +129,6 @@ describe('nx-plugin g configuration', () => {
         'utf8',
       ),
     ).rejects.toThrow('no such file or directory');
-  });
-
-  it('should NOT add target to project.json if skipTarget is given', async () => {
-    const cwd = path.join(testFileDir, 'configure-skip-target');
-    await materializeTree(tree, cwd);
-
-    const { code, stdout } = await executeProcess({
-      command: 'npx',
-      args: [
-        'nx',
-        'g',
-        '@code-pushup/nx-plugin:configuration',
-        project,
-        '--skipTarget',
-      ],
-      cwd,
-    });
-    expect(code).toBe(0);
-
-    const cleanedStdout = removeColorCodes(stdout);
-
-    expect(cleanedStdout).toContain(
-      'NX  Generating @code-pushup/nx-plugin:configuration',
-    );
-    expect(cleanedStdout).toMatch(/^CREATE.*code-pushup.config.ts/m);
-    expect(cleanedStdout).not.toMatch(/^UPDATE.*project.json/m);
-
-    const projectJson = await readFile(
-      path.join(cwd, 'libs', project, 'project.json'),
-      'utf8',
-    );
-    expect(JSON.parse(projectJson)).toStrictEqual(
-      expect.objectContaining({
-        targets: expect.not.objectContaining({
-          'code-pushup': {
-            executor: '@code-pushup/nx-plugin:cli',
-          },
-        }),
-      }),
-    );
-
-    await expect(
-      readFile(
-        path.join(cwd, 'libs', project, 'code-pushup.config.ts'),
-        'utf8',
-      ),
-    ).resolves.toStrictEqual(expect.any(String));
   });
 
   it('should inform about dry run', async () => {

--- a/e2e/nx-plugin-e2e/tests/plugin-create-nodes.e2e.test.ts
+++ b/e2e/nx-plugin-e2e/tests/plugin-create-nodes.e2e.test.ts
@@ -51,7 +51,7 @@ describe('nx-plugin', () => {
         configurations: {},
         executor: 'nx:run-commands',
         options: {
-          command: `nx g @code-pushup/nx-plugin:configuration --skipTarget --targetName="code-pushup" --project="${project}"`,
+          command: `nx g @code-pushup/nx-plugin:configuration --project="${project}"`,
         },
         parallelism: true,
       },
@@ -120,7 +120,7 @@ describe('nx-plugin', () => {
     expect(projectJson.targets).toStrictEqual({
       'code-pushup--configuration': expect.objectContaining({
         options: {
-          command: `nx g XYZ:configuration --skipTarget --targetName="code-pushup" --project="${project}"`,
+          command: `nx g XYZ:configuration --project="${project}"`,
         },
       }),
     });

--- a/packages/nx-plugin/src/generators/configuration/generator.int.test.ts
+++ b/packages/nx-plugin/src/generators/configuration/generator.int.test.ts
@@ -8,73 +8,7 @@ import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import * as path from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { DEFAULT_TARGET_NAME, PACKAGE_NAME } from '../../internal/constants.js';
-import { addTargetToProject, configurationGenerator } from './generator.js';
-
-describe('addTargetToProject', () => {
-  let tree: Tree;
-  const testProjectName = 'test-app';
-
-  beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace();
-    addProjectConfiguration(tree, 'test-app', {
-      root: 'test-app',
-    });
-  });
-
-  afterEach(() => {
-    //reset tree
-    tree.delete(testProjectName);
-  });
-
-  it('should generate a project target', () => {
-    addTargetToProject(
-      tree,
-      {
-        root: testProjectName,
-        projectType: 'library',
-        sourceRoot: `${testProjectName}/src`,
-        targets: {},
-      },
-      {
-        project: testProjectName,
-      },
-    );
-
-    const projectConfiguration = readProjectConfiguration(
-      tree,
-      testProjectName,
-    );
-
-    expect(projectConfiguration.targets?.[DEFAULT_TARGET_NAME]).toEqual({
-      executor: `${PACKAGE_NAME}:cli`,
-    });
-  });
-
-  it('should use targetName to generate a project target', () => {
-    addTargetToProject(
-      tree,
-      {
-        root: testProjectName,
-        projectType: 'library',
-        sourceRoot: `${testProjectName}/src`,
-        targets: {},
-      },
-      {
-        project: testProjectName,
-        targetName: 'cp',
-      },
-    );
-
-    const projectConfiguration = readProjectConfiguration(
-      tree,
-      testProjectName,
-    );
-
-    expect(projectConfiguration.targets?.['cp']).toEqual({
-      executor: `${PACKAGE_NAME}:cli`,
-    });
-  });
-});
+import { configurationGenerator } from './generator.js';
 
 describe('configurationGenerator', () => {
   let tree: Tree;

--- a/packages/nx-plugin/src/generators/configuration/generator.int.test.ts
+++ b/packages/nx-plugin/src/generators/configuration/generator.int.test.ts
@@ -26,21 +26,6 @@ describe('configurationGenerator', () => {
     tree.delete(testProjectName);
   });
 
-  it('should generate a project target and config file', async () => {
-    await configurationGenerator(tree, {
-      project: testProjectName,
-    });
-
-    const projectConfiguration = readProjectConfiguration(
-      tree,
-      testProjectName,
-    );
-
-    expect(projectConfiguration.targets?.[DEFAULT_TARGET_NAME]).toEqual({
-      executor: `${PACKAGE_NAME}:cli`,
-    });
-  });
-
   it('should skip config creation if skipConfig is used', async () => {
     await configurationGenerator(tree, {
       project: testProjectName,
@@ -53,20 +38,6 @@ describe('configurationGenerator', () => {
       tree.read(path.join('libs', testProjectName, 'code-pushup.config.ts')),
     ).toBeNull();
     expect(loggerInfoSpy).toHaveBeenCalledWith('Skip config file creation');
-  });
-
-  it('should skip target creation if skipTarget is used', async () => {
-    await configurationGenerator(tree, {
-      project: testProjectName,
-      skipTarget: true,
-    });
-
-    const projectConfiguration = readProjectConfiguration(
-      tree,
-      testProjectName,
-    );
-    expect(projectConfiguration.targets).toBeUndefined();
-    expect(loggerInfoSpy).toHaveBeenCalledWith('Skip adding target to project');
   });
 
   it('should skip formatting', async () => {

--- a/packages/nx-plugin/src/generators/configuration/generator.ts
+++ b/packages/nx-plugin/src/generators/configuration/generator.ts
@@ -3,10 +3,7 @@ import {
   formatFiles,
   logger,
   readProjectConfiguration,
-  updateProjectConfiguration,
 } from '@nx/devkit';
-import type { ProjectConfiguration } from 'nx/src/config/workspace-json-project-json';
-import { DEFAULT_TARGET_NAME, PACKAGE_NAME } from '../../internal/constants.js';
 import { generateCodePushupConfig } from './code-pushup-config.js';
 import type { ConfigurationGeneratorOptions } from './schema.js';
 
@@ -16,7 +13,7 @@ export async function configurationGenerator(
 ) {
   const projectConfiguration = readProjectConfiguration(tree, options.project);
 
-  const { skipConfig, skipTarget, skipFormat } = options;
+  const { skipConfig, skipFormat } = options;
 
   if (skipConfig === true) {
     logger.info('Skip config file creation');
@@ -24,38 +21,11 @@ export async function configurationGenerator(
     generateCodePushupConfig(tree, projectConfiguration.root);
   }
 
-  if (skipTarget === true) {
-    logger.info('Skip adding target to project');
-  } else {
-    addTargetToProject(tree, projectConfiguration, options);
-  }
-
   if (skipFormat === true) {
     logger.info('Skip formatting files');
   } else {
     await formatFiles(tree);
   }
-}
-
-export function addTargetToProject(
-  tree: Tree,
-  projectConfiguration: ProjectConfiguration,
-  options: ConfigurationGeneratorOptions,
-) {
-  const { targets } = projectConfiguration;
-  const { targetName, project } = options;
-
-  const codePushupTargetConfig = {
-    executor: `${PACKAGE_NAME}:cli`,
-  };
-
-  updateProjectConfiguration(tree, project, {
-    ...projectConfiguration,
-    targets: {
-      ...targets,
-      [targetName ?? DEFAULT_TARGET_NAME]: codePushupTargetConfig,
-    },
-  });
 }
 
 export default configurationGenerator;

--- a/packages/nx-plugin/src/generators/configuration/schema.json
+++ b/packages/nx-plugin/src/generators/configuration/schema.json
@@ -15,20 +15,9 @@
         "index": 0
       }
     },
-    "targetName": {
-      "type": "string",
-      "description": "The name of the target.",
-      "x-prompt": "Which name should the target get? default is code-pushup.",
-      "default": "code-pushup"
-    },
     "bin": {
       "type": "string",
       "description": "Path to Code PushUp CLI"
-    },
-    "skipTarget": {
-      "type": "boolean",
-      "description": "Skip adding the target to project.json.",
-      "$default": "false"
     },
     "skipConfig": {
       "type": "boolean",

--- a/packages/nx-plugin/src/plugin/plugin.unit.test.ts
+++ b/packages/nx-plugin/src/plugin/plugin.unit.test.ts
@@ -40,7 +40,7 @@ describe('@code-pushup/nx-plugin/plugin', () => {
       [projectRoot]: {
         targets: {
           [`${CP_TARGET_NAME}--configuration`]: {
-            command: `nx g ${PACKAGE_NAME}:configuration --skipTarget --targetName="code-pushup" --project="@org/empty-root"`,
+            command: `nx g ${PACKAGE_NAME}:configuration --skipTarget --project="@org/empty-root"`,
           },
         },
       },
@@ -66,7 +66,7 @@ describe('@code-pushup/nx-plugin/plugin', () => {
       [projectRoot]: {
         targets: {
           [`${CP_TARGET_NAME}--configuration`]: {
-            command: `nx g ${PACKAGE_NAME}:configuration --skipTarget --targetName="code-pushup" --project="@org/empty-root"`,
+            command: `nx g ${PACKAGE_NAME}:configuration --skipTarget --project="@org/empty-root"`,
           },
         },
       },

--- a/packages/nx-plugin/src/plugin/plugin.unit.test.ts
+++ b/packages/nx-plugin/src/plugin/plugin.unit.test.ts
@@ -40,7 +40,7 @@ describe('@code-pushup/nx-plugin/plugin', () => {
       [projectRoot]: {
         targets: {
           [`${CP_TARGET_NAME}--configuration`]: {
-            command: `nx g ${PACKAGE_NAME}:configuration --skipTarget --project="@org/empty-root"`,
+            command: `nx g ${PACKAGE_NAME}:configuration --project="@org/empty-root"`,
           },
         },
       },
@@ -66,7 +66,7 @@ describe('@code-pushup/nx-plugin/plugin', () => {
       [projectRoot]: {
         targets: {
           [`${CP_TARGET_NAME}--configuration`]: {
-            command: `nx g ${PACKAGE_NAME}:configuration --skipTarget --project="@org/empty-root"`,
+            command: `nx g ${PACKAGE_NAME}:configuration --project="@org/empty-root"`,
           },
         },
       },

--- a/packages/nx-plugin/src/plugin/target/configuration-target.ts
+++ b/packages/nx-plugin/src/plugin/target/configuration-target.ts
@@ -2,22 +2,15 @@ import type { TargetConfiguration } from '@nx/devkit';
 import type { RunCommandsOptions } from 'nx/src/executors/run-commands/run-commands.impl';
 import { objectToCliArgs } from '../../executors/internal/cli.js';
 import { PACKAGE_NAME } from '../../internal/constants.js';
-import { CP_TARGET_NAME } from '../constants.js';
 
 export function createConfigurationTarget(options?: {
-  targetName?: string;
   projectName?: string;
   bin?: string;
 }): TargetConfiguration<RunCommandsOptions> {
-  const {
-    projectName,
-    bin = PACKAGE_NAME,
-    targetName = CP_TARGET_NAME,
-  } = options ?? {};
+  const { projectName, bin = PACKAGE_NAME } = options ?? {};
   return {
     command: `nx g ${bin}:configuration ${objectToCliArgs({
       skipTarget: true,
-      targetName,
       ...(projectName ? { project: projectName } : {}),
     }).join(' ')}`,
   };

--- a/packages/nx-plugin/src/plugin/target/configuration-target.ts
+++ b/packages/nx-plugin/src/plugin/target/configuration-target.ts
@@ -8,10 +8,10 @@ export function createConfigurationTarget(options?: {
   bin?: string;
 }): TargetConfiguration<RunCommandsOptions> {
   const { projectName, bin = PACKAGE_NAME } = options ?? {};
+  const args = objectToCliArgs({
+    ...(projectName ? { project: projectName } : {}),
+  });
   return {
-    command: `nx g ${bin}:configuration ${objectToCliArgs({
-      skipTarget: true,
-      ...(projectName ? { project: projectName } : {}),
-    }).join(' ')}`,
+    command: `nx g ${bin}:configuration${args.length > 0 ? ` ${args.join(' ')}` : ''}`,
   };
 }

--- a/packages/nx-plugin/src/plugin/target/configuration.target.unit.test.ts
+++ b/packages/nx-plugin/src/plugin/target/configuration.target.unit.test.ts
@@ -7,13 +7,13 @@ describe('createConfigurationTarget', () => {
     expect(
       createConfigurationTarget({ projectName: 'my-project' }),
     ).toStrictEqual({
-      command: `nx g ${PACKAGE_NAME}:configuration --skipTarget --targetName="code-pushup" --project="my-project"`,
+      command: `nx g ${PACKAGE_NAME}:configuration --project="my-project"`,
     });
   });
 
   it('should return code-pushup--configuration target without project name', () => {
     expect(createConfigurationTarget()).toStrictEqual({
-      command: `nx g ${PACKAGE_NAME}:configuration --skipTarget --targetName="code-pushup"`,
+      command: `nx g ${PACKAGE_NAME}:configuration`,
     });
   });
 });

--- a/packages/nx-plugin/src/plugin/target/targets.ts
+++ b/packages/nx-plugin/src/plugin/target/targets.ts
@@ -28,7 +28,6 @@ export async function createTargets(normalizedContext: CreateTargetsOptions) {
     : // if NO code-pushup.config.*.(ts|js|mjs) is present return configuration target
       {
         [`${targetName}--configuration`]: createConfigurationTarget({
-          targetName,
           projectName: normalizedContext.projectJson.name,
           bin,
         }),

--- a/packages/nx-plugin/src/plugin/target/targets.unit.test.ts
+++ b/packages/nx-plugin/src/plugin/target/targets.unit.test.ts
@@ -35,7 +35,7 @@ describe('createTargets', () => {
       } as NormalizedCreateNodesContext),
     ).resolves.toStrictEqual({
       [`${CP_TARGET_NAME}--configuration`]: {
-        command: `nx g ${PACKAGE_NAME}:configuration --skipTarget --targetName="code-pushup" --project="${projectName}"`,
+        command: `nx g ${PACKAGE_NAME}:configuration --project="${projectName}"`,
       },
     });
   });
@@ -55,7 +55,7 @@ describe('createTargets', () => {
       } as NormalizedCreateNodesContext),
     ).resolves.toStrictEqual({
       [`${targetName}--configuration`]: {
-        command: `nx g ${PACKAGE_NAME}:configuration --skipTarget --targetName="cp" --project="${projectName}"`,
+        command: `nx g ${PACKAGE_NAME}:configuration --project="${projectName}"`,
       },
     });
   });


### PR DESCRIPTION
This PR:
- removes the generator to add a target to a project. from V19 on this is done over plugins