### PR TITLE
test(examples-plugins): do not use memfs in integration tests, intended for unit tests only

### DIFF
--- a/examples/plugins/src/package-json/src/package-json.plugin.int.test.ts
+++ b/examples/plugins/src/package-json/src/package-json.plugin.int.test.ts
@@ -1,4 +1,5 @@
-import { vol } from 'memfs';
+import { mkdir, rm, writeFile } from 'node:fs/promises';
+import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { executePlugin } from '@code-pushup/core';
 import {
@@ -7,7 +8,6 @@ import {
   pluginConfigSchema,
   pluginReportSchema,
 } from '@code-pushup/models';
-import { MEMFS_VOLUME } from '@code-pushup/test-utils';
 import { audits, pluginSlug as slug } from './constants.js';
 import { type PluginOptions, create } from './package-json.plugin.js';
 import {
@@ -18,17 +18,24 @@ import {
 } from './scoring.js';
 
 describe('create-package-json', () => {
+  const workDir = path.join(
+    'tmp',
+    'int-tests',
+    'examples-plugins',
+    'package-json',
+  );
+
   const baseOptions: PluginOptions = {
-    directory: '/',
+    directory: workDir,
   };
 
-  beforeEach(() => {
-    vol.fromJSON(
-      {
-        'package.json': '{}',
-      },
-      MEMFS_VOLUME,
-    );
+  beforeAll(async () => {
+    await mkdir(workDir, { recursive: true });
+    await writeFile(path.join(workDir, 'package.json'), '{}');
+  });
+
+  afterAll(async () => {
+    await rm(workDir, { recursive: true, force: true });
   });
 
   it('should return valid PluginConfig', () => {

--- a/examples/plugins/vitest.int.config.ts
+++ b/examples/plugins/vitest.int.config.ts
@@ -22,7 +22,6 @@ export default defineConfig({
     include: ['src/**/*.int.test.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
     globalSetup: ['../../global-setup.ts'],
     setupFiles: [
-      '../../testing/test-setup/src/lib/fs.mock.ts',
       '../../testing/test-setup/src/lib/git.mock.ts',
       '../../testing/test-setup/src/lib/console.mock.ts',
       '../../testing/test-setup/src/lib/reset.mocks.ts',


### PR DESCRIPTION
Some integration tests in example plugins were using `memfs` mocks. This breaks our testing strategy - only unit tests should be using a mock file system, integration and E2E tests should use the real file system in `tmp`.