### PR TITLE
test(nx-plugin-e2e): fix print-config tests after output argument made required

### DIFF
--- a/e2e/nx-plugin-e2e/tests/executor-cli.e2e.test.ts
+++ b/e2e/nx-plugin-e2e/tests/executor-cli.e2e.test.ts
@@ -100,25 +100,6 @@ describe('executor command', () => {
     expect(cleanStdout).toContain('nx run my-lib:code-pushup');
   });
 
-  it('should execute print-config executor', async () => {
-    const cwd = path.join(testFileDir, 'execute-print-config-command');
-    await addTargetToWorkspace(tree, { cwd, project });
-
-    const { stdout, code } = await executeProcess({
-      command: 'npx',
-      args: ['nx', 'run', `${project}:code-pushup`, 'print-config'],
-      cwd,
-    });
-
-    expect(code).toBe(0);
-    const cleanStdout = removeColorCodes(stdout);
-    expect(cleanStdout).toContain('nx run my-lib:code-pushup print-config');
-
-    await expect(() =>
-      readJsonFile(path.join(cwd, '.code-pushup', project, 'report.json')),
-    ).rejects.toThrow('');
-  });
-
   it('should execute print-config executor with output', async () => {
     const cwd = path.join(testFileDir, 'execute-print-config-command');
     await addTargetToWorkspace(tree, { cwd, project });
@@ -142,32 +123,6 @@ describe('executor command', () => {
     await expect(
       readJsonFile(path.join(cwd, 'code-pushup.config.json')),
     ).resolves.not.toThrow();
-  });
-
-  it('should execute print-config executor with api key', async () => {
-    const cwd = path.join(testFileDir, 'execute-print-config-command');
-    await addTargetToWorkspace(tree, { cwd, project });
-
-    const { stdout, code } = await executeProcess({
-      command: 'npx',
-      args: [
-        'nx',
-        'run',
-        `${project}:code-pushup`,
-        'print-config',
-        '--upload.apiKey=a123a',
-      ],
-      cwd,
-    });
-
-    expect(code).toBe(0);
-    const cleanStdout = removeColorCodes(stdout);
-    expect(cleanStdout).toContain('nx run my-lib:code-pushup print-config');
-    expect(cleanStdout).toContain('a123a');
-
-    await expect(() =>
-      readJsonFile(path.join(cwd, '.code-pushup', project, 'report.json')),
-    ).rejects.toThrow('');
   });
 
   it('should execute collect executor and merge target and command-line options', async () => {


### PR DESCRIPTION
Fixes [failing E2E test](https://github.com/code-pushup/cli/actions/runs/20057444745/job/57525914405#step:6:735) after `print-config`'s `--output` argument was made mandatory in #1174.