### PR TITLE
feat(plugin-js-packages): log initializer and runner steps

### DIFF
--- a/packages/plugin-js-packages/package.json
+++ b/packages/plugin-js-packages/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "@code-pushup/models": "0.97.0",
     "@code-pushup/utils": "0.97.0",
+    "ansis": "^3.3.2",
     "build-md": "^0.4.1",
     "semver": "^7.6.0",
     "zod": "^4.0.5"

--- a/packages/plugin-js-packages/src/lib/constants.ts
+++ b/packages/plugin-js-packages/src/lib/constants.ts
@@ -2,6 +2,9 @@ import type { IssueSeverity } from '@code-pushup/models';
 import type { DependencyGroup, PackageAuditLevel } from './config.js';
 import type { DependencyGroupLong } from './runner/outdated/types.js';
 
+export const JS_PACKAGES_PLUGIN_SLUG = 'js-packages';
+export const JS_PACKAGES_PLUGIN_TITLE = 'JS packages';
+
 export const defaultAuditLevelMapping: Record<
   PackageAuditLevel,
   IssueSeverity

--- a/packages/plugin-js-packages/src/lib/format.ts
+++ b/packages/plugin-js-packages/src/lib/format.ts
@@ -1,0 +1,4 @@
+import { pluginMetaLogFormatter } from '@code-pushup/utils';
+import { JS_PACKAGES_PLUGIN_TITLE } from './constants.js';
+
+export const formatMetaLog = pluginMetaLogFormatter(JS_PACKAGES_PLUGIN_TITLE);

--- a/packages/plugin-js-packages/src/lib/js-packages-plugin.ts
+++ b/packages/plugin-js-packages/src/lib/js-packages-plugin.ts
@@ -1,5 +1,7 @@
+import ansis from 'ansis';
 import { createRequire } from 'node:module';
 import type { Audit, Group, PluginConfig } from '@code-pushup/models';
+import { logger, pluralizeToken } from '@code-pushup/utils';
 import {
   type DependencyGroup,
   type JSPackagesPluginConfig,
@@ -7,7 +9,13 @@ import {
   type PackageManagerId,
   dependencyGroups,
 } from './config.js';
-import { dependencyDocs, dependencyGroupWeights } from './constants.js';
+import {
+  JS_PACKAGES_PLUGIN_SLUG,
+  JS_PACKAGES_PLUGIN_TITLE,
+  dependencyDocs,
+  dependencyGroupWeights,
+} from './constants.js';
+import { formatMetaLog } from './format.js';
 import { packageManagers } from './package-managers/package-managers.js';
 import { createRunnerFunction } from './runner/runner.js';
 import { normalizeConfig } from './utils.js';
@@ -44,17 +52,26 @@ export async function jsPackagesPlugin(
     '../../package.json',
   ) as typeof import('../../package.json');
 
+  const audits = createAudits(packageManager.slug, checks, depGroups);
+  const groups = createGroups(packageManager.slug, checks, depGroups);
+
+  logger.info(
+    formatMetaLog(
+      `Created ${pluralizeToken('audit', audits.length)} and ${pluralizeToken('group', groups.length)} for ${ansis.bold(packageManager.name)} package manager`,
+    ),
+  );
+
   return {
-    slug: 'js-packages',
-    title: 'JS Packages',
+    slug: JS_PACKAGES_PLUGIN_SLUG,
+    title: JS_PACKAGES_PLUGIN_TITLE,
     icon: packageManager.icon,
     description:
       'This plugin runs audit to uncover vulnerabilities and lists outdated dependencies. It supports npm, yarn classic, yarn modern, and pnpm package managers.',
     docsUrl: packageManager.docs.homepage,
     packageName: packageJson.name,
     version: packageJson.version,
-    audits: createAudits(packageManager.slug, checks, depGroups),
-    groups: createGroups(packageManager.slug, checks, depGroups),
+    audits,
+    groups,
     runner: createRunnerFunction({
       ...jsPackagesPluginConfigRest,
       checks,

--- a/packages/plugin-js-packages/src/lib/js-packages-plugin.unit.test.ts
+++ b/packages/plugin-js-packages/src/lib/js-packages-plugin.unit.test.ts
@@ -23,7 +23,7 @@ describe('jsPackagesPlugin', () => {
     await expect(jsPackagesPlugin()).resolves.toStrictEqual(
       expect.objectContaining({
         slug: 'js-packages',
-        title: 'JS Packages',
+        title: 'JS packages',
         audits: expect.arrayContaining([
           expect.objectContaining({ slug: 'npm-audit-prod' }),
           expect.objectContaining({ slug: 'npm-audit-dev' }),
@@ -49,7 +49,7 @@ describe('jsPackagesPlugin', () => {
     ).resolves.toStrictEqual(
       expect.objectContaining({
         slug: 'js-packages',
-        title: 'JS Packages',
+        title: 'JS packages',
         audits: expect.any(Array),
         groups: expect.any(Array),
         runner: expect.any(Function),

--- a/packages/plugin-js-packages/src/lib/package-managers/derive-package-manager.ts
+++ b/packages/plugin-js-packages/src/lib/package-managers/derive-package-manager.ts
@@ -1,8 +1,10 @@
 import { readFile } from 'node:fs/promises';
 import path from 'node:path';
-import { fileExists } from '@code-pushup/utils';
+import { fileExists, logger } from '@code-pushup/utils';
 import type { PackageManagerId } from '../config.js';
+import { formatMetaLog } from '../format.js';
 import { deriveYarnVersion } from './derive-yarn.js';
+import { packageManagers } from './package-managers.js';
 
 export async function derivePackageManagerInPackageJson(
   currentDir = process.cwd(),
@@ -35,22 +37,44 @@ export async function derivePackageManager(
   const pkgManagerFromPackageJson =
     await derivePackageManagerInPackageJson(currentDir);
   if (pkgManagerFromPackageJson) {
+    logDerivedPackageManager(
+      pkgManagerFromPackageJson,
+      'packageManager field in package.json',
+    );
     return pkgManagerFromPackageJson;
   }
 
   // Check for lock files
   if (await fileExists(path.join(currentDir, 'package-lock.json'))) {
+    logDerivedPackageManager('npm', 'existence of package-lock.json file');
     return 'npm';
   } else if (await fileExists(path.join(currentDir, 'pnpm-lock.yaml'))) {
+    logDerivedPackageManager('pnpm', 'existence of pnpm-lock.yaml file');
     return 'pnpm';
   } else if (await fileExists(path.join(currentDir, 'yarn.lock'))) {
     const yarnVersion = await deriveYarnVersion();
     if (yarnVersion) {
+      logDerivedPackageManager(
+        yarnVersion,
+        'existence of yarn.lock file and yarn -v command',
+      );
       return yarnVersion;
     }
   }
 
   throw new Error(
     'Could not detect package manager. Please provide it in the js-packages plugin config.',
+  );
+}
+
+function logDerivedPackageManager(
+  id: PackageManagerId,
+  sourceDescription: string,
+): void {
+  const pm = packageManagers[id];
+  logger.info(
+    formatMetaLog(
+      `Inferred ${pm.name} package manager from ${sourceDescription}`,
+    ),
   );
 }

--- a/packages/plugin-js-packages/src/lib/package-managers/npm/npm.ts
+++ b/packages/plugin-js-packages/src/lib/package-managers/npm/npm.ts
@@ -13,7 +13,7 @@ const npmDependencyOptions: Record<DependencyGroup, string[]> = {
 
 export const npmPackageManager: PackageManager = {
   slug: 'npm',
-  name: 'NPM',
+  name: 'npm',
   command: 'npm',
   icon: 'npm',
   docs: {

--- a/packages/plugin-js-packages/src/lib/package-managers/yarn-modern/yarn-modern.ts
+++ b/packages/plugin-js-packages/src/lib/package-managers/yarn-modern/yarn-modern.ts
@@ -13,7 +13,7 @@ const yarnModernEnvironmentOptions: Record<DependencyGroup, string> = {
 
 export const yarnModernPackageManager: PackageManager = {
   slug: 'yarn-modern',
-  name: 'yarn-modern',
+  name: 'Yarn v2+',
   command: 'yarn',
   icon: 'yarn',
   docs: {

--- a/packages/plugin-js-packages/src/lib/utils.unit.test.ts
+++ b/packages/plugin-js-packages/src/lib/utils.unit.test.ts
@@ -23,7 +23,7 @@ describe('normalizeConfig', () => {
   });
 
   it('should throw if no package manager is detected', async () => {
-    await expect(normalizeConfig()).rejects.toThrow(
+    await expect(normalizeConfig(undefined)).rejects.toThrow(
       'Could not detect package manager. Please provide it in the js-packages plugin config.',
     );
   });
@@ -36,7 +36,7 @@ describe('normalizeConfig', () => {
         packageManager: expect.objectContaining({
           slug: 'npm',
           command: 'npm',
-          name: 'NPM',
+          name: 'npm',
         }),
       }),
     );
@@ -64,7 +64,7 @@ describe('normalizeConfig', () => {
         packageManager: expect.objectContaining({
           slug: 'yarn-modern',
           command: 'yarn',
-          name: 'yarn-modern',
+          name: 'Yarn v2+',
         }),
       }),
     );


### PR DESCRIPTION
Part of #888. Improves logs from the _JS packages_ plugin.

## Examples

### non-verbose

<img width="1184" height="554" alt="image" src="https://github.com/user-attachments/assets/0f0761ad-8d8c-49dc-ac93-5d9f485c600e" />

[screen-capture (8).webm](https://github.com/user-attachments/assets/a948c185-c252-4176-abc1-9444e3e39c6a)

### verbose

<img width="1184" height="893" alt="image" src="https://github.com/user-attachments/assets/59fda8c9-754b-47ce-80d1-339d61eae10a" />
