### PR TITLE
ci: check fixup commits are autosquashed before PR merge

### DIFF
--- a/.github/workflows/git-checks.yml
+++ b/.github/workflows/git-checks.yml
@@ -1,0 +1,15 @@
+name: Git Checks
+
+on: pull_request
+
+jobs:
+  block-fixup:
+    name: Block fixup commits
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+      - name: Block fixup commit merge
+        uses: 13rac1/block-fixup-merge-action@v2.0.0


### PR DESCRIPTION
To prevent merging [fixup commits](https://github.com/TheAssemblyArmada/Thyme/wiki/Using-Fixup-Commits) to `main`, the [`block-fixup-commit-merge`](https://github.com/marketplace/actions/block-fixup-commit-merge) action will fail if there are any fixup commits present (example [here](https://github.com/code-pushup/cli/actions/runs/19704884491/job/56449870797?pr=1153#step:4:46)). This is to remind the author to run `git rebase -i main --autosquash` before merging.