### PR TITLE
ci: fix protected branch error in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,29 +9,36 @@ concurrency:
   group: release
   cancel-in-progress: false
 
-permissions:
-  contents: write
-  id-token: write
-
-env:
-  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  NX_NON_NATIVE_HASHER: true
-  NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
-
 jobs:
   release:
     name: Publish packages
     runs-on: ubuntu-latest
+    environment: release
+    env:
+      NX_NON_NATIVE_HASHER: true
+      NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
     steps:
+      - name: Authenticate as "Code PushUp Bot" GitHub App
+        uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ vars.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+      - name: Fetch GitHub App's user ID
+        id: get-user-id
+        run: echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+      - name: Configure Git user
+        run: |
+          git config --global user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
+          git config --global user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com'
       - name: Clone the repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Configure Git user
-        # https://github.com/actions/checkout/blob/main/README.md#push-a-commit-using-the-built-in-token
-        run: |
-          git config user.name github-actions[bot]
-          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: false
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
@@ -41,3 +48,5 @@ jobs:
         run: npm ci
       - name: Version, release and publish packages
         run: npx nx release --yes
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
Possible fix for #1114. Follow-up to #1117.

Turns out the default `github-actions[bot]` can't push to `main` (see [CI error](https://github.com/code-pushup/cli/actions/runs/17969395646/job/51108271743#step:6:318)):

>  NX   Pushing to git remote "origin"
> 
> 
>  NX   Unexpected git push error: remote: error: GH006: Protected branch update failed for refs/heads/main.        
> 
> remote: 
> remote: - Changes must be made through a pull request.        
> To https://github.com/code-pushup/cli
>  ! [remote rejected]   main -> main (protected branch hook declined)
>  ! [remote rejected]   v0.80.0 -> v0.80.0 (atomic transaction failed)
> error: failed to push some refs to 'https://github.com/code-pushup/cli'

This is probably why the `code-pushup-bot` was used before, because unlike the built-in GitHub bot, we can configure exceptions for GitHub Apps.

<img width="748" height="314" alt="image" src="https://github.com/user-attachments/assets/42b3d605-383c-4202-8c8a-cd0995596a23" />

The Git user configuration is taken from an [example in `create-github-app-token` docs](https://github.com/actions/create-github-app-token?tab=readme-ov-file#configure-git-cli-for-an-apps-bot-user).

I've tested the authentication [here](https://github.com/code-pushup/cli/actions/runs/17975710481/job/51128614812#step:4:3). I can't really test the rest until this is merged into `main` :crossed_fingers: 

