### PR TITLE
fix(plugin-typescript): exclude test files from standalone analysis

### DIFF
--- a/code-pushup.preset.ts
+++ b/code-pushup.preset.ts
@@ -155,7 +155,7 @@ export async function configureJsPackagesPlugin(): Promise<CoreConfig> {
 export function configureTypescriptPlugin(projectName?: string): CoreConfig {
   const tsconfig = projectName
     ? `packages/${projectName}/tsconfig.lib.json`
-    : 'tsconfig.base.json';
+    : 'tsconfig.code-pushup.json';
   return {
     plugins: [typescriptPlugin({ tsconfig })],
     categories: getCategories(),

--- a/tsconfig.code-pushup.json
+++ b/tsconfig.code-pushup.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.base.json",
+  "exclude": ["node_modules", "tmp", "**/*.test.ts"]
+}


### PR DESCRIPTION
Closes #1201 

Code PushUp plugins focus on production code, so test files should be excluded from analysis. This PR adds `tsconfig.code-pushup.json`, extending the base config with test file exclusions.