### PR TITLE
build(models): run prettier immediately after zod2md docs generation

### DIFF
--- a/packages/models/project.json
+++ b/packages/models/project.json
@@ -5,7 +5,14 @@
   "projectType": "library",
   "targets": {
     "generate-docs": {
-      "command": "npx zod2md --config packages/models/zod2md.config.ts",
+      "executor": "nx:run-commands",
+      "options": {
+        "commands": [
+          "zod2md --config {projectRoot}/zod2md.config.ts",
+          "prettier --write {projectRoot}/docs/models-reference.md"
+        ],
+        "parallel": false
+      },
       "cache": true,
       "inputs": ["production", "^production", "{projectRoot}/zod2md.config.ts"],
       "outputs": ["{projectRoot}/docs/models-reference.md"]


### PR DESCRIPTION
This PR fixes a slightly annoying local development problem.

The `models:generate-docs` target is being run automatically for each `models:build`, which is fairly frequent because other tasks often depend on `build` (e.g. `e2e-test`, or recently `lint`). This itself is fine, but because the Markdown generated by `zod2md` is 100% the same as how Prettier would format it, you often end up having a local change to `models-reference.md`. It disappears once you commit, because our `pre-commit` hook formats files with `prettier`, which effectively reverts the file changes. So it's not a big deal, but it still happens often enough to be a nuisance.

```diff
diff --git a/packages/models/docs/models-reference.md b/packages/models/docs/models-reference.md
index 0782c525..9013123d 100644
--- a/packages/models/docs/models-reference.md
+++ b/packages/models/docs/models-reference.md
@@ -308,7 +308,7 @@ _Enum, one of the following possible values:_
 
 ## GlobPath
 
-Schema for a glob pattern (supports wildcards like \*, \*\*, {}, !, etc.)
+Schema for a glob pattern (supports wildcards like *, **, {}, !, etc.)
 
 _String which has a minimum length of 1 and matches the regular expression `/^!?[^<>"|]+$/`._
 
@@ -1316,7 +1316,7 @@ _Object record with dynamic keys:_
 
 - _keys of type_ `string`
 - _values of type_ `unknown`
-  (_optional_)
+ (_optional_)
 
 ## PluginMeta
 
@@ -1364,7 +1364,7 @@ _Union of the following possible types:_
 
 - `number` (_≥0, ≤1_) (_optional_)
 - _Object with dynamic keys of type_ `string` _and values of type_ `number` (_≥0, ≤1_)
-  (_optional_)
+ (_optional_)
 
 ## Report
 

```

I've tweaked the `generate-docs` target to run `prettier` immediately after `zod2md`, so there are no intermediate file changes anymore. :relieved: 
