### PR TITLE
fix(plugin-js-packages): pnpm outdated fallback

### DIFF
--- a/packages/plugin-js-packages/src/lib/package-managers/pnpm/outdated-result.ts
+++ b/packages/plugin-js-packages/src/lib/package-managers/pnpm/outdated-result.ts
@@ -8,10 +8,12 @@ export function pnpmToOutdatedResult(output: string): OutdatedResult {
     filterOutWarnings(output),
   ) as PnpmOutdatedResultJson;
 
+  // "current" may be missing if package is not installed
+  // Fallback to "wanted" - same approach as npm
   return objectToEntries(pnpmOutdated).map(
-    ([name, { current, latest, dependencyType: type }]) => ({
+    ([name, { current, latest, wanted, dependencyType: type }]) => ({
       name,
-      current,
+      current: current || wanted,
       latest,
       type,
     }),

--- a/packages/plugin-js-packages/src/lib/package-managers/pnpm/outdated-result.unit.test.ts
+++ b/packages/plugin-js-packages/src/lib/package-managers/pnpm/outdated-result.unit.test.ts
@@ -11,11 +11,13 @@ describe('pnpmToOutdatedResult', () => {
           cypress: {
             current: '8.5.0',
             latest: '13.6.0',
+            wanted: '8.5.0',
             dependencyType: 'devDependencies',
           },
           '@cypress/request': {
             current: '2.88.10',
             latest: '3.0.0',
+            wanted: '2.88.10',
             dependencyType: 'devDependencies',
           },
         } satisfies PnpmOutdatedResultJson),
@@ -49,11 +51,13 @@ describe('pnpmToOutdatedResult', () => {
         "cypress": {
           "current": "8.5.0",
           "latest": "13.6.0",
+          "wanted": "8.5.0",
           "dependencyType": "devDependencies"
         },
         "@cypress/request": {
           "current": "2.88.10",
           "latest": "3.0.0",
+          "wanted": "2.88.10",
           "dependencyType": "devDependencies"
         }
       }
@@ -71,6 +75,37 @@ describe('pnpmToOutdatedResult', () => {
         current: '2.88.10',
         latest: '3.0.0',
         type: 'devDependencies',
+      },
+    ]);
+  });
+
+  it('should handle dependencies with missing current version by falling back to wanted', () => {
+    const output = JSON.stringify({
+      '@angular/animations': {
+        latest: '21.0.1',
+        wanted: '20.3.12',
+        dependencyType: 'dependencies',
+      },
+      rxjs: {
+        current: '7.8.0',
+        latest: '7.8.1',
+        wanted: '7.8.0',
+        dependencyType: 'dependencies',
+      },
+    });
+
+    expect(pnpmToOutdatedResult(output)).toEqual([
+      {
+        name: '@angular/animations',
+        current: '20.3.12',
+        latest: '21.0.1',
+        type: 'dependencies',
+      },
+      {
+        name: 'rxjs',
+        current: '7.8.0',
+        latest: '7.8.1',
+        type: 'dependencies',
       },
     ]);
   });

--- a/packages/plugin-js-packages/src/lib/package-managers/pnpm/types.ts
+++ b/packages/plugin-js-packages/src/lib/package-managers/pnpm/types.ts
@@ -20,8 +20,9 @@ export type PnpmAuditResultJson = {
 
 // Subset of PNPM outdated JSON type
 export type PnpmVersionOverview = {
-  current: string;
+  current?: string;
   latest: string;
+  wanted: string;
   dependencyType: DependencyGroupLong;
 };
 export type PnpmOutdatedResultJson = Record<string, PnpmVersionOverview>;


### PR DESCRIPTION
This bug surfaced in CI when a pull request removed a dependency. 

The Code PushUp GitHub Action installs dependencies for the PR branch, which no longer includes the removed package in `node_modules`. When the action switches to the base branch for comparison, it does not reinstall dependencies. The base branch's `package.json` still references the removed dependency, so `pnpm outdated --json` reports it but without a current field since the package is not in `node_modules`.

<details>
<summary>Example</summary>
<img width="287" height="87" src="https://github.com/user-attachments/assets/f3cfcf1b-3124-460a-832b-c09379bed9ff" />
</details>

The plugin then crashes when calling `semver.clean(undefined)` on the missing `current` value.