### PR TITLE
feat(utils): export loose autocomplete type helper

### DIFF
--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -104,7 +104,7 @@ export {
 } from './lib/reports/generate-md-reports-diff.js';
 export { loadReport } from './lib/reports/load-report.js';
 export { logStdoutSummary } from './lib/reports/log-stdout-summary.js';
-export { scoreReport, scoreAuditsWithTarget } from './lib/reports/scoring.js';
+export { scoreAuditsWithTarget, scoreReport } from './lib/reports/scoring.js';
 export { sortReport } from './lib/reports/sorting.js';
 export type {
   ScoredCategoryConfig,
@@ -142,6 +142,7 @@ export type {
   ExtractArray,
   ExtractArrays,
   ItemOrArray,
+  LooseAutocomplete,
   Prettify,
   WithRequired,
 } from './lib/types.js';

--- a/packages/utils/src/lib/types.ts
+++ b/packages/utils/src/lib/types.ts
@@ -27,3 +27,14 @@ export type KebabCaseToCamelCase<T extends string> =
   T extends `${infer First}-${infer Rest}`
     ? `${First}${Capitalize<KebabCaseToCamelCase<Rest>>}`
     : T;
+
+/**
+ * Autocompletes string from union, while allowing any other string to be assigned.
+ *
+ * @example
+ * let color: LooseAutocomplete< 'red' | 'green' | 'blue'>;
+ *
+ * color = 'green'; // IDE autocompletes 'red', 'green', 'blue'
+ * color = '#516bc6'; // any string passes type check
+ */
+export type LooseAutocomplete<T extends string> = T | (string & {});


### PR DESCRIPTION
Adding a useful type helper, discussed in other PRs.