### PR TITLE
fix(plugin-lighthouse): prevent cleanup permissions error on windows

### DIFF
--- a/packages/plugin-lighthouse/src/lib/runner/runner.ts
+++ b/packages/plugin-lighthouse/src/lib/runner/runner.ts
@@ -12,13 +12,14 @@ import {
   getConfig,
   normalizeAuditOutputs,
   toAuditOutputs,
+  withLocalTmpDir,
 } from './utils.js';
 
 export function createRunnerFunction(
   urls: string[],
   flags: LighthouseCliFlags = DEFAULT_CLI_FLAGS,
 ): RunnerFunction {
-  return async (): Promise<AuditOutputs> => {
+  return withLocalTmpDir(async (): Promise<AuditOutputs> => {
     const config = await getConfig(flags);
     const normalizationFlags = enrichFlags(flags);
     const isSingleUrl = !shouldExpandForUrls(urls.length);
@@ -58,7 +59,7 @@ export function createRunnerFunction(
       );
     }
     return normalizeAuditOutputs(allResults, normalizationFlags);
-  };
+  });
 }
 
 async function runLighthouseForUrl(


### PR DESCRIPTION
Fixes #1122

The permissions error seems to be a cleanup bug in `lighthouse`/`chrome-launcher` (see GoogleChrome/chrome-launcher#355). Overriding the default system temporary directory path on Windows to a local path [fixes the tests](https://github.com/code-pushup/cli/actions/runs/18037951230/job/51329257914?pr=1124#step:6:56).

From Node.js [`os.tmpdir()` docs](https://nodejs.org/api/os.html#ostmpdir):

> On Windows, the result can be overridden by `TEMP` and `TMP` environment variables, and `TEMP` takes precedence over `TMP`. If neither is set, it defaults to `%SystemRoot%\temp` or `%windir%\temp`.
> 
> On non-Windows platforms, `TMPDIR`, `TMP` and `TEMP` environment variables will be checked to override the result of this method, in the described order. If none of them is set, it defaults to `/tmp`.
> 
> Some operating system distributions would either configure `TMPDIR` (non-Windows) or `TEMP` and `TMP` (Windows) by default without additional configurations by the system administrators. The result of `os.tmpdir()` typically reflects the system preference unless it's explicitly overridden by the users.



I suspect GitHub's recent [`windows-latest` image migration](https://github.blog/changelog/2025-07-31-github-actions-new-apis-and-windows-latest-migration-notice/#windows-latest-image-label-migration) might be the reason the jobs started failing for us recently.