### PR TITLE
build(models-transformers): cache ts-patch install

### DIFF
--- a/packages/models/transformers/project.json
+++ b/packages/models/transformers/project.json
@@ -7,11 +7,7 @@
     "build": {
       "executor": "@nx/js:tsc",
       "outputs": ["{options.outputPath}"],
-      "dependsOn": [
-        {
-          "target": "pre-build"
-        }
-      ],
+      "dependsOn": ["pre-build"],
       "options": {
         "outputPath": "packages/models/transformers/dist",
         "main": "packages/models/transformers/src/index.ts",
@@ -19,10 +15,9 @@
       }
     },
     "pre-build": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "npx ts-patch install"
-      }
+      "command": "ts-patch install",
+      "cache": true,
+      "inputs": ["sharedGlobals", { "runtime": "ts-patch check" }]
     }
   }
 }


### PR DESCRIPTION
This PR makes the `models-transformers:pre-build` target cacheable.

Because of the `models:build` :arrow_right:   `models-transformers:build` :arrow_right: `models-transformers:pre-build` dependencies, any tasks that depend on `^build` are likely to run this `pre-build` target, so it's very frequent. It's inconvenient to have an uncachable task at the root of our task graph.

The `pre-build` target runs `ts-patch install`, which is a no-op if it's been run before. So I took advantage of the `ts-patch check` command that prints installed versions. If the output is the same as what's cached, the `ts-patch install` command is skipped.