### PR TITLE
fix(plugin-axe): resolve pnpm install issue

### DIFF
--- a/packages/plugin-axe/src/lib/runner/run-axe.ts
+++ b/packages/plugin-axe/src/lib/runner/run-axe.ts
@@ -1,6 +1,6 @@
-import AxeBuilder from '@axe-core/playwright';
+import { AxeBuilder } from '@axe-core/playwright';
 import { createRequire } from 'node:module';
-import { dirname, join } from 'node:path';
+import path from 'node:path';
 import { type Browser, chromium } from 'playwright-core';
 import type { AuditOutputs } from '@code-pushup/models';
 import {
@@ -11,8 +11,10 @@ import {
 } from '@code-pushup/utils';
 import { toAuditOutputs } from './transform.js';
 
+/* eslint-disable functional/no-let */
 let browser: Browser | undefined;
 let browserChecked = false;
+/* eslint-enable functional/no-let */
 
 export async function runAxeForUrl(
   url: string,
@@ -89,7 +91,7 @@ async function ensureBrowserInstalled(): Promise<void> {
   const require = createRequire(import.meta.url);
   const pkgPath = require.resolve('playwright-core/package.json');
   const pkg = require(pkgPath);
-  const cliPath = join(dirname(pkgPath), pkg.bin['playwright-core']);
+  const cliPath = path.join(path.dirname(pkgPath), pkg.bin['playwright-core']);
 
   await executeProcess({
     command: 'node',


### PR DESCRIPTION
Use Node's module resolution and npm bin specification to locate and execute `playwright-core` CLI directly, instead of relying on npx, which fails with pnpm's strict dependency isolation.

With pnpm, transitive dependency binaries are not hoisted to the root `node_modules/.bin` directory, causing `npx playwright-core` to fail with `playwright-core: command not found`.

The fix was verified with all major package managers by installing the preview package `https://pkg.pr.new/code-pushup/cli/@code-pushup/axe-plugin@1150` and testing browser installation with Axe accessibility audits:

- **pnpm** (local + GitHub Actions CI)
- **npm** (local)
- **yarn** (local)