### PR TITLE
refactor: fix lighthouse text styling

### DIFF
--- a/packages/plugin-lighthouse/src/lib/runner/runner.unit.test.ts
+++ b/packages/plugin-lighthouse/src/lib/runner/runner.unit.test.ts
@@ -199,7 +199,7 @@ describe('createRunnerFunction', () => {
     );
 
     expect(logger.warn).toHaveBeenCalledWith(
-      `Lighthouse did not produce a result for URL: ${ansis.underline.blueBright('fail')}`,
+      `Lighthouse did not produce a result for URL: ${ansis.blueBright('fail')}`,
     );
   });
 


### PR DESCRIPTION
This PR fixes a bug that slipped into master.

See: https://github.com/code-pushup/cli/blob/f20b3b879cd3b12727332d8a11a6e0fd05586748/packages/utils/src/lib/text-formats/ascii/link.ts#L4

In the jobs only the main branch fails. https://github.com/code-pushup/cli/actions/runs/19903612406/job/57053902389?pr=1165