### PR TITLE
feat(plugin-jsdocs): log initializer and runner steps

### DIFF
--- a/code-pushup.preset.ts
+++ b/code-pushup.preset.ts
@@ -16,10 +16,6 @@ import eslintPlugin, {
 import jsPackagesPlugin from './packages/plugin-js-packages/src/index.js';
 import jsDocsPlugin from './packages/plugin-jsdocs/src/index.js';
 import {
-  PLUGIN_SLUG,
-  groups,
-} from './packages/plugin-jsdocs/src/lib/constants.js';
-import {
   lighthouseCategories,
   lighthouseGroupRef,
   lighthousePlugin,
@@ -185,12 +181,14 @@ export function configureJsDocsPlugin(projectName?: string): CoreConfig {
         slug: 'docs',
         title: 'Documentation',
         description: 'Measures how much of your code is **documented**.',
-        refs: groups.map(group => ({
-          weight: 1,
-          type: 'group',
-          plugin: PLUGIN_SLUG,
-          slug: group.slug,
-        })),
+        refs: [
+          {
+            type: 'group',
+            plugin: 'jsdocs',
+            slug: 'documentation-coverage',
+            weight: 1,
+          },
+        ],
       },
     ],
   };

--- a/e2e/plugin-jsdocs-e2e/tests/__snapshots__/collect.e2e.test.ts.snap
+++ b/e2e/plugin-jsdocs-e2e/tests/__snapshots__/collect.e2e.test.ts.snap
@@ -567,7 +567,7 @@ exports[`PLUGIN collect report with jsdocs-plugin NPM package > should run JSDoc
       ],
       "icon": "folder-docs",
       "slug": "jsdocs",
-      "title": "JSDoc coverage",
+      "title": "JSDocs coverage",
     },
   ],
 }

--- a/packages/plugin-coverage/src/lib/runner/lcov/lcov-runner.ts
+++ b/packages/plugin-coverage/src/lib/runner/lcov/lcov-runner.ts
@@ -3,9 +3,11 @@ import type { LCOVRecord } from 'parse-lcov';
 import type { AuditOutputs, TableColumnObject } from '@code-pushup/models';
 import {
   type FileCoverage,
+  aggregateCoverageStats,
   capitalize,
   exists,
   formatAsciiTable,
+  formatCoveragePercentage,
   getGitRoot,
   logger,
   objectFromEntries,
@@ -210,7 +212,7 @@ function logLcovRecords(recordsPerReport: Record<string, LCOVRecord[]>): void {
           const stats: Record<CoverageType, string> = objectFromEntries(
             objectToEntries(groups).map(([type, files = []]) => [
               type,
-              formatCoverageSum(files),
+              formatCoveragePercentage(aggregateCoverageStats(files)),
             ]),
           );
           const report = truncatedPaths[idx] ?? reportPath;
@@ -220,25 +222,6 @@ function logLcovRecords(recordsPerReport: Record<string, LCOVRecord[]>): void {
     }),
   );
   logger.newline();
-}
-
-function formatCoverageSum(files: FileCoverage[]): string {
-  const { covered, total } = files.reduce<
-    Pick<FileCoverage, 'covered' | 'total'>
-  >(
-    (acc, file) => ({
-      covered: acc.covered + file.covered,
-      total: acc.total + file.total,
-    }),
-    { covered: 0, total: 0 },
-  );
-
-  if (total === 0) {
-    return 'n/a';
-  }
-
-  const percentage = (covered / total) * 100;
-  return `${percentage.toFixed(1)}%`;
 }
 
 function logMergedRecords(counts: { before: number; after: number }): void {

--- a/packages/plugin-jsdocs/src/lib/constants.ts
+++ b/packages/plugin-jsdocs/src/lib/constants.ts
@@ -2,6 +2,10 @@ import type { Audit, Group } from '@code-pushup/models';
 import type { AuditSlug } from './models.js';
 
 export const PLUGIN_SLUG = 'jsdocs';
+export const PLUGIN_TITLE = 'JSDocs coverage';
+export const PLUGIN_DESCRIPTION = 'Official Code PushUp JSDoc coverage plugin.';
+export const PLUGIN_DOCS_URL =
+  'https://www.npmjs.com/package/@code-pushup/jsdocs-plugin/';
 
 export const AUDITS_MAP: Record<AuditSlug, Audit> = {
   'classes-coverage': {
@@ -46,7 +50,7 @@ export const AUDITS_MAP: Record<AuditSlug, Audit> = {
   },
 } as const;
 
-export const groups: Group[] = [
+export const GROUPS: Group[] = [
   {
     slug: 'documentation-coverage',
     title: 'Documentation coverage',

--- a/packages/plugin-jsdocs/src/lib/format.ts
+++ b/packages/plugin-jsdocs/src/lib/format.ts
@@ -1,0 +1,4 @@
+import { pluginMetaLogFormatter } from '@code-pushup/utils';
+import { PLUGIN_TITLE } from './constants.js';
+
+export const formatMetaLog = pluginMetaLogFormatter(PLUGIN_TITLE);

--- a/packages/plugin-jsdocs/src/lib/jsdocs-plugin.ts
+++ b/packages/plugin-jsdocs/src/lib/jsdocs-plugin.ts
@@ -1,18 +1,18 @@
 import { type PluginConfig, validate } from '@code-pushup/models';
 import { type JsDocsPluginConfig, jsDocsPluginConfigSchema } from './config.js';
-import { PLUGIN_SLUG, groups } from './constants.js';
+import {
+  GROUPS,
+  PLUGIN_DESCRIPTION,
+  PLUGIN_DOCS_URL,
+  PLUGIN_SLUG,
+  PLUGIN_TITLE,
+} from './constants.js';
 import { createRunnerFunction } from './runner/runner.js';
 import {
   filterAuditsByPluginConfig,
   filterGroupsByOnlyAudits,
+  logAuditsAndGroups,
 } from './utils.js';
-
-export const PLUGIN_TITLE = 'JSDoc coverage';
-
-export const PLUGIN_DESCRIPTION = 'Official Code PushUp JSDoc coverage plugin.';
-
-export const PLUGIN_DOCS_URL =
-  'https://www.npmjs.com/package/@code-pushup/jsdocs-plugin/';
 
 /**
  * Instantiates Code PushUp documentation coverage plugin for core config.
@@ -34,14 +34,19 @@ export function jsDocsPlugin(config: JsDocsPluginConfig): PluginConfig {
   const jsDocsConfig = validate(jsDocsPluginConfigSchema, config);
   const scoreTargets = jsDocsConfig.scoreTargets;
 
+  const groups = filterGroupsByOnlyAudits(GROUPS, jsDocsConfig);
+  const audits = filterAuditsByPluginConfig(jsDocsConfig);
+
+  logAuditsAndGroups(audits, groups);
+
   return {
     slug: PLUGIN_SLUG,
     title: PLUGIN_TITLE,
     icon: 'folder-docs',
     description: PLUGIN_DESCRIPTION,
     docsUrl: PLUGIN_DOCS_URL,
-    groups: filterGroupsByOnlyAudits(groups, jsDocsConfig),
-    audits: filterAuditsByPluginConfig(jsDocsConfig),
+    groups,
+    audits,
     runner: createRunnerFunction(jsDocsConfig),
     ...(scoreTargets && { scoreTargets }),
   };

--- a/packages/plugin-jsdocs/src/lib/jsdocs-plugin.unit.test.ts
+++ b/packages/plugin-jsdocs/src/lib/jsdocs-plugin.unit.test.ts
@@ -1,19 +1,21 @@
 import { describe, expect, it, vi } from 'vitest';
 import { pluginConfigSchema } from '@code-pushup/models';
-import { PLUGIN_SLUG, groups } from './constants.js';
 import {
+  GROUPS,
   PLUGIN_DESCRIPTION,
   PLUGIN_DOCS_URL,
+  PLUGIN_SLUG,
   PLUGIN_TITLE,
-  jsDocsPlugin,
-} from './jsdocs-plugin.js';
+} from './constants.js';
+import { jsDocsPlugin } from './jsdocs-plugin.js';
 import { createRunnerFunction } from './runner/runner.js';
 import {
   filterAuditsByPluginConfig,
   filterGroupsByOnlyAudits,
 } from './utils.js';
 
-vi.mock('./utils.js', () => ({
+vi.mock('./utils.js', async () => ({
+  ...(await vi.importActual('./utils.js')),
   filterAuditsByPluginConfig: vi.fn().mockReturnValue([
     {
       slug: 'mock-audit',
@@ -69,7 +71,7 @@ describe('jsDocsPlugin', () => {
     const config = { patterns: ['src/**/*.ts'] };
     jsDocsPlugin(config);
 
-    expect(filterGroupsByOnlyAudits).toHaveBeenCalledWith(groups, config);
+    expect(filterGroupsByOnlyAudits).toHaveBeenCalledWith(GROUPS, config);
   });
 
   it('should filter audits', async () => {

--- a/packages/plugin-jsdocs/src/lib/runner/doc-processor.ts
+++ b/packages/plugin-jsdocs/src/lib/runner/doc-processor.ts
@@ -16,6 +16,8 @@ import type { CoverageType } from './models.js';
 import {
   createInitialCoverageTypesRecord,
   getCoverageTypeFromKind,
+  logReport,
+  logSourceFiles,
   singularCoverageType,
 } from './utils.js';
 
@@ -29,7 +31,7 @@ type Node = {
 
 /**
  * Gets the variables information from the variable statements
- * @param variableStatements - The variable statements to process
+ * @param variableStatements The variable statements to process
  * @returns The variables information with the right methods to get the information
  */
 export function getVariablesInformation(
@@ -54,7 +56,7 @@ export function getVariablesInformation(
 
 /**
  * Processes documentation coverage for TypeScript files in the specified path
- * @param config - The configuration object containing patterns to include for documentation analysis
+ * @param config The configuration object containing patterns to include for documentation analysis
  * @returns Object containing coverage statistics and undocumented items
  */
 export function processJsDocs(
@@ -62,7 +64,15 @@ export function processJsDocs(
 ): Record<CoverageType, FileCoverage[]> {
   const project = new Project();
   project.addSourceFilesAtPaths(config.patterns);
-  return getDocumentationReport(project.getSourceFiles());
+  const sourceFiles = project.getSourceFiles();
+
+  logSourceFiles(sourceFiles, config);
+
+  const report = getDocumentationReport(sourceFiles);
+
+  logReport(report);
+
+  return report;
 }
 
 export function getAllNodesFromASourceFile(sourceFile: SourceFile) {
@@ -80,7 +90,7 @@ export function getAllNodesFromASourceFile(sourceFile: SourceFile) {
 
 /**
  * Gets the documentation coverage report from the source files
- * @param sourceFiles - The source files to process
+ * @param sourceFiles The source files to process
  * @returns The documentation coverage report
  */
 export function getDocumentationReport(
@@ -101,8 +111,8 @@ export function getDocumentationReport(
 
 /**
  * Gets the coverage from all nodes of a file
- * @param nodes - The nodes to process
- * @param filePath - The file path where the nodes are located
+ * @param nodes The nodes to process
+ * @param filePath The file path where the nodes are located
  * @returns The coverage report for the nodes
  */
 function getCoverageFromAllNodesOfFile(nodes: Node[], filePath: string) {
@@ -145,7 +155,7 @@ function getCoverageFromAllNodesOfFile(nodes: Node[], filePath: string) {
 
 /**
  * Gets the nodes from a class
- * @param classNodes - The class nodes to process
+ * @param classNodes The class nodes to process
  * @returns The nodes from the class
  */
 export function getClassNodes(classNodes: ClassDeclaration[]) {

--- a/packages/plugin-jsdocs/src/lib/utils.ts
+++ b/packages/plugin-jsdocs/src/lib/utils.ts
@@ -1,6 +1,8 @@
 import type { Audit, Group } from '@code-pushup/models';
+import { logger, pluralizeToken } from '@code-pushup/utils';
 import type { JsDocsPluginTransformedConfig } from './config.js';
-import { AUDITS_MAP } from './constants.js';
+import { AUDITS_MAP, GROUPS } from './constants.js';
+import { formatMetaLog } from './format.js';
 
 /**
  * Get audits based on the configuration.
@@ -49,4 +51,31 @@ export function filterGroupsByOnlyAudits(
       ),
     }))
     .filter(group => group.refs.length > 0);
+}
+
+export function logAuditsAndGroups(audits: Audit[], groups: Group[]) {
+  logger.info(
+    formatMetaLog(
+      `Created ${pluralizeToken('audit', audits.length)} and ${pluralizeToken('group', groups.length)}`,
+    ),
+  );
+  const skippedAudits = Object.keys(AUDITS_MAP).filter(
+    slug => !audits.some(audit => audit.slug === slug),
+  );
+  const skippedGroups = GROUPS.filter(
+    group => !groups.some(({ slug }) => slug === group.slug),
+  );
+  if (skippedAudits.length > 0) {
+    logger.info(
+      formatMetaLog(
+        [
+          `Skipped ${pluralizeToken('audit', skippedAudits.length)}`,
+          skippedGroups.length > 0 &&
+            pluralizeToken('group', skippedGroups.length),
+        ]
+          .filter(Boolean)
+          .join(' and '),
+      ),
+    );
+  }
 }

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -9,7 +9,11 @@ export {
   uppercase,
 } from './lib/case-conversions.js';
 export { formatCommandStatus } from './lib/command.js';
-export { filesCoverageToTree, type FileCoverage } from './lib/coverage-tree.js';
+export {
+  filesCoverageToTree,
+  type FileCoverage,
+  aggregateCoverageStats,
+} from './lib/coverage-tree.js';
 export { createRunnerFiles } from './lib/create-runner-files.js';
 export { dateToUnixTimestamp } from './lib/dates.js';
 export { comparePairs, matchArrayItemsByKey, type Diff } from './lib/diff.js';
@@ -49,6 +53,7 @@ export {
 export { filterItemRefsBy } from './lib/filter.js';
 export {
   formatBytes,
+  formatCoveragePercentage,
   formatDuration,
   indentLines,
   pluginMetaLogFormatter,

--- a/packages/utils/src/lib/coverage-tree.ts
+++ b/packages/utils/src/lib/coverage-tree.ts
@@ -168,3 +168,13 @@ function sortCoverageTree(root: CoverageTreeNode): CoverageTreeNode {
       ),
   };
 }
+
+export function aggregateCoverageStats(files: CoverageStats[]): CoverageStats {
+  return files.reduce<CoverageStats>(
+    (acc, file) => ({
+      covered: acc.covered + file.covered,
+      total: acc.total + file.total,
+    }),
+    { covered: 0, total: 0 },
+  );
+}

--- a/packages/utils/src/lib/coverage-tree.unit.test.ts
+++ b/packages/utils/src/lib/coverage-tree.unit.test.ts
@@ -1,6 +1,10 @@
 import path from 'node:path';
 import type { CoverageTree } from '@code-pushup/models';
-import { type FileCoverage, filesCoverageToTree } from './coverage-tree.js';
+import {
+  type FileCoverage,
+  aggregateCoverageStats,
+  filesCoverageToTree,
+} from './coverage-tree.js';
 
 describe('filesCoverageToTree', () => {
   it('should convert list of files to folder structure', () => {
@@ -221,5 +225,19 @@ describe('filesCoverageToTree', () => {
         }),
       }),
     );
+  });
+});
+
+describe('aggregateCoverageStats', () => {
+  it('should sum covered and total counts from all files', () => {
+    expect(
+      aggregateCoverageStats([
+        { covered: 1, total: 5 },
+        { covered: 0, total: 3 },
+        { covered: 4, total: 4 },
+        { covered: 0, total: 0 },
+        { covered: 5, total: 8 },
+      ]),
+    ).toEqual({ covered: 10, total: 20 });
   });
 });

--- a/packages/utils/src/lib/formatting.ts
+++ b/packages/utils/src/lib/formatting.ts
@@ -182,3 +182,17 @@ export function pluginMetaLogFormatter(
       (line, idx) => `${idx === 0 ? prefix : padding} ${line}`,
     );
 }
+
+export function formatCoveragePercentage(stats: {
+  covered: number;
+  total: number;
+}): string {
+  const { covered, total } = stats;
+
+  if (total === 0) {
+    return '-';
+  }
+
+  const percentage = (covered / total) * 100;
+  return `${percentage.toFixed(1)}%`;
+}

--- a/packages/utils/src/lib/formatting.unit.test.ts
+++ b/packages/utils/src/lib/formatting.unit.test.ts
@@ -2,6 +2,7 @@ import ansis from 'ansis';
 import { describe, expect, it } from 'vitest';
 import {
   formatBytes,
+  formatCoveragePercentage,
   formatDate,
   formatDuration,
   indentLines,
@@ -294,5 +295,29 @@ describe('pluginMetaLogFormatter', () => {
            - Function coverage
 `.trim(),
     );
+  });
+});
+
+describe('formatCoveragePercentage', () => {
+  it('should render percentage', () => {
+    expect(formatCoveragePercentage({ covered: 125, total: 1000 })).toBe(
+      '12.5%',
+    );
+  });
+
+  it('should render max 1 decimal', () => {
+    expect(formatCoveragePercentage({ covered: 1, total: 3 })).toBe('33.3%');
+  });
+
+  it('should render at least 1 decimal', () => {
+    expect(formatCoveragePercentage({ covered: 0, total: 10 })).toBe('0.0%');
+  });
+
+  it('should round decimal up if appropriate', () => {
+    expect(formatCoveragePercentage({ covered: 2, total: 3 })).toBe('66.7%');
+  });
+
+  it('should not render invalid percentage', () => {
+    expect(formatCoveragePercentage({ covered: 0, total: 0 })).toBe('-');
   });
 });


### PR DESCRIPTION
Part of #888. Improves logs in the _JSDocs_ plugin.

## Examples

### non-verbose

<img width="1001" height="496" alt="image" src="https://github.com/user-attachments/assets/06ae13de-ca7c-4e88-8c5d-2a0c6ccebcb7" />

### verbose

<img width="1001" height="373" alt="image" src="https://github.com/user-attachments/assets/f6f1c4ea-daaf-4703-99bb-877722751493" />
