### PR TITLE
refactor(plugin-axe): omit URL from issues when analyzing single URL

### DIFF
--- a/e2e/plugin-axe-e2e/tests/__snapshots__/collect.e2e.test.ts.snap
+++ b/e2e/plugin-axe-e2e/tests/__snapshots__/collect.e2e.test.ts.snap
@@ -497,7 +497,7 @@ exports[`PLUGIN collect report with axe-plugin NPM package > should run plugin o
           "details": {
             "issues": [
               {
-                "message": "[\`body > button\`] Fix any of the following: Element does not have inner text that is visible to screen readers aria-label attribute does not exist or is empty aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty Element has no title attribute Element does not have an implicit (wrapped) <label> Element does not have an explicit <label> Element's default semantics were not overridden with role="none" or role="presentation" ([/<TEST_DIR>/index.html](file:///<TEST_DIR>/index.html))",
+                "message": "[\`body > button\`] Fix any of the following: Element does not have inner text that is visible to screen readers aria-label attribute does not exist or is empty aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty Element has no title attribute Element does not have an implicit (wrapped) <label> Element does not have an explicit <label> Element's default semantics were not overridden with role="none" or role="presentation"",
                 "severity": "error",
               },
             ],
@@ -523,7 +523,7 @@ exports[`PLUGIN collect report with axe-plugin NPM package > should run plugin o
           "details": {
             "issues": [
               {
-                "message": "[\`.low-contrast\`] Fix any of the following: Element has insufficient color contrast of 1.57 (foreground color: #777777, background color: #999999, font size: 12.0pt (16px), font weight: normal). Expected contrast ratio of 4.5:1 ([/<TEST_DIR>/index.html](file:///<TEST_DIR>/index.html))",
+                "message": "[\`.low-contrast\`] Fix any of the following: Element has insufficient color contrast of 1.57 (foreground color: #777777, background color: #999999, font size: 12.0pt (16px), font weight: normal). Expected contrast ratio of 4.5:1",
                 "severity": "error",
               },
             ],
@@ -612,7 +612,7 @@ exports[`PLUGIN collect report with axe-plugin NPM package > should run plugin o
           "details": {
             "issues": [
               {
-                "message": "[\`div[role="button"]\`] Fix any of the following: Invalid ARIA attribute name: aria-invalid-attribute ([/<TEST_DIR>/index.html](file:///<TEST_DIR>/index.html))",
+                "message": "[\`div[role="button"]\`] Fix any of the following: Invalid ARIA attribute name: aria-invalid-attribute",
                 "severity": "error",
               },
             ],
@@ -629,7 +629,7 @@ exports[`PLUGIN collect report with axe-plugin NPM package > should run plugin o
           "details": {
             "issues": [
               {
-                "message": "[\`img\`] Fix any of the following: Element does not have an alt attribute aria-label attribute does not exist or is empty aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty Element has no title attribute Element's default semantics were not overridden with role="none" or role="presentation" ([/<TEST_DIR>/index.html](file:///<TEST_DIR>/index.html))",
+                "message": "[\`img\`] Fix any of the following: Element does not have an alt attribute aria-label attribute does not exist or is empty aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty Element has no title attribute Element's default semantics were not overridden with role="none" or role="presentation"",
                 "severity": "error",
               },
             ],
@@ -646,7 +646,7 @@ exports[`PLUGIN collect report with axe-plugin NPM package > should run plugin o
           "details": {
             "issues": [
               {
-                "message": "[\`a\`] Fix all of the following: Element is in tab order and does not have accessible text Fix any of the following: Element does not have text that is visible to screen readers aria-label attribute does not exist or is empty aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty Element has no title attribute ([/<TEST_DIR>/index.html](file:///<TEST_DIR>/index.html))",
+                "message": "[\`a\`] Fix all of the following: Element is in tab order and does not have accessible text Fix any of the following: Element does not have text that is visible to screen readers aria-label attribute does not exist or is empty aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty Element has no title attribute",
                 "severity": "error",
               },
             ],

--- a/e2e/plugin-axe-e2e/tests/collect.e2e.test.ts
+++ b/e2e/plugin-axe-e2e/tests/collect.e2e.test.ts
@@ -11,16 +11,6 @@ import {
 } from '@code-pushup/test-utils';
 import { executeProcess, readJsonFile } from '@code-pushup/utils';
 
-function sanitizeReportPaths(report: Report): Report {
-  // Convert to JSON, replace paths, and parse back
-  const reportJson = JSON.stringify(report);
-  const sanitized = reportJson.replace(
-    /\/(?:[^/\s"]+\/)+index\.html/g,
-    '/<TEST_DIR>/index.html',
-  );
-  return JSON.parse(sanitized);
-}
-
 describe('PLUGIN collect report with axe-plugin NPM package', () => {
   const testFileDir = path.join(
     E2E_ENVIRONMENTS_DIR,
@@ -53,8 +43,6 @@ describe('PLUGIN collect report with axe-plugin NPM package', () => {
     );
 
     expect(() => reportSchema.parse(report)).not.toThrow();
-    expect(
-      omitVariableReportData(sanitizeReportPaths(report)),
-    ).toMatchSnapshot();
+    expect(omitVariableReportData(report)).toMatchSnapshot();
   });
 });

--- a/packages/plugin-axe/src/lib/runner/run-axe.ts
+++ b/packages/plugin-axe/src/lib/runner/run-axe.ts
@@ -12,7 +12,7 @@ import {
   logger,
   pluralizeToken,
 } from '@code-pushup/utils';
-import { toAuditOutputs } from './transform.js';
+import { createUrlSuffix, toAuditOutputs } from './transform.js';
 
 /* eslint-disable functional/no-let */
 let browser: Browser | undefined;
@@ -54,7 +54,10 @@ export async function runAxeForUrl(args: AxeUrlArgs): Promise<AxeUrlResult> {
       const page = await context.newPage();
       try {
         const axeResults = await runAxeForPage(page, args);
-        const auditOutputs = toAuditOutputs(axeResults, url);
+        const auditOutputs = toAuditOutputs(
+          axeResults,
+          createUrlSuffix(url, urlsCount),
+        );
         return {
           message: `${prefix} Analyzed URL ${url}`,
           result: { url, axeResults, auditOutputs },


### PR DESCRIPTION
Omit URL from issue messages when analyzing a single URL.

Previously, every issue included the analyzed URL in parentheses, e.g.:

```
[`img`] Element does not have an alt attribute ([example.com](https://example.com))
```

This is useful for multi-URL setups to identify which page an issue came from, but adds noise when there's only one URL.