### PR TITLE
feat(plugin-typescript): log initializer and runner steps

### DIFF
--- a/packages/plugin-typescript/src/lib/constants.ts
+++ b/packages/plugin-typescript/src/lib/constants.ts
@@ -4,6 +4,8 @@ import { TS_CODE_RANGE_NAMES } from './runner/ts-error-codes.js';
 import type { AuditSlug } from './types.js';
 
 export const TYPESCRIPT_PLUGIN_SLUG = 'typescript';
+export const TYPESCRIPT_PLUGIN_TITLE = 'TypeScript';
+
 export const DEFAULT_TS_CONFIG = 'tsconfig.json';
 
 const AUDIT_DESCRIPTIONS: Record<AuditSlug, string> = {

--- a/packages/plugin-typescript/src/lib/format.ts
+++ b/packages/plugin-typescript/src/lib/format.ts
@@ -1,0 +1,4 @@
+import { pluginMetaLogFormatter } from '@code-pushup/utils';
+import { TYPESCRIPT_PLUGIN_TITLE } from './constants.js';
+
+export const formatMetaLog = pluginMetaLogFormatter(TYPESCRIPT_PLUGIN_TITLE);

--- a/packages/plugin-typescript/src/lib/runner/runner.int.test.ts
+++ b/packages/plugin-typescript/src/lib/runner/runner.int.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect } from 'vitest';
-import type { AuditOutputs } from '@code-pushup/models';
+import { type AuditOutputs, DEFAULT_PERSIST_CONFIG } from '@code-pushup/models';
 import { osAgnosticAuditOutputs } from '@code-pushup/test-utils';
 import { getAudits } from '../utils.js';
 import { createRunnerFunction } from './runner.js';
@@ -12,7 +12,7 @@ describe('createRunnerFunction', () => {
       expectedAudits: getAudits(),
     });
 
-    const result = await runnerFunction();
+    const result = await runnerFunction({ persist: DEFAULT_PERSIST_CONFIG });
 
     expect(osAgnosticAuditOutputs(result as AuditOutputs)).toMatchSnapshot();
   }, 35_000);

--- a/packages/plugin-typescript/src/lib/runner/runner.unit.test.ts
+++ b/packages/plugin-typescript/src/lib/runner/runner.unit.test.ts
@@ -4,7 +4,11 @@ import {
   type SourceFile,
 } from 'typescript';
 import { beforeEach, describe, expect } from 'vitest';
-import { auditOutputsSchema } from '@code-pushup/models';
+import {
+  DEFAULT_PERSIST_CONFIG,
+  type RunnerArgs,
+  auditOutputsSchema,
+} from '@code-pushup/models';
 import { createRunnerFunction } from './runner.js';
 import * as runnerModule from './ts-runner.js';
 import * as utilsModule from './utils.js';
@@ -19,6 +23,8 @@ describe('createRunnerFunction', () => {
     utilsModule,
     'getIssueFromDiagnostic',
   );
+
+  const runnerArgs: RunnerArgs = { persist: DEFAULT_PERSIST_CONFIG };
 
   const semanticTsCode = 2322;
   const mockSemanticDiagnostic = {
@@ -47,51 +53,51 @@ describe('createRunnerFunction', () => {
     getTypeScriptDiagnosticsSpy.mockReset();
   });
 
-  it('should return empty array if no diagnostics are found', async () => {
-    getTypeScriptDiagnosticsSpy.mockResolvedValue([]);
+  it('should return empty array if no diagnostics are found', () => {
+    getTypeScriptDiagnosticsSpy.mockReturnValue([]);
     const runner = createRunnerFunction({
       tsconfig: 'tsconfig.json',
       expectedAudits: [],
     });
-    await expect(runner(() => void 0)).resolves.toStrictEqual([]);
+    expect(runner(runnerArgs)).toStrictEqual([]);
   });
 
-  it('should return empty array if no supported diagnostics are found', async () => {
-    getTypeScriptDiagnosticsSpy.mockResolvedValue([mockSemanticDiagnostic]);
+  it('should return empty array if no supported diagnostics are found', () => {
+    getTypeScriptDiagnosticsSpy.mockReturnValue([mockSemanticDiagnostic]);
     const runner = createRunnerFunction({
       tsconfig: 'tsconfig.json',
       expectedAudits: [],
     });
-    await expect(runner(() => void 0)).resolves.toStrictEqual([]);
+    expect(runner(runnerArgs)).toStrictEqual([]);
   });
 
-  it('should pass the diagnostic code to tsCodeToSlug', async () => {
-    getTypeScriptDiagnosticsSpy.mockResolvedValue([mockSemanticDiagnostic]);
+  it('should pass the diagnostic code to tsCodeToSlug', () => {
+    getTypeScriptDiagnosticsSpy.mockReturnValue([mockSemanticDiagnostic]);
     const runner = createRunnerFunction({
       tsconfig: 'tsconfig.json',
       expectedAudits: [],
     });
-    await expect(runner(() => void 0)).resolves.toStrictEqual([]);
+    expect(runner(runnerArgs)).toStrictEqual([]);
     expect(tSCodeToAuditSlugSpy).toHaveBeenCalledTimes(1);
     expect(tSCodeToAuditSlugSpy).toHaveBeenCalledWith(semanticTsCode);
   });
 
-  it('should pass the diagnostic to getIssueFromDiagnostic', async () => {
-    getTypeScriptDiagnosticsSpy.mockResolvedValue([mockSemanticDiagnostic]);
+  it('should pass the diagnostic to getIssueFromDiagnostic', () => {
+    getTypeScriptDiagnosticsSpy.mockReturnValue([mockSemanticDiagnostic]);
     const runner = createRunnerFunction({
       tsconfig: 'tsconfig.json',
       expectedAudits: [],
     });
-    await expect(runner(() => void 0)).resolves.toStrictEqual([]);
+    expect(runner(runnerArgs)).toStrictEqual([]);
     expect(getIssueFromDiagnosticSpy).toHaveBeenCalledTimes(1);
     expect(getIssueFromDiagnosticSpy).toHaveBeenCalledWith(
       mockSemanticDiagnostic,
     );
   });
 
-  it('should return multiple issues per audit', async () => {
+  it('should return multiple issues per audit', () => {
     const code = 2222;
-    getTypeScriptDiagnosticsSpy.mockResolvedValue([
+    getTypeScriptDiagnosticsSpy.mockReturnValue([
       mockSemanticDiagnostic,
       {
         ...mockSemanticDiagnostic,
@@ -104,7 +110,7 @@ describe('createRunnerFunction', () => {
       expectedAudits: [{ slug: 'semantic-errors' }],
     });
 
-    const auditOutputs = await runner(() => void 0);
+    const auditOutputs = runner(runnerArgs);
     expect(auditOutputs).toStrictEqual([
       {
         slug: 'semantic-errors',
@@ -126,8 +132,8 @@ describe('createRunnerFunction', () => {
     expect(() => auditOutputsSchema.parse(auditOutputs)).not.toThrow();
   });
 
-  it('should return multiple audits', async () => {
-    getTypeScriptDiagnosticsSpy.mockResolvedValue([
+  it('should return multiple audits', () => {
+    getTypeScriptDiagnosticsSpy.mockReturnValue([
       mockSyntacticDiagnostic,
       mockSemanticDiagnostic,
     ]);
@@ -136,7 +142,7 @@ describe('createRunnerFunction', () => {
       expectedAudits: [{ slug: 'semantic-errors' }, { slug: 'syntax-errors' }],
     });
 
-    const auditOutputs = await runner(() => void 0);
+    const auditOutputs = runner(runnerArgs);
     expect(auditOutputs).toStrictEqual([
       expect.objectContaining({
         slug: 'semantic-errors',
@@ -159,8 +165,8 @@ describe('createRunnerFunction', () => {
     ]);
   });
 
-  it('should return valid AuditOutput shape', async () => {
-    getTypeScriptDiagnosticsSpy.mockResolvedValue([
+  it('should return valid AuditOutput shape', () => {
+    getTypeScriptDiagnosticsSpy.mockReturnValue([
       mockSyntacticDiagnostic,
       {
         ...mockSyntacticDiagnostic,
@@ -178,7 +184,7 @@ describe('createRunnerFunction', () => {
       tsconfig: 'tsconfig.json',
       expectedAudits: [{ slug: 'semantic-errors' }, { slug: 'syntax-errors' }],
     });
-    const auditOutputs = await runner(() => void 0);
+    const auditOutputs = runner(runnerArgs);
     expect(() => auditOutputsSchema.parse(auditOutputs)).not.toThrow();
   });
 });

--- a/packages/plugin-typescript/src/lib/runner/ts-runner.int.test.ts
+++ b/packages/plugin-typescript/src/lib/runner/ts-runner.int.test.ts
@@ -2,12 +2,12 @@ import { describe, expect } from 'vitest';
 import { getTypeScriptDiagnostics } from './ts-runner.js';
 
 describe('getTypeScriptDiagnostics', () => {
-  it('should return valid diagnostics', async () => {
-    await expect(
+  it('should return valid diagnostics', () => {
+    expect(
       getTypeScriptDiagnostics({
         tsconfig:
           'packages/plugin-typescript/mocks/fixtures/basic-setup/tsconfig.json',
       }),
-    ).resolves.toHaveLength(8);
+    ).toHaveLength(8);
   });
 });

--- a/packages/plugin-typescript/src/lib/runner/ts-runner.ts
+++ b/packages/plugin-typescript/src/lib/runner/ts-runner.ts
@@ -3,23 +3,30 @@ import {
   createProgram,
   getPreEmitDiagnostics,
 } from 'typescript';
-import { stringifyError } from '@code-pushup/utils';
+import { logger, pluralizeToken, stringifyError } from '@code-pushup/utils';
 import { loadTargetConfig } from './utils.js';
 
 export type DiagnosticsOptions = {
   tsconfig: string;
 };
 
-export async function getTypeScriptDiagnostics({
+export function getTypeScriptDiagnostics({
   tsconfig,
-}: DiagnosticsOptions): Promise<readonly Diagnostic[]> {
+}: DiagnosticsOptions): readonly Diagnostic[] {
   const { fileNames, options } = loadTargetConfig(tsconfig);
+  logger.info(
+    `Parsed TypeScript config file ${tsconfig}, program includes ${pluralizeToken('file', fileNames.length)}`,
+  );
   try {
     const program = createProgram(fileNames, options);
-    return getPreEmitDiagnostics(program);
+    const diagnostics = getPreEmitDiagnostics(program);
+    logger.info(
+      `TypeScript compiler found ${pluralizeToken('diagnostic', diagnostics.length)}`,
+    );
+    return diagnostics;
   } catch (error) {
     throw new Error(
-      `Can't create TS program in getDiagnostics. \n ${stringifyError(error)}`,
+      `Can't create TS program and get diagnostics.\n${stringifyError(error)}`,
     );
   }
 }

--- a/packages/plugin-typescript/src/lib/runner/utils.ts
+++ b/packages/plugin-typescript/src/lib/runner/utils.ts
@@ -14,7 +14,7 @@ import type { CodeRangeName } from './types.js';
 
 /**
  * Transform the TypeScript error code to the audit slug.
- * @param code - The TypeScript error code.
+ * @param code The TypeScript error code.
  * @returns The audit slug.
  * @throws Error if the code is not supported.
  */
@@ -31,7 +31,7 @@ export function tsCodeToAuditSlug(code: number): CodeRangeName {
  * - ts.DiagnosticCategory.Error (2)
  * - ts.DiagnosticCategory.Suggestion (3)
  * - ts.DiagnosticCategory.Message (4)
- * @param category - The TypeScript diagnostic category.
+ * @param category The TypeScript diagnostic category.
  * @returns The severity of the issue.
  */
 export function getSeverity(category: DiagnosticCategory): Issue['severity'] {
@@ -47,7 +47,7 @@ export function getSeverity(category: DiagnosticCategory): Issue['severity'] {
 
 /**
  * Format issue message from the TypeScript diagnostic.
- * @param diag - The TypeScript diagnostic.
+ * @param diag The TypeScript diagnostic.
  * @returns The issue message.
  */
 export function getMessage(diag: Diagnostic): string {
@@ -60,7 +60,7 @@ export function getMessage(diag: Diagnostic): string {
 
 /**
  * Get the issue from the TypeScript diagnostic.
- * @param diag - The TypeScript diagnostic.
+ * @param diag The TypeScript diagnostic.
  * @returns The issue.
  * @throws Error if the diagnostic is global (e.g., invalid compiler option).
  */
@@ -84,13 +84,7 @@ export function getIssueFromDiagnostic(diag: Diagnostic) {
     ...issue,
     source: {
       file: path.relative(process.cwd(), diag.file.fileName),
-      ...(startLine
-        ? {
-            position: {
-              startLine,
-            },
-          }
-        : {}),
+      ...(startLine ? { position: { startLine } } : {}),
     },
   } satisfies Issue;
 }

--- a/packages/plugin-typescript/src/lib/typescript-plugin.ts
+++ b/packages/plugin-typescript/src/lib/typescript-plugin.ts
@@ -1,14 +1,18 @@
 import { createRequire } from 'node:module';
 import { type PluginConfig, validate } from '@code-pushup/models';
 import { stringifyError } from '@code-pushup/utils';
-import { DEFAULT_TS_CONFIG, TYPESCRIPT_PLUGIN_SLUG } from './constants.js';
+import {
+  DEFAULT_TS_CONFIG,
+  TYPESCRIPT_PLUGIN_SLUG,
+  TYPESCRIPT_PLUGIN_TITLE,
+} from './constants.js';
 import { createRunnerFunction } from './runner/runner.js';
 import {
   type TypescriptPluginConfig,
   type TypescriptPluginOptions,
   typescriptPluginConfigSchema,
 } from './schema.js';
-import { getAudits, getGroups, logSkippedAudits } from './utils.js';
+import { getAudits, getGroups, logAuditsAndGroups } from './utils.js';
 
 const packageJson = createRequire(import.meta.url)(
   '../../package.json',
@@ -23,24 +27,24 @@ export function typescriptPlugin(
     scoreTargets,
   } = parseOptions(options ?? {});
 
-  const filteredAudits = getAudits({ onlyAudits });
-  const filteredGroups = getGroups({ onlyAudits });
+  const audits = getAudits({ onlyAudits });
+  const groups = getGroups({ onlyAudits });
 
-  logSkippedAudits(filteredAudits);
+  logAuditsAndGroups(audits, groups);
 
   return {
     slug: TYPESCRIPT_PLUGIN_SLUG,
-    packageName: packageJson.name,
-    version: packageJson.version,
-    title: 'TypeScript',
+    title: TYPESCRIPT_PLUGIN_TITLE,
+    icon: 'typescript',
     description: 'Official Code PushUp TypeScript plugin.',
     docsUrl: 'https://www.npmjs.com/package/@code-pushup/typescript-plugin/',
-    icon: 'typescript',
-    audits: filteredAudits,
-    groups: filteredGroups,
+    packageName: packageJson.name,
+    version: packageJson.version,
+    audits,
+    groups,
     runner: createRunnerFunction({
       tsconfig,
-      expectedAudits: filteredAudits,
+      expectedAudits: audits,
     }),
     ...(scoreTargets && { scoreTargets }),
   };

--- a/packages/plugin-typescript/src/lib/utils.ts
+++ b/packages/plugin-typescript/src/lib/utils.ts
@@ -1,7 +1,17 @@
 import type { CompilerOptions } from 'typescript';
-import type { Audit, CategoryConfig, CategoryRef } from '@code-pushup/models';
-import { kebabCaseToCamelCase, logger } from '@code-pushup/utils';
+import type {
+  Audit,
+  CategoryConfig,
+  CategoryRef,
+  Group,
+} from '@code-pushup/models';
+import {
+  kebabCaseToCamelCase,
+  logger,
+  pluralizeToken,
+} from '@code-pushup/utils';
 import { AUDITS, GROUPS, TYPESCRIPT_PLUGIN_SLUG } from './constants.js';
+import { formatMetaLog } from './format.js';
 import type {
   TypescriptPluginConfig,
   TypescriptPluginOptions,
@@ -141,11 +151,29 @@ export function getCategories() {
   return Object.values(CATEGORY_MAP);
 }
 
-export function logSkippedAudits(audits: Audit[]) {
+export function logAuditsAndGroups(audits: Audit[], groups: Group[]) {
+  logger.info(
+    formatMetaLog(
+      `Created ${pluralizeToken('audit', audits.length)} and ${pluralizeToken('group', groups.length)}`,
+    ),
+  );
   const skippedAudits = AUDITS.filter(
-    audit => !audits.some(filtered => filtered.slug === audit.slug),
-  ).map(audit => kebabCaseToCamelCase(audit.slug));
+    audit => !audits.some(({ slug }) => slug === audit.slug),
+  );
+  const skippedGroups = GROUPS.filter(
+    group => !groups.some(({ slug }) => slug === group.slug),
+  );
   if (skippedAudits.length > 0) {
-    logger.info(`Skipped audits: [${skippedAudits.join(', ')}]`);
+    logger.info(
+      formatMetaLog(
+        [
+          `Skipped ${pluralizeToken('audit', skippedAudits.length)}`,
+          skippedGroups.length > 0 &&
+            pluralizeToken('group', skippedGroups.length),
+        ]
+          .filter(Boolean)
+          .join(' and '),
+      ),
+    );
   }
 }


### PR DESCRIPTION
Part of #888. Improves logs in the _TypeScript_ plugin.

## Examples

### non-verbose

<img width="1129" height="770" alt="image" src="https://github.com/user-attachments/assets/01839911-463c-4467-ba44-90cfa8654ce1" />

### verbose

<img width="1129" height="200" alt="image" src="https://github.com/user-attachments/assets/d3a3f994-d7be-4328-9ed4-8d4378c82b5f" />
