### PR TITLE
test(plugin-lighthouse): fix test assertion link style change

### DIFF
--- a/packages/plugin-lighthouse/src/lib/runner/runner.unit.test.ts
+++ b/packages/plugin-lighthouse/src/lib/runner/runner.unit.test.ts
@@ -199,7 +199,7 @@ describe('createRunnerFunction', () => {
     );
 
     expect(logger.warn).toHaveBeenCalledWith(
-      `Lighthouse did not produce a result for URL: ${ansis.underline.blueBright('fail')}`,
+      `Lighthouse did not produce a result for URL: ${ansis.blueBright('fail')}`,
     );
   });
 


### PR DESCRIPTION
A [broken test](https://github.com/code-pushup/cli/actions/runs/19898755491/job/57036255399#step:6:750) was merged in #1164. Weirdly, the CI didn't catch it, [remote cache](https://github.com/code-pushup/cli/actions/runs/19897056872/job/57031841237#step:6:560) was used when it should've been invalidated :grimacing: 

The Code PushUp jobs in this PR are failing in the `main` branch because of the broken test.