### PR TITLE
test: fix vitest config type errors (unknown test property)

### DIFF
--- a/e2e/ci-e2e/vitest.e2e.config.ts
+++ b/e2e/ci-e2e/vitest.e2e.config.ts
@@ -1,5 +1,5 @@
 /// <reference types="vitest" />
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 import { tsconfigPathAliases } from '../../tools/vitest-tsconfig-path-aliases.js';
 
 export default defineConfig({

--- a/e2e/cli-e2e/vitest.e2e.config.ts
+++ b/e2e/cli-e2e/vitest.e2e.config.ts
@@ -1,5 +1,5 @@
 /// <reference types="vitest" />
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 import { tsconfigPathAliases } from '../../tools/vitest-tsconfig-path-aliases.js';
 
 export default defineConfig({

--- a/e2e/create-cli-e2e/vitest.e2e.config.ts
+++ b/e2e/create-cli-e2e/vitest.e2e.config.ts
@@ -1,5 +1,5 @@
 /// <reference types="vitest" />
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 import { tsconfigPathAliases } from '../../tools/vitest-tsconfig-path-aliases.js';
 
 export default defineConfig({

--- a/e2e/nx-plugin-e2e/vitest.e2e.config.ts
+++ b/e2e/nx-plugin-e2e/vitest.e2e.config.ts
@@ -1,5 +1,5 @@
 /// <reference types="vitest" />
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 import { tsconfigPathAliases } from '../../tools/vitest-tsconfig-path-aliases.js';
 
 export default defineConfig({

--- a/e2e/plugin-coverage-e2e/mocks/fixtures/basic-setup/vitest.config.ts
+++ b/e2e/plugin-coverage-e2e/mocks/fixtures/basic-setup/vitest.config.ts
@@ -1,7 +1,7 @@
 /// <reference types="vitest" />
 import { dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   root: fileURLToPath(dirname(import.meta.url)),

--- a/e2e/plugin-coverage-e2e/vitest.e2e.config.ts
+++ b/e2e/plugin-coverage-e2e/vitest.e2e.config.ts
@@ -1,5 +1,5 @@
 /// <reference types="vitest" />
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 import { tsconfigPathAliases } from '../../tools/vitest-tsconfig-path-aliases.js';
 
 export default defineConfig({

--- a/e2e/plugin-eslint-e2e/vitest.e2e.config.ts
+++ b/e2e/plugin-eslint-e2e/vitest.e2e.config.ts
@@ -1,5 +1,5 @@
 /// <reference types="vitest" />
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 import { tsconfigPathAliases } from '../../tools/vitest-tsconfig-path-aliases.js';
 
 export default defineConfig({

--- a/e2e/plugin-js-packages-e2e/vitest.e2e.config.ts
+++ b/e2e/plugin-js-packages-e2e/vitest.e2e.config.ts
@@ -1,5 +1,5 @@
 /// <reference types="vitest" />
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 import { tsconfigPathAliases } from '../../tools/vitest-tsconfig-path-aliases.js';
 
 export default defineConfig({

--- a/e2e/plugin-jsdocs-e2e/vitest.e2e.config.ts
+++ b/e2e/plugin-jsdocs-e2e/vitest.e2e.config.ts
@@ -1,5 +1,5 @@
 /// <reference types="vitest" />
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 import { tsconfigPathAliases } from '../../tools/vitest-tsconfig-path-aliases.js';
 
 export default defineConfig({

--- a/e2e/plugin-lighthouse-e2e/vitest.e2e.config.ts
+++ b/e2e/plugin-lighthouse-e2e/vitest.e2e.config.ts
@@ -1,5 +1,5 @@
 /// <reference types="vitest" />
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 import { tsconfigPathAliases } from '../../tools/vitest-tsconfig-path-aliases.js';
 
 export default defineConfig({

--- a/e2e/plugin-typescript-e2e/vitest.e2e.config.ts
+++ b/e2e/plugin-typescript-e2e/vitest.e2e.config.ts
@@ -1,5 +1,5 @@
 /// <reference types="vitest" />
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 import { tsconfigPathAliases } from '../../tools/vitest-tsconfig-path-aliases.js';
 
 export default defineConfig({

--- a/examples/plugins/vitest.int.config.ts
+++ b/examples/plugins/vitest.int.config.ts
@@ -1,5 +1,5 @@
 /// <reference types="vitest" />
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 import { tsconfigPathAliases } from '../../tools/vitest-tsconfig-path-aliases.js';
 
 export default defineConfig({

--- a/examples/plugins/vitest.unit.config.ts
+++ b/examples/plugins/vitest.unit.config.ts
@@ -1,5 +1,5 @@
 /// <reference types="vitest" />
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 import { tsconfigPathAliases } from '../../tools/vitest-tsconfig-path-aliases.js';
 
 export default defineConfig({

--- a/packages/ci/vitest.int.config.ts
+++ b/packages/ci/vitest.int.config.ts
@@ -1,5 +1,5 @@
 /// <reference types="vitest" />
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 import { tsconfigPathAliases } from '../../tools/vitest-tsconfig-path-aliases.js';
 
 export default defineConfig({

--- a/packages/ci/vitest.unit.config.ts
+++ b/packages/ci/vitest.unit.config.ts
@@ -1,5 +1,5 @@
 /// <reference types="vitest" />
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 import { tsconfigPathAliases } from '../../tools/vitest-tsconfig-path-aliases.js';
 
 export default defineConfig({

--- a/packages/cli/vitest.int.config.ts
+++ b/packages/cli/vitest.int.config.ts
@@ -1,5 +1,5 @@
 /// <reference types="vitest" />
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 import { tsconfigPathAliases } from '../../tools/vitest-tsconfig-path-aliases.js';
 
 export default defineConfig({

--- a/packages/cli/vitest.unit.config.ts
+++ b/packages/cli/vitest.unit.config.ts
@@ -1,5 +1,5 @@
 /// <reference types="vitest" />
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 import { tsconfigPathAliases } from '../../tools/vitest-tsconfig-path-aliases.js';
 
 export default defineConfig({

--- a/packages/core/vitest.int.config.ts
+++ b/packages/core/vitest.int.config.ts
@@ -1,5 +1,5 @@
 /// <reference types="vitest" />
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 import { tsconfigPathAliases } from '../../tools/vitest-tsconfig-path-aliases.js';
 
 export default defineConfig({

--- a/packages/core/vitest.unit.config.ts
+++ b/packages/core/vitest.unit.config.ts
@@ -1,5 +1,5 @@
 /// <reference types="vitest" />
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 import { tsconfigPathAliases } from '../../tools/vitest-tsconfig-path-aliases.js';
 
 export default defineConfig({

--- a/packages/create-cli/vitest.unit.config.ts
+++ b/packages/create-cli/vitest.unit.config.ts
@@ -1,5 +1,5 @@
 /// <reference types="vitest" />
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 import { tsconfigPathAliases } from '../../tools/vitest-tsconfig-path-aliases.js';
 
 export default defineConfig({

--- a/packages/models/vitest.unit.config.ts
+++ b/packages/models/vitest.unit.config.ts
@@ -1,5 +1,5 @@
 /// <reference types="vitest" />
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 import { tsconfigPathAliases } from '../../tools/vitest-tsconfig-path-aliases.js';
 
 export default defineConfig({

--- a/packages/nx-plugin/vitest.int.config.ts
+++ b/packages/nx-plugin/vitest.int.config.ts
@@ -1,5 +1,5 @@
 /// <reference types="vitest" />
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 import { tsconfigPathAliases } from '../../tools/vitest-tsconfig-path-aliases.js';
 
 export default defineConfig({

--- a/packages/nx-plugin/vitest.unit.config.ts
+++ b/packages/nx-plugin/vitest.unit.config.ts
@@ -1,5 +1,5 @@
 /// <reference types="vitest" />
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 import { tsconfigPathAliases } from '../../tools/vitest-tsconfig-path-aliases.js';
 
 export default defineConfig({

--- a/packages/plugin-coverage/vitest.int.config.ts
+++ b/packages/plugin-coverage/vitest.int.config.ts
@@ -1,5 +1,5 @@
 /// <reference types="vitest" />
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 import { tsconfigPathAliases } from '../../tools/vitest-tsconfig-path-aliases.js';
 
 export default defineConfig({

--- a/packages/plugin-coverage/vitest.unit.config.ts
+++ b/packages/plugin-coverage/vitest.unit.config.ts
@@ -1,5 +1,5 @@
 /// <reference types="vitest" />
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 import { tsconfigPathAliases } from '../../tools/vitest-tsconfig-path-aliases.js';
 
 export default defineConfig({

--- a/packages/plugin-eslint/vitest.int.config.ts
+++ b/packages/plugin-eslint/vitest.int.config.ts
@@ -1,5 +1,5 @@
 /// <reference types="vitest" />
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 import { tsconfigPathAliases } from '../../tools/vitest-tsconfig-path-aliases.js';
 
 export default defineConfig({

--- a/packages/plugin-eslint/vitest.unit.config.ts
+++ b/packages/plugin-eslint/vitest.unit.config.ts
@@ -1,5 +1,5 @@
 /// <reference types="vitest" />
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 import { tsconfigPathAliases } from '../../tools/vitest-tsconfig-path-aliases.js';
 
 export default defineConfig({

--- a/packages/plugin-js-packages/vitest.int.config.ts
+++ b/packages/plugin-js-packages/vitest.int.config.ts
@@ -1,5 +1,5 @@
 /// <reference types="vitest" />
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 import { tsconfigPathAliases } from '../../tools/vitest-tsconfig-path-aliases.js';
 
 export default defineConfig({

--- a/packages/plugin-js-packages/vitest.unit.config.ts
+++ b/packages/plugin-js-packages/vitest.unit.config.ts
@@ -1,5 +1,5 @@
 /// <reference types="vitest" />
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 import { tsconfigPathAliases } from '../../tools/vitest-tsconfig-path-aliases.js';
 
 export default defineConfig({

--- a/packages/plugin-jsdocs/vitest.int.config.ts
+++ b/packages/plugin-jsdocs/vitest.int.config.ts
@@ -1,5 +1,5 @@
 /// <reference types="vitest" />
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 import { tsconfigPathAliases } from '../../tools/vitest-tsconfig-path-aliases.js';
 
 export default defineConfig({

--- a/packages/plugin-jsdocs/vitest.unit.config.ts
+++ b/packages/plugin-jsdocs/vitest.unit.config.ts
@@ -1,5 +1,5 @@
 /// <reference types="vitest" />
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 import { tsconfigPathAliases } from '../../tools/vitest-tsconfig-path-aliases.js';
 
 export default defineConfig({

--- a/packages/plugin-lighthouse/vitest.unit.config.ts
+++ b/packages/plugin-lighthouse/vitest.unit.config.ts
@@ -1,5 +1,5 @@
 /// <reference types="vitest" />
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 import { tsconfigPathAliases } from '../../tools/vitest-tsconfig-path-aliases.js';
 
 export default defineConfig({

--- a/packages/plugin-typescript/vitest.int.config.ts
+++ b/packages/plugin-typescript/vitest.int.config.ts
@@ -1,5 +1,5 @@
 /// <reference types="vitest" />
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 import { tsconfigPathAliases } from '../../tools/vitest-tsconfig-path-aliases.js';
 
 export default defineConfig({

--- a/packages/plugin-typescript/vitest.unit.config.ts
+++ b/packages/plugin-typescript/vitest.unit.config.ts
@@ -1,5 +1,5 @@
 /// <reference types="vitest" />
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 import { tsconfigPathAliases } from '../../tools/vitest-tsconfig-path-aliases.js';
 
 export default defineConfig({

--- a/packages/utils/vitest.int.config.ts
+++ b/packages/utils/vitest.int.config.ts
@@ -1,5 +1,5 @@
 /// <reference types="vitest" />
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 import { tsconfigPathAliases } from '../../tools/vitest-tsconfig-path-aliases.js';
 
 export default defineConfig({

--- a/packages/utils/vitest.unit.config.ts
+++ b/packages/utils/vitest.unit.config.ts
@@ -1,5 +1,5 @@
 /// <reference types="vitest" />
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 import { tsconfigPathAliases } from '../../tools/vitest-tsconfig-path-aliases.js';
 
 export default defineConfig({

--- a/testing/test-nx-utils/vitest.unit.config.ts
+++ b/testing/test-nx-utils/vitest.unit.config.ts
@@ -1,5 +1,5 @@
 /// <reference types="vitest" />
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 import { tsconfigPathAliases } from '../../tools/vitest-tsconfig-path-aliases.js';
 
 export default defineConfig({

--- a/testing/test-setup/vitest.unit.config.ts
+++ b/testing/test-setup/vitest.unit.config.ts
@@ -1,5 +1,5 @@
 /// <reference types="vitest" />
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 import { tsconfigPathAliases } from '../../tools/vitest-tsconfig-path-aliases.js';
 
 export default defineConfig({

--- a/testing/test-utils/vitest.unit.config.ts
+++ b/testing/test-utils/vitest.unit.config.ts
@@ -1,5 +1,5 @@
 /// <reference types="vitest" />
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 import { tsconfigPathAliases } from '../../tools/vitest-tsconfig-path-aliases.js';
 
 export default defineConfig({

--- a/tools/eslint-formatter-multi/vitest.unit.config.ts
+++ b/tools/eslint-formatter-multi/vitest.unit.config.ts
@@ -1,5 +1,5 @@
 /// <reference types="vitest" />
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 // eslint-disable-next-line import/no-useless-path-segments
 import { tsconfigPathAliases } from '../../tools/vitest-tsconfig-path-aliases.js';
 


### PR DESCRIPTION
Fixes type errors in `vitest.config.ts` files. TypeScript doesn't recognize the `test` property unless `defineConfig` is imported from `vitest/config`, not `vite` (different `UserConfig` types).

<details><summary>:framed_picture: before</summary>
<img width="1108" height="967" alt="image" src="https://github.com/user-attachments/assets/9fcaa08c-3106-4543-95a5-c753b221f3a5" />
</details> 

<details><summary>:framed_picture: after</summary>
<img width="1108" height="988" alt="image" src="https://github.com/user-attachments/assets/76973681-0d33-4086-8480-3e9f4a1330dc" />
</details> 
