### PR TITLE
ci: add dependency-review action

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,19 @@
+name: Dependency Review
+
+on: pull_request
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    name: Scan new dependencies
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+      - name: Check for vulnerabilities in new dependencies
+        uses: actions/dependency-review-action@v4
+        with:
+          comment-summary-in-pr: on-failure


### PR DESCRIPTION
## Motivation

In light of recent [supply chain attack](https://www.aikido.dev/blog/s1ngularity-nx-attackers-strike-again), we decided to enhance our security tooling.

## Changes in this PR

- Added [`dependency-review-action`](https://github.com/actions/dependency-review-action) to check for vulnerabilities for changed dependencies on each PR.

## Other related changes

- All public repos in the [`code-pushup` organization](https://github.com/organizations/code-pushup/settings/security_products) have the [GitHub-recommended security configuration](https://docs.github.com/en/code-security/securing-your-organization/introduction-to-securing-your-organization-at-scale/about-enabling-security-features-at-scale#about-security-configurations). This includes Dependabot alerts and CodeQL scanning.
- [Dependabot alerts](https://docs.github.com/en/code-security/dependabot/dependabot-alerts/about-dependabot-alerts) have been enabled for private repos.

