### PR TITLE
ci: fix automated releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,76 +1,34 @@
-name: Release Packages
+name: Release
 
 on:
-  pull_request:
-    branches:
-      - main
   push:
-    branches:
-      - main
-  workflow_dispatch:
-    inputs:
-      dryRun:
-        type: choice
-        description: 'Dry run'
-        required: true
-        default: 'false'
-        options:
-          - 'true'
-          - 'false'
+    # TODO
+    # branches:
+    #   - main
+
+permissions:
+  contents: write
+  id-token: write
 
 env:
+  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   NX_NON_NATIVE_HASHER: true
   NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
 
 jobs:
-  dry-run-release:
-    if: |
-      github.repository == 'code-pushup/cli' && (
-        github.event_name == 'pull_request' ||
-        (github.event_name == 'workflow_dispatch' && github.event.inputs.dryRun == 'true')
-      )
-    name: Dry run release
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout the repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: .node-version
-          cache: npm
-      - name: Install dependencies
-        run: npm ci
-      - name: Version, release and publish packages
-        run: npx nx release --yes --dry-run
   release:
-    if: |
-      github.repository == 'code-pushup/cli' && (
-        (github.event_name == 'workflow_dispatch' && github.event.inputs.dryRun == 'false') ||
-        (github.event_name == 'push')
-      )
-    name: Release packages
+    name: Publish packages
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
-      - name: Generate a token
-        id: generate_token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ secrets.GH_APP_ID }}
-          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-      - name: Checkout the repository
+      - name: Clone the repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ steps.generate_token.outputs.token }}
-      - name: Set up Git
+      - name: Configure Git user
+        # https://github.com/actions/checkout/blob/main/README.md#push-a-commit-using-the-built-in-token
         run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
@@ -79,19 +37,6 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Version, release and publish packages
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
-        run: |
-          echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" >> .npmrc
-          npx nx release --yes
-          git push --follow-tags
-      - name: Run Code PushUp on release commit
-        uses: code-pushup/github-action@v0
-        with:
-          bin: npx nx code-pushup --
-        env:
-          CP_SERVER: ${{ secrets.CP_SERVER }}
-          CP_API_KEY: ${{ secrets.CP_API_KEY }}
-          CP_ORGANIZATION: code-pushup
-          CP_PROJECT: cli
+        # TODO
+        # run: npx nx release --yes
+        run: npx nx release --yes 0.79.2-alpha.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,9 +2,8 @@ name: Release
 
 on:
   push:
-    # TODO
-    # branches:
-    #   - main
+    branches:
+      - main
 
 permissions:
   contents: write
@@ -37,6 +36,4 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Version, release and publish packages
-        # TODO
-        # run: npx nx release --yes
-        run: npx nx release --yes 0.79.2-alpha.1
+        run: npx nx release --yes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: release
+  cancel-in-progress: false
+
 permissions:
   contents: write
   id-token: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,9 +2,8 @@ name: Release
 
 on:
   push:
-    # TODO: revert
-    # branches:
-    #   - main
+    branches:
+      - main
 
 concurrency:
   group: release
@@ -41,6 +40,4 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Version, release and publish packages
-        # TODO: revert
-        run: npx nx release --yes 0.79.2
-        # run: npx nx release --yes
+        run: npx nx release --yes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,9 @@ name: Release
 
 on:
   push:
-    branches:
-      - main
+    # TODO: revert
+    # branches:
+    #   - main
 
 concurrency:
   group: release
@@ -40,4 +41,6 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Version, release and publish packages
-        run: npx nx release --yes
+        # TODO: revert
+        run: npx nx release --yes 0.79.2
+        # run: npx nx release --yes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.79.2 (2025-09-23)
+
+This was a version bump only, there were no code changes.
+
 ## 0.79.2-alpha.1 (2025-09-23)
 
 ### 🚀 Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.79.2-alpha.1 (2025-09-23)
+
+### 🚀 Features
+
+- add local GitHub Action for testing CI changes ([#1104](https://github.com/code-pushup/cli/pull/1104), [#1093](https://github.com/code-pushup/cli/issues/1093))
+
+### ❤️ Thank You
+
+- Hanna Skryl @hanna-skryl
+
 ## 0.79.1 (2025-09-04)
 
 ### 🩹 Fixes

--- a/packages/ci/package.json
+++ b/packages/ci/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@code-pushup/ci",
-  "version": "0.79.1",
+  "version": "0.79.2-alpha.1",
   "description": "CI automation logic for Code PushUp (provider-agnostic)",
   "license": "MIT",
   "homepage": "https://github.com/code-pushup/cli/tree/main/packages/ci#readme",
@@ -26,9 +26,9 @@
   },
   "type": "module",
   "dependencies": {
-    "@code-pushup/models": "0.79.1",
+    "@code-pushup/models": "0.79.2-alpha.1",
     "@code-pushup/portal-client": "^0.16.0",
-    "@code-pushup/utils": "0.79.1",
+    "@code-pushup/utils": "0.79.2-alpha.1",
     "glob": "^11.0.1",
     "simple-git": "^3.20.0",
     "yaml": "^2.5.1",

--- a/packages/ci/package.json
+++ b/packages/ci/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@code-pushup/ci",
-  "version": "0.79.2-alpha.1",
+  "version": "0.79.2",
   "description": "CI automation logic for Code PushUp (provider-agnostic)",
   "license": "MIT",
   "homepage": "https://github.com/code-pushup/cli/tree/main/packages/ci#readme",
@@ -26,9 +26,9 @@
   },
   "type": "module",
   "dependencies": {
-    "@code-pushup/models": "0.79.2-alpha.1",
+    "@code-pushup/models": "0.79.2",
     "@code-pushup/portal-client": "^0.16.0",
-    "@code-pushup/utils": "0.79.2-alpha.1",
+    "@code-pushup/utils": "0.79.2",
     "glob": "^11.0.1",
     "simple-git": "^3.20.0",
     "yaml": "^2.5.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@code-pushup/cli",
-  "version": "0.79.1",
+  "version": "0.79.2-alpha.1",
   "license": "MIT",
   "description": "A CLI to run all kinds of code quality measurements to align your team with company goals",
   "homepage": "https://code-pushup.dev",
@@ -45,9 +45,9 @@
     "node": ">=20"
   },
   "dependencies": {
-    "@code-pushup/models": "0.79.1",
-    "@code-pushup/core": "0.79.1",
-    "@code-pushup/utils": "0.79.1",
+    "@code-pushup/models": "0.79.2-alpha.1",
+    "@code-pushup/core": "0.79.2-alpha.1",
+    "@code-pushup/utils": "0.79.2-alpha.1",
     "yargs": "^17.7.2",
     "ansis": "^3.3.0",
     "simple-git": "^3.20.0"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@code-pushup/cli",
-  "version": "0.79.2-alpha.1",
+  "version": "0.79.2",
   "license": "MIT",
   "description": "A CLI to run all kinds of code quality measurements to align your team with company goals",
   "homepage": "https://code-pushup.dev",
@@ -45,9 +45,9 @@
     "node": ">=20"
   },
   "dependencies": {
-    "@code-pushup/models": "0.79.2-alpha.1",
-    "@code-pushup/core": "0.79.2-alpha.1",
-    "@code-pushup/utils": "0.79.2-alpha.1",
+    "@code-pushup/models": "0.79.2",
+    "@code-pushup/core": "0.79.2",
+    "@code-pushup/utils": "0.79.2",
     "yargs": "^17.7.2",
     "ansis": "^3.3.0",
     "simple-git": "^3.20.0"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@code-pushup/core",
-  "version": "0.79.2-alpha.1",
+  "version": "0.79.2",
   "license": "MIT",
   "description": "Core business logic for the used by the Code PushUp CLI",
   "homepage": "https://github.com/code-pushup/cli/tree/main/packages/core#readme",
@@ -39,8 +39,8 @@
   },
   "type": "module",
   "dependencies": {
-    "@code-pushup/models": "0.79.2-alpha.1",
-    "@code-pushup/utils": "0.79.2-alpha.1",
+    "@code-pushup/models": "0.79.2",
+    "@code-pushup/utils": "0.79.2",
     "ansis": "^3.3.0"
   },
   "peerDependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@code-pushup/core",
-  "version": "0.79.1",
+  "version": "0.79.2-alpha.1",
   "license": "MIT",
   "description": "Core business logic for the used by the Code PushUp CLI",
   "homepage": "https://github.com/code-pushup/cli/tree/main/packages/core#readme",
@@ -39,8 +39,8 @@
   },
   "type": "module",
   "dependencies": {
-    "@code-pushup/models": "0.79.1",
-    "@code-pushup/utils": "0.79.1",
+    "@code-pushup/models": "0.79.2-alpha.1",
+    "@code-pushup/utils": "0.79.2-alpha.1",
     "ansis": "^3.3.0"
   },
   "peerDependencies": {

--- a/packages/create-cli/package.json
+++ b/packages/create-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@code-pushup/create-cli",
-  "version": "0.79.1",
+  "version": "0.79.2-alpha.1",
   "license": "MIT",
   "bin": "index.js",
   "homepage": "https://github.com/code-pushup/cli/tree/main/packages/create-cli#readme",
@@ -26,8 +26,8 @@
   },
   "type": "module",
   "dependencies": {
-    "@code-pushup/nx-plugin": "0.79.1",
-    "@code-pushup/utils": "0.79.1"
+    "@code-pushup/nx-plugin": "0.79.2-alpha.1",
+    "@code-pushup/utils": "0.79.2-alpha.1"
   },
   "files": [
     "src",

--- a/packages/create-cli/package.json
+++ b/packages/create-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@code-pushup/create-cli",
-  "version": "0.79.2-alpha.1",
+  "version": "0.79.2",
   "license": "MIT",
   "bin": "index.js",
   "homepage": "https://github.com/code-pushup/cli/tree/main/packages/create-cli#readme",
@@ -26,8 +26,8 @@
   },
   "type": "module",
   "dependencies": {
-    "@code-pushup/nx-plugin": "0.79.2-alpha.1",
-    "@code-pushup/utils": "0.79.2-alpha.1"
+    "@code-pushup/nx-plugin": "0.79.2",
+    "@code-pushup/utils": "0.79.2"
   },
   "files": [
     "src",

--- a/packages/models/package.json
+++ b/packages/models/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@code-pushup/models",
-  "version": "0.79.2-alpha.1",
+  "version": "0.79.2",
   "license": "MIT",
   "description": "Model definitions and validators for the Code PushUp CLI",
   "homepage": "https://github.com/code-pushup/cli/tree/main/packages/models#readme",

--- a/packages/models/package.json
+++ b/packages/models/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@code-pushup/models",
-  "version": "0.79.1",
+  "version": "0.79.2-alpha.1",
   "license": "MIT",
   "description": "Model definitions and validators for the Code PushUp CLI",
   "homepage": "https://github.com/code-pushup/cli/tree/main/packages/models#readme",

--- a/packages/nx-plugin/package.json
+++ b/packages/nx-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@code-pushup/nx-plugin",
-  "version": "0.79.1",
+  "version": "0.79.2-alpha.1",
   "license": "MIT",
   "description": "Nx plugin to integrate the Code PushUp CLI into your workspace 🛠️",
   "publishConfig": {
@@ -32,8 +32,8 @@
   "generators": "./generators.json",
   "executors": "./executors.json",
   "dependencies": {
-    "@code-pushup/models": "0.79.1",
-    "@code-pushup/utils": "0.79.1",
+    "@code-pushup/models": "0.79.2-alpha.1",
+    "@code-pushup/utils": "0.79.2-alpha.1",
     "@nx/devkit": ">=17.0.0",
     "ansis": "^3.3.0",
     "nx": ">=17.0.0",

--- a/packages/nx-plugin/package.json
+++ b/packages/nx-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@code-pushup/nx-plugin",
-  "version": "0.79.2-alpha.1",
+  "version": "0.79.2",
   "license": "MIT",
   "description": "Nx plugin to integrate the Code PushUp CLI into your workspace 🛠️",
   "publishConfig": {
@@ -32,8 +32,8 @@
   "generators": "./generators.json",
   "executors": "./executors.json",
   "dependencies": {
-    "@code-pushup/models": "0.79.2-alpha.1",
-    "@code-pushup/utils": "0.79.2-alpha.1",
+    "@code-pushup/models": "0.79.2",
+    "@code-pushup/utils": "0.79.2",
     "@nx/devkit": ">=17.0.0",
     "ansis": "^3.3.0",
     "nx": ">=17.0.0",

--- a/packages/plugin-coverage/package.json
+++ b/packages/plugin-coverage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@code-pushup/coverage-plugin",
-  "version": "0.79.2-alpha.1",
+  "version": "0.79.2",
   "description": "Code PushUp plugin for tracking code coverage ☂",
   "license": "MIT",
   "homepage": "https://github.com/code-pushup/cli/tree/main/packages/plugin-coverage#readme",
@@ -34,8 +34,8 @@
   },
   "type": "module",
   "dependencies": {
-    "@code-pushup/models": "0.79.2-alpha.1",
-    "@code-pushup/utils": "0.79.2-alpha.1",
+    "@code-pushup/models": "0.79.2",
+    "@code-pushup/utils": "0.79.2",
     "ansis": "^3.3.0",
     "parse-lcov": "^1.0.4",
     "yargs": "^17.7.2",

--- a/packages/plugin-coverage/package.json
+++ b/packages/plugin-coverage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@code-pushup/coverage-plugin",
-  "version": "0.79.1",
+  "version": "0.79.2-alpha.1",
   "description": "Code PushUp plugin for tracking code coverage ☂",
   "license": "MIT",
   "homepage": "https://github.com/code-pushup/cli/tree/main/packages/plugin-coverage#readme",
@@ -34,8 +34,8 @@
   },
   "type": "module",
   "dependencies": {
-    "@code-pushup/models": "0.79.1",
-    "@code-pushup/utils": "0.79.1",
+    "@code-pushup/models": "0.79.2-alpha.1",
+    "@code-pushup/utils": "0.79.2-alpha.1",
     "ansis": "^3.3.0",
     "parse-lcov": "^1.0.4",
     "yargs": "^17.7.2",

--- a/packages/plugin-eslint/package.json
+++ b/packages/plugin-eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@code-pushup/eslint-plugin",
-  "version": "0.79.1",
+  "version": "0.79.2-alpha.1",
   "license": "MIT",
   "description": "Code PushUp plugin for detecting problems in source code using ESLint.📋",
   "homepage": "https://github.com/code-pushup/cli/tree/main/packages/plugin-eslint#readme",
@@ -39,8 +39,8 @@
   "type": "module",
   "dependencies": {
     "glob": "^11.0.0",
-    "@code-pushup/utils": "0.79.1",
-    "@code-pushup/models": "0.79.1",
+    "@code-pushup/utils": "0.79.2-alpha.1",
+    "@code-pushup/models": "0.79.2-alpha.1",
     "zod": "^4.0.5"
   },
   "peerDependencies": {

--- a/packages/plugin-eslint/package.json
+++ b/packages/plugin-eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@code-pushup/eslint-plugin",
-  "version": "0.79.2-alpha.1",
+  "version": "0.79.2",
   "license": "MIT",
   "description": "Code PushUp plugin for detecting problems in source code using ESLint.📋",
   "homepage": "https://github.com/code-pushup/cli/tree/main/packages/plugin-eslint#readme",
@@ -39,8 +39,8 @@
   "type": "module",
   "dependencies": {
     "glob": "^11.0.0",
-    "@code-pushup/utils": "0.79.2-alpha.1",
-    "@code-pushup/models": "0.79.2-alpha.1",
+    "@code-pushup/utils": "0.79.2",
+    "@code-pushup/models": "0.79.2",
     "zod": "^4.0.5"
   },
   "peerDependencies": {

--- a/packages/plugin-js-packages/package.json
+++ b/packages/plugin-js-packages/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@code-pushup/js-packages-plugin",
-  "version": "0.79.1",
+  "version": "0.79.2-alpha.1",
   "description": "Code PushUp plugin for JavaScript packages 🛡️",
   "license": "MIT",
   "homepage": "https://github.com/code-pushup/cli/tree/main/packages/plugin-js-packages#readme",
@@ -37,8 +37,8 @@
   },
   "type": "module",
   "dependencies": {
-    "@code-pushup/models": "0.79.1",
-    "@code-pushup/utils": "0.79.1",
+    "@code-pushup/models": "0.79.2-alpha.1",
+    "@code-pushup/utils": "0.79.2-alpha.1",
     "build-md": "^0.4.1",
     "semver": "^7.6.0",
     "yargs": "^17.7.2",

--- a/packages/plugin-js-packages/package.json
+++ b/packages/plugin-js-packages/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@code-pushup/js-packages-plugin",
-  "version": "0.79.2-alpha.1",
+  "version": "0.79.2",
   "description": "Code PushUp plugin for JavaScript packages 🛡️",
   "license": "MIT",
   "homepage": "https://github.com/code-pushup/cli/tree/main/packages/plugin-js-packages#readme",
@@ -37,8 +37,8 @@
   },
   "type": "module",
   "dependencies": {
-    "@code-pushup/models": "0.79.2-alpha.1",
-    "@code-pushup/utils": "0.79.2-alpha.1",
+    "@code-pushup/models": "0.79.2",
+    "@code-pushup/utils": "0.79.2",
     "build-md": "^0.4.1",
     "semver": "^7.6.0",
     "yargs": "^17.7.2",

--- a/packages/plugin-jsdocs/package.json
+++ b/packages/plugin-jsdocs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@code-pushup/jsdocs-plugin",
-  "version": "0.79.1",
+  "version": "0.79.2-alpha.1",
   "description": "Code PushUp plugin for tracking documentation coverage 📚",
   "license": "MIT",
   "homepage": "https://github.com/code-pushup/cli/tree/main/packages/plugin-jsdocs#readme",
@@ -35,8 +35,8 @@
   },
   "type": "module",
   "dependencies": {
-    "@code-pushup/models": "0.79.1",
-    "@code-pushup/utils": "0.79.1",
+    "@code-pushup/models": "0.79.2-alpha.1",
+    "@code-pushup/utils": "0.79.2-alpha.1",
     "zod": "^4.0.5",
     "ts-morph": "^24.0.0"
   },

--- a/packages/plugin-jsdocs/package.json
+++ b/packages/plugin-jsdocs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@code-pushup/jsdocs-plugin",
-  "version": "0.79.2-alpha.1",
+  "version": "0.79.2",
   "description": "Code PushUp plugin for tracking documentation coverage 📚",
   "license": "MIT",
   "homepage": "https://github.com/code-pushup/cli/tree/main/packages/plugin-jsdocs#readme",
@@ -35,8 +35,8 @@
   },
   "type": "module",
   "dependencies": {
-    "@code-pushup/models": "0.79.2-alpha.1",
-    "@code-pushup/utils": "0.79.2-alpha.1",
+    "@code-pushup/models": "0.79.2",
+    "@code-pushup/utils": "0.79.2",
     "zod": "^4.0.5",
     "ts-morph": "^24.0.0"
   },

--- a/packages/plugin-lighthouse/package.json
+++ b/packages/plugin-lighthouse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@code-pushup/lighthouse-plugin",
-  "version": "0.79.1",
+  "version": "0.79.2-alpha.1",
   "license": "MIT",
   "description": "Code PushUp plugin for measuring web performance and quality with Lighthouse 🔥",
   "homepage": "https://github.com/code-pushup/cli/tree/main/packages/plugin-lighthouse#readme",
@@ -36,8 +36,8 @@
   },
   "type": "module",
   "dependencies": {
-    "@code-pushup/models": "0.79.1",
-    "@code-pushup/utils": "0.79.1",
+    "@code-pushup/models": "0.79.2-alpha.1",
+    "@code-pushup/utils": "0.79.2-alpha.1",
     "ansis": "^3.3.0",
     "chrome-launcher": "^1.1.1",
     "lighthouse": "^12.0.0",

--- a/packages/plugin-lighthouse/package.json
+++ b/packages/plugin-lighthouse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@code-pushup/lighthouse-plugin",
-  "version": "0.79.2-alpha.1",
+  "version": "0.79.2",
   "license": "MIT",
   "description": "Code PushUp plugin for measuring web performance and quality with Lighthouse 🔥",
   "homepage": "https://github.com/code-pushup/cli/tree/main/packages/plugin-lighthouse#readme",
@@ -36,8 +36,8 @@
   },
   "type": "module",
   "dependencies": {
-    "@code-pushup/models": "0.79.2-alpha.1",
-    "@code-pushup/utils": "0.79.2-alpha.1",
+    "@code-pushup/models": "0.79.2",
+    "@code-pushup/utils": "0.79.2",
     "ansis": "^3.3.0",
     "chrome-launcher": "^1.1.1",
     "lighthouse": "^12.0.0",

--- a/packages/plugin-typescript/package.json
+++ b/packages/plugin-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@code-pushup/typescript-plugin",
-  "version": "0.79.2-alpha.1",
+  "version": "0.79.2",
   "license": "MIT",
   "description": "Code PushUp plugin for incrementally adopting strict compilation flags in TypeScript projects",
   "homepage": "https://github.com/code-pushup/cli/tree/main/packages/plugin-typescript#readme",
@@ -23,8 +23,8 @@
   },
   "type": "module",
   "dependencies": {
-    "@code-pushup/models": "0.79.2-alpha.1",
-    "@code-pushup/utils": "0.79.2-alpha.1",
+    "@code-pushup/models": "0.79.2",
+    "@code-pushup/utils": "0.79.2",
     "zod": "^4.0.5"
   },
   "peerDependencies": {

--- a/packages/plugin-typescript/package.json
+++ b/packages/plugin-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@code-pushup/typescript-plugin",
-  "version": "0.79.1",
+  "version": "0.79.2-alpha.1",
   "license": "MIT",
   "description": "Code PushUp plugin for incrementally adopting strict compilation flags in TypeScript projects",
   "homepage": "https://github.com/code-pushup/cli/tree/main/packages/plugin-typescript#readme",
@@ -23,8 +23,8 @@
   },
   "type": "module",
   "dependencies": {
-    "@code-pushup/models": "0.79.1",
-    "@code-pushup/utils": "0.79.1",
+    "@code-pushup/models": "0.79.2-alpha.1",
+    "@code-pushup/utils": "0.79.2-alpha.1",
     "zod": "^4.0.5"
   },
   "peerDependencies": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@code-pushup/utils",
-  "version": "0.79.1",
+  "version": "0.79.2-alpha.1",
   "description": "Low-level utilities (helper functions, etc.) used by Code PushUp CLI",
   "license": "MIT",
   "homepage": "https://github.com/code-pushup/cli/tree/main/packages/utils#readme",
@@ -27,7 +27,7 @@
     "node": ">=17.0.0"
   },
   "dependencies": {
-    "@code-pushup/models": "0.79.1",
+    "@code-pushup/models": "0.79.2-alpha.1",
     "@isaacs/cliui": "^8.0.2",
     "@poppinss/cliui": "^6.4.0",
     "ansis": "^3.3.0",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@code-pushup/utils",
-  "version": "0.79.2-alpha.1",
+  "version": "0.79.2",
   "description": "Low-level utilities (helper functions, etc.) used by Code PushUp CLI",
   "license": "MIT",
   "homepage": "https://github.com/code-pushup/cli/tree/main/packages/utils#readme",
@@ -27,7 +27,7 @@
     "node": ">=17.0.0"
   },
   "dependencies": {
-    "@code-pushup/models": "0.79.2-alpha.1",
+    "@code-pushup/models": "0.79.2",
     "@isaacs/cliui": "^8.0.2",
     "@poppinss/cliui": "^6.4.0",
     "ansis": "^3.3.0",


### PR DESCRIPTION
- Closes #1114 
- Closes #893

## Changes

- Enabled previously disabled [`release.yml`](https://github.com/code-pushup/cli/actions/workflows/release.yml) workflow.
- Removed `NPM_TOKEN` secret. Instead, the `release.yml` workflow is configured as a trusted publisher and uses OIDC authentication. This is configured in the [_Settings_ tab](https://www.npmjs.com/package/@code-pushup/cli/access) for each package:
  <img width="795" height="525" alt="image" src="https://github.com/user-attachments/assets/814fc829-e119-41b2-aad8-0c0444de69d6" />

  - Provenance attestations are now automatically generated for all packages, see [example](https://www.npmjs.com/package/@code-pushup/cli/v/0.79.2-alpha.1#provenance-details-header):
    <img width="795" height="180" alt="image" src="https://github.com/user-attachments/assets/5e70505d-ff87-46af-a99e-6d67d09542d7" />
- Removed unnecessary GitHub App authentication. The `id-token: write` (for OIDC) and `contents: write` (for GitHub Release) permissions are sufficient.
  <img width="702" height="254" alt="image" src="https://github.com/user-attachments/assets/fe76e58b-1921-4c2f-81ee-3b7d9ffc2be0" />
- Removed unnecessary `dry-run` logic and `workflow-dispatch`. It was overly complex. And, in practice, it doesn't catch many errors anyway.
- Configured [concurrency](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency) to prevent parallel releases.
- Tested with an alpha release ([`0.79.2-alpha.1`](https://github.com/code-pushup/cli/releases/tag/v0.79.2-alpha.1)). Versioning, changelogs, release, and npm publish all worked correctly (see [CI job](https://github.com/code-pushup/cli/actions/runs/17943498194/job/51024416383#step:6:1717)) :tada:  
  - Also tested that workflow passes without changes when there's nothing to release (see [CI job](https://github.com/code-pushup/cli/actions/runs/17943011796/job/51023343337#step:6:73)).

---

**Edit**: Had to release version `0.79.2`, as it turns out our E2E tests break when there's a pre-release version :grimacing: Reported as a bug: push-based/nx-verdaccio#94