### PR TITLE
fix(core): run plugins sequentially

### DIFF
--- a/packages/core/src/lib/implementation/execute-plugin.ts
+++ b/packages/core/src/lib/implementation/execute-plugin.ts
@@ -11,11 +11,13 @@ import {
 } from '@code-pushup/models';
 import {
   type ProgressBar,
+  asyncSequential,
   getProgressBar,
   groupByStatus,
   logMultipleResults,
   pluralizeToken,
   scoreAuditsWithTarget,
+  settlePromise,
   stringifyError,
 } from '@code-pushup/utils';
 import {
@@ -176,7 +178,7 @@ export async function executePlugins(
   );
 
   const errorsTransform = ({ reason }: PromiseRejectedResult) => String(reason);
-  const results = await Promise.allSettled(pluginsResult);
+  const results = await asyncSequential(pluginsResult, settlePromise);
 
   progressBar?.endProgress('Done running plugins');
 


### PR DESCRIPTION
This fix should prevent problems with concurrent spinners, such as in #1144. 

Plugins are intended to be executed sequentially, but it appears they were (unintentionally?) made concurrent in 7a592ebd268cb9b211da29e3473c4170f9ad4525 as part of the large PR #811.

I intend to make more changes to the plugin execution (log groups, etc.), but for now this is just a minimal fix.