### PR TITLE
feat: multi-URL aware helpers for cross-plugin composition

### DIFF
--- a/code-pushup.preset.ts
+++ b/code-pushup.preset.ts
@@ -1,11 +1,7 @@
 /* eslint-disable @nx/enforce-module-boundaries */
 import { createProjectGraphAsync } from '@nx/devkit';
-import type {
-  CategoryConfig,
-  CoreConfig,
-  PluginUrls,
-} from './packages/models/src/index.js';
-import axePlugin, { axeCategories } from './packages/plugin-axe/src/index.js';
+import type { CoreConfig, PluginUrls } from './packages/models/src/index.js';
+import axePlugin, { axeGroupRefs } from './packages/plugin-axe/src/index.js';
 import coveragePlugin, {
   type CoveragePluginConfig,
   getNxCoveragePaths,
@@ -16,8 +12,7 @@ import eslintPlugin, {
 import jsPackagesPlugin from './packages/plugin-js-packages/src/index.js';
 import jsDocsPlugin from './packages/plugin-jsdocs/src/index.js';
 import {
-  lighthouseCategories,
-  lighthouseGroupRef,
+  lighthouseGroupRefs,
   lighthousePlugin,
 } from './packages/plugin-lighthouse/src/index.js';
 import typescriptPlugin, {
@@ -195,31 +190,30 @@ export async function configureLighthousePlugin(
   urls: PluginUrls,
 ): Promise<CoreConfig> {
   const lhPlugin = await lighthousePlugin(urls);
-  const lhCategories: CategoryConfig[] = [
-    {
-      slug: 'performance',
-      title: 'Performance',
-      refs: [lighthouseGroupRef('performance')],
-    },
-    {
-      slug: 'a11y',
-      title: 'Accessibility',
-      refs: [lighthouseGroupRef('accessibility')],
-    },
-    {
-      slug: 'best-practices',
-      title: 'Best Practices',
-      refs: [lighthouseGroupRef('best-practices')],
-    },
-    {
-      slug: 'seo',
-      title: 'SEO',
-      refs: [lighthouseGroupRef('seo')],
-    },
-  ];
   return {
     plugins: [lhPlugin],
-    categories: lighthouseCategories(lhPlugin, lhCategories),
+    categories: [
+      {
+        slug: 'performance',
+        title: 'Performance',
+        refs: lighthouseGroupRefs(lhPlugin, 'performance'),
+      },
+      {
+        slug: 'a11y',
+        title: 'Accessibility',
+        refs: lighthouseGroupRefs(lhPlugin, 'accessibility'),
+      },
+      {
+        slug: 'best-practices',
+        title: 'Best Practices',
+        refs: lighthouseGroupRefs(lhPlugin, 'best-practices'),
+      },
+      {
+        slug: 'seo',
+        title: 'SEO',
+        refs: lighthouseGroupRefs(lhPlugin, 'seo'),
+      },
+    ],
   };
 }
 
@@ -227,6 +221,12 @@ export function configureAxePlugin(urls: PluginUrls): CoreConfig {
   const axe = axePlugin(urls);
   return {
     plugins: [axe],
-    categories: axeCategories(axe),
+    categories: [
+      {
+        slug: 'axe-a11y',
+        title: 'Axe Accessibility',
+        refs: axeGroupRefs(axe),
+      },
+    ],
   };
 }

--- a/packages/models/docs/models-reference.md
+++ b/packages/models/docs/models-reference.md
@@ -25,15 +25,15 @@ _All properties are optional._
 
 _Object containing the following properties:_
 
-| Property                 | Description                          | Type                                                                                                                                                                                                                                                                                                  |
-| :----------------------- | :----------------------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **`slug`** (\*)          | Unique ID (human-readable, URL-safe) | [Slug](#slug)                                                                                                                                                                                                                                                                                         |
-| **`title`** (\*)         | Descriptive name                     | `string` (_max length: 256_)                                                                                                                                                                                                                                                                          |
-| `docsUrl`                | Documentation site                   | `string` (_url_) (_optional_) _or_ `''`                                                                                                                                                                                                                                                               |
-| **`scores`** (\*)        | Score comparison                     | _Object with properties:_<ul><li>**`before`** (\*): [Score](#score) - Value between 0 and 1 (source commit)</li><li>**`after`** (\*): [Score](#score) - Value between 0 and 1 (target commit)</li><li>**`diff`** (\*): `number` (_≥-1, ≤1_) - Score change (`scores.after - scores.before`)</li></ul> |
-| **`plugin`** (\*)        | Plugin which defines it              | _Object with properties:_<ul><li>**`slug`** (\*): [Slug](#slug) - Unique plugin slug within core config</li><li>**`title`** (\*): `string` (_max length: 256_) - Descriptive name</li><li>`docsUrl`: `string` (_url_) (_optional_) _or_ `''` - Plugin documentation site</li></ul>                    |
-| **`values`** (\*)        | Audit `value` comparison             | _Object with properties:_<ul><li>**`before`** (\*): `number` (_≥0_) - Raw numeric value (source commit)</li><li>**`after`** (\*): `number` (_≥0_) - Raw numeric value (target commit)</li><li>**`diff`** (\*): `number` - Value change (`values.after - values.before`)</li></ul>                     |
-| **`displayValues`** (\*) | Audit `displayValue` comparison      | _Object with properties:_<ul><li>`before`: `string` - Formatted value (e.g. '0.9 s', '2.1 MB') (source commit)</li><li>`after`: `string` - Formatted value (e.g. '0.9 s', '2.1 MB') (target commit)</li></ul>                                                                                         |
+| Property                 | Description                          | Type                                                                                                                                                                                                                                                                                                                              |
+| :----------------------- | :----------------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`slug`** (\*)          | Unique ID (human-readable, URL-safe) | [Slug](#slug)                                                                                                                                                                                                                                                                                                                     |
+| **`title`** (\*)         | Descriptive name                     | `string` (_max length: 256_)                                                                                                                                                                                                                                                                                                      |
+| `docsUrl`                | Documentation site                   | `string` (_url_) (_optional_) _or_ `''`                                                                                                                                                                                                                                                                                           |
+| **`scores`** (\*)        | Score comparison                     | _Object with properties:_<ul><li>**`before`** (\*): [Score](#score) - Value between 0 and 1 (source commit)</li><li>**`after`** (\*): [Score](#score) - Value between 0 and 1 (target commit)</li><li>**`diff`** (\*): `number` (_≥-1, ≤1_) - Score change (`scores.after - scores.before`)</li></ul>                             |
+| **`plugin`** (\*)        | Plugin which defines it              | _Object with properties:_<ul><li>**`slug`** (\*): [Slug](#slug) - Unique plugin slug within core config</li><li>**`title`** (\*): `string` (_max length: 256_) - Descriptive name</li><li>`docsUrl`: `string` (_url_) (_optional_) _or_ `''` - Plugin documentation site</li></ul>                                                |
+| **`values`** (\*)        | Audit `value` comparison             | _Object with properties:_<ul><li>**`before`** (\*): [NonnegativeNumber](#nonnegativenumber) - Raw numeric value (source commit)</li><li>**`after`** (\*): [NonnegativeNumber](#nonnegativenumber) - Raw numeric value (target commit)</li><li>**`diff`** (\*): `number` - Value change (`values.after - values.before`)</li></ul> |
+| **`displayValues`** (\*) | Audit `displayValue` comparison      | _Object with properties:_<ul><li>`before`: `string` - Formatted value (e.g. '0.9 s', '2.1 MB') (source commit)</li><li>`after`: `string` - Formatted value (e.g. '0.9 s', '2.1 MB') (target commit)</li></ul>                                                                                                                     |
 
 _(\*) Required._
 
@@ -43,14 +43,14 @@ Audit information
 
 _Object containing the following properties:_
 
-| Property         | Description                              | Type                          |
-| :--------------- | :--------------------------------------- | :---------------------------- |
-| **`slug`** (\*)  | Reference to audit                       | [Slug](#slug)                 |
-| `displayValue`   | Formatted value (e.g. '0.9 s', '2.1 MB') | `string`                      |
-| **`value`** (\*) | Raw numeric value                        | `number` (_≥0_)               |
-| **`score`** (\*) | Value between 0 and 1                    | [Score](#score)               |
-| `scoreTarget`    | Pass/fail score threshold (0-1)          | `number` (_≥0, ≤1_)           |
-| `details`        | Detailed information                     | [AuditDetails](#auditdetails) |
+| Property         | Description                              | Type                                    |
+| :--------------- | :--------------------------------------- | :-------------------------------------- |
+| **`slug`** (\*)  | Reference to audit                       | [Slug](#slug)                           |
+| `displayValue`   | Formatted value (e.g. '0.9 s', '2.1 MB') | `string`                                |
+| **`value`** (\*) | Raw numeric value                        | [NonnegativeNumber](#nonnegativenumber) |
+| **`score`** (\*) | Value between 0 and 1                    | [Score](#score)                         |
+| `scoreTarget`    | Pass/fail score threshold (0-1)          | `number` (_≥0, ≤1_)                     |
+| `details`        | Detailed information                     | [AuditDetails](#auditdetails)           |
 
 _(\*) Required._
 
@@ -72,7 +72,7 @@ _Object containing the following properties:_
 | `docsUrl`        | Link to documentation (rationale)        | `string` (_url_) (_optional_) _or_ `''` |
 | `isSkipped`      | Indicates whether the audit is skipped   | `boolean`                               |
 | `displayValue`   | Formatted value (e.g. '0.9 s', '2.1 MB') | `string`                                |
-| **`value`** (\*) | Raw numeric value                        | `number` (_≥0_)                         |
+| **`value`** (\*) | Raw numeric value                        | [NonnegativeNumber](#nonnegativenumber) |
 | **`score`** (\*) | Value between 0 and 1                    | [Score](#score)                         |
 | `scoreTarget`    | Pass/fail score threshold (0-1)          | `number` (_≥0, ≤1_)                     |
 | `details`        | Detailed information                     | [AuditDetails](#auditdetails)           |
@@ -90,7 +90,7 @@ _Object containing the following properties:_
 | `docsUrl`         | Documentation site                       | `string` (_url_) (_optional_) _or_ `''`                                                                                                                                                                                                                                            |
 | **`plugin`** (\*) | Plugin which defines it                  | _Object with properties:_<ul><li>**`slug`** (\*): [Slug](#slug) - Unique plugin slug within core config</li><li>**`title`** (\*): `string` (_max length: 256_) - Descriptive name</li><li>`docsUrl`: `string` (_url_) (_optional_) _or_ `''` - Plugin documentation site</li></ul> |
 | **`score`** (\*)  | Value between 0 and 1                    | [Score](#score)                                                                                                                                                                                                                                                                    |
-| **`value`** (\*)  | Raw numeric value                        | `number` (_≥0_)                                                                                                                                                                                                                                                                    |
+| **`value`** (\*)  | Raw numeric value                        | [NonnegativeNumber](#nonnegativenumber)                                                                                                                                                                                                                                            |
 | `displayValue`    | Formatted value (e.g. '0.9 s', '2.1 MB') | `string`                                                                                                                                                                                                                                                                           |
 
 _(\*) Required._
@@ -198,12 +198,12 @@ _(\*) Required._
 
 _Object containing the following properties:_
 
-| Property          | Description                                                        | Type                 |
-| :---------------- | :----------------------------------------------------------------- | :------------------- |
-| **`slug`** (\*)   | Slug of an audit or group (depending on `type`)                    | [Slug](#slug)        |
-| **`weight`** (\*) | Weight used to calculate score                                     | `number` (_≥0_)      |
-| **`type`** (\*)   | Discriminant for reference kind, affects where `slug` is looked up | `'audit' \| 'group'` |
-| **`plugin`** (\*) | Plugin slug (plugin should contain referenced audit or group)      | [Slug](#slug)        |
+| Property          | Description                                                        | Type                                    |
+| :---------------- | :----------------------------------------------------------------- | :-------------------------------------- |
+| **`slug`** (\*)   | Slug of an audit or group (depending on `type`)                    | [Slug](#slug)                           |
+| **`weight`** (\*) | Weight used to calculate score                                     | [NonnegativeNumber](#nonnegativenumber) |
+| **`type`** (\*)   | Discriminant for reference kind, affects where `slug` is looked up | `'audit' \| 'group'`                    |
+| **`plugin`** (\*) | Plugin slug (plugin should contain referenced audit or group)      | [Slug](#slug)                           |
 
 _(\*) Required._
 
@@ -332,10 +332,10 @@ Weighted reference to a group
 
 _Object containing the following properties:_
 
-| Property          | Description                                                     | Type            |
-| :---------------- | :-------------------------------------------------------------- | :-------------- |
-| **`slug`** (\*)   | Reference slug to a group within this plugin (e.g. 'max-lines') | [Slug](#slug)   |
-| **`weight`** (\*) | Weight used to calculate score                                  | `number` (_≥0_) |
+| Property          | Description                                                     | Type                                    |
+| :---------------- | :-------------------------------------------------------------- | :-------------------------------------- |
+| **`slug`** (\*)   | Reference slug to a group within this plugin (e.g. 'max-lines') | [Slug](#slug)                           |
+| **`weight`** (\*) | Weight used to calculate score                                  | [NonnegativeNumber](#nonnegativenumber) |
 
 _(\*) Required._
 
@@ -1262,6 +1262,10 @@ _Enum, one of the following possible values:_
 
 </details>
 
+## NonnegativeNumber
+
+_Number which is greater than or equal to 0._
+
 ## PersistConfig
 
 _Object containing the following properties:_
@@ -1374,7 +1378,7 @@ _Union of the following possible types:_
 
 - `string` (_url_)
 - `Array<string (_url_)>`
-- _Object with dynamic keys of type_ `string` (_url_) _and values of type_ `number` (_≥0_)
+- _Object with dynamic keys of type_ `string` (_url_) _and values of type_ [NonnegativeNumber](#nonnegativenumber)
 
 ## PositiveInt
 
@@ -1574,3 +1578,9 @@ _Object containing the following properties:_
 | `timeout`               | Request timeout in minutes (default is 5)                            | `number` (_>0, int_) |
 
 _(\*) Required._
+
+## Weight
+
+Coefficient for the given score (use weight 0 if only for display)
+
+_Number which is greater than or equal to 0._

--- a/packages/models/src/index.ts
+++ b/packages/models/src/index.ts
@@ -66,9 +66,11 @@ export {
   filePathSchema,
   globPathSchema,
   materialIconSchema,
+  nonnegativeNumberSchema,
   positiveIntSchema,
   scoreSchema,
   slugSchema,
+  weightSchema,
   type MaterialIcon,
 } from './lib/implementation/schemas.js';
 export { exists } from './lib/implementation/utils.js';

--- a/packages/plugin-axe/README.md
+++ b/packages/plugin-axe/README.md
@@ -163,51 +163,105 @@ Use `npx code-pushup print-config --onlyPlugins=axe` to list all audits and grou
 
 The plugin provides helpers to integrate Axe results into your categories.
 
-### Auto-generate accessibility category
+### Building categories with ref helpers
 
-Use `axeCategories` to automatically create an accessibility category from all plugin groups:
+Use `axeGroupRefs` and `axeAuditRefs` to build categories. These helpers automatically handle multi-URL expansion:
 
 ```ts
-import axePlugin, { axeCategories } from '@code-pushup/axe-plugin';
+import axePlugin, { axeGroupRefs } from '@code-pushup/axe-plugin';
 
 const axe = axePlugin('https://example.com');
 
 export default {
   plugins: [axe],
-  categories: axeCategories(axe),
+  categories: [
+    {
+      slug: 'a11y',
+      title: 'Accessibility',
+      refs: axeGroupRefs(axe),
+    },
+  ],
 };
 ```
 
-This configuration works with both single-URL and multi-URL configurations. For multi-URL setups, refs are automatically expanded for each URL with appropriate weights.
-
-### Custom categories
-
-For fine-grained control, provide your own categories with specific groups:
+For multi-URL setups, refs are automatically expanded for each URL with appropriate weights:
 
 ```ts
-import axePlugin, { axeCategories, axeGroupRef } from '@code-pushup/axe-plugin';
+import axePlugin, { axeGroupRefs } from '@code-pushup/axe-plugin';
 
-const axe = axePlugin(['https://example.com', 'https://example.com/about']);
+const axe = axePlugin({
+  'https://example.com': 2,
+  'https://example.com/about': 1,
+});
 
 export default {
   plugins: [axe],
-  categories: axeCategories(axe, [
+  categories: [
     {
-      slug: 'axe-a11y',
-      title: 'Axe Accessibility',
-      refs: [axeGroupRef('aria', 2), axeGroupRef('color'), axeGroupRef('keyboard')],
+      slug: 'a11y',
+      title: 'Accessibility',
+      refs: axeGroupRefs(axe),
     },
-  ]),
+  ],
 };
 ```
 
+### Custom categories with specific groups
+
+For fine-grained control, specify which groups to include:
+
+```ts
+import axePlugin, { axeGroupRefs } from '@code-pushup/axe-plugin';
+
+const axe = axePlugin('https://example.com');
+
+export default {
+  plugins: [axe],
+  categories: [
+    {
+      slug: 'a11y',
+      title: 'Accessibility',
+      refs: [...axeGroupRefs(axe, 'aria', 2), ...axeGroupRefs(axe, 'color'), ...axeGroupRefs(axe, 'keyboard')],
+    },
+  ],
+};
+```
+
+### Combining with Lighthouse
+
+For comprehensive accessibility testing, combine Axe with Lighthouse's accessibility group in a single category:
+
+```ts
+import axePlugin, { axeGroupRefs } from '@code-pushup/axe-plugin';
+import lighthousePlugin, { lighthouseGroupRefs } from '@code-pushup/lighthouse-plugin';
+
+const urls = ['https://example.com', 'https://example.com/about'];
+const axe = axePlugin(urls);
+const lighthouse = await lighthousePlugin(urls);
+
+export default {
+  plugins: [axe, lighthouse],
+  categories: [
+    {
+      slug: 'a11y',
+      title: 'Accessibility',
+      refs: [...lighthouseGroupRefs(lighthouse, 'accessibility'), ...axeGroupRefs(axe)],
+    },
+  ],
+};
+```
+
+This gives you both Lighthouse's performance-focused accessibility audits and Axe's comprehensive WCAG coverage in one category score.
+
 ### Helper functions
 
-| Function        | Description                            |
-| --------------- | -------------------------------------- |
-| `axeCategories` | Auto-generates or expands categories   |
-| `axeGroupRef`   | Creates a category ref to an Axe group |
-| `axeAuditRef`   | Creates a category ref to an Axe audit |
+| Function       | Description                                              |
+| -------------- | -------------------------------------------------------- |
+| `axeGroupRefs` | Creates category refs to Axe group(s), handles multi-URL |
+| `axeAuditRefs` | Creates category refs to Axe audit(s), handles multi-URL |
+
+> [!TIP]
+> Weights determine each ref's influence on the category score. Use weight `0` to include a ref as info only, without affecting the score.
 
 ### Type safety
 
@@ -218,6 +272,16 @@ import type { AxeGroupSlug } from '@code-pushup/axe-plugin';
 
 const group: AxeGroupSlug = 'aria';
 ```
+
+### Deprecated helpers
+
+The following helpers are deprecated and will be removed in a future version:
+
+| Function        | Replacement                                       |
+| --------------- | ------------------------------------------------- |
+| `axeCategories` | Build categories manually with `axeGroupRefs`     |
+| `axeGroupRef`   | Use `axeGroupRefs` (plural) for multi-URL support |
+| `axeAuditRef`   | Use `axeAuditRefs` (plural) for multi-URL support |
 
 ## Resources
 

--- a/packages/plugin-axe/src/index.ts
+++ b/packages/plugin-axe/src/index.ts
@@ -5,5 +5,10 @@ export default axePlugin;
 export type { AxePluginOptions, AxePreset } from './lib/config.js';
 export type { AxeGroupSlug } from './lib/groups.js';
 
-export { axeAuditRef, axeGroupRef } from './lib/utils.js';
+export {
+  axeAuditRef,
+  axeAuditRefs,
+  axeGroupRef,
+  axeGroupRefs,
+} from './lib/utils.js';
 export { axeCategories } from './lib/categories.js';

--- a/packages/plugin-axe/src/lib/categories.ts
+++ b/packages/plugin-axe/src/lib/categories.ts
@@ -1,29 +1,32 @@
-import type { CategoryConfig, Group, PluginConfig } from '@code-pushup/models';
+import {
+  type CategoryConfig,
+  type PluginConfig,
+  validate,
+} from '@code-pushup/models';
 import {
   type PluginUrlContext,
-  createCategoryRefs,
   expandCategoryRefs,
-  removeIndex,
+  pluginUrlContextSchema,
   shouldExpandForUrls,
-  validateUrlContext,
 } from '@code-pushup/utils';
 import { AXE_PLUGIN_SLUG } from './constants.js';
-import { type AxeCategoryGroupSlug, isAxeGroupSlug } from './groups.js';
+import { axeGroupRefs } from './utils.js';
 
 /**
- * Creates categories for the Axe plugin.
- *
- * @public
- * @param plugin - {@link PluginConfig} object with groups and context
- * @param categories - {@link CategoryConfig} optional user-defined categories
- * @returns {CategoryConfig[]} - expanded and aggregated categories
+ * @deprecated Use `axeGroupRefs` to build categories manually instead.
  *
  * @example
- * const axe = await axePlugin(urls);
- * const axeCoreConfig = {
- *   plugins: [axe],
- *   categories: axeCategories(axe),
- * };
+ * // Instead of:
+ * const categories = axeCategories(axePlugin);
+ *
+ * // Use:
+ * const categories = [
+ *   {
+ *     slug: 'a11y',
+ *     title: 'Accessibility',
+ *     refs: axeGroupRefs(axePlugin),
+ *   },
+ * ];
  */
 export function axeCategories(
   plugin: Pick<PluginConfig, 'groups' | 'context'>,
@@ -32,44 +35,35 @@ export function axeCategories(
   if (!plugin.groups || plugin.groups.length === 0) {
     return categories ?? [];
   }
-  validateUrlContext(plugin.context);
   if (!categories) {
-    return createCategories(plugin.groups, plugin.context);
+    return createCategories(plugin);
   }
-  return expandCategories(categories, plugin.context);
+  return expandCategories(plugin, categories);
 }
 
 function createCategories(
-  groups: Group[],
-  context: PluginUrlContext,
+  plugin: Pick<PluginConfig, 'groups' | 'context'>,
 ): CategoryConfig[] {
-  return [createAggregatedCategory(groups, context)];
+  return [
+    {
+      slug: 'axe-a11y',
+      title: 'Axe Accessibility',
+      refs: axeGroupRefs(plugin),
+    },
+  ];
 }
 
 function expandCategories(
+  plugin: Pick<PluginConfig, 'context'>,
   categories: CategoryConfig[],
-  context: PluginUrlContext,
 ): CategoryConfig[] {
+  const context = validate(pluginUrlContextSchema, plugin.context);
   if (!shouldExpandForUrls(context.urlCount)) {
     return categories;
   }
   return categories.map(category =>
     expandAggregatedCategory(category, context),
   );
-}
-
-export function createAggregatedCategory(
-  groups: Group[],
-  context: PluginUrlContext,
-): CategoryConfig {
-  const refs = extractGroupSlugs(groups).flatMap(slug =>
-    createCategoryRefs(slug, AXE_PLUGIN_SLUG, context),
-  );
-  return {
-    slug: 'axe-a11y',
-    title: 'Axe Accessibility',
-    refs,
-  };
 }
 
 export function expandAggregatedCategory(
@@ -82,9 +76,4 @@ export function expandAggregatedCategory(
       ref.plugin === AXE_PLUGIN_SLUG ? expandCategoryRefs(ref, context) : [ref],
     ),
   };
-}
-
-export function extractGroupSlugs(groups: Group[]): AxeCategoryGroupSlug[] {
-  const slugs = groups.map(({ slug }) => removeIndex(slug));
-  return [...new Set(slugs)].filter(isAxeGroupSlug);
 }

--- a/packages/plugin-axe/src/lib/categories.unit.test.ts
+++ b/packages/plugin-axe/src/lib/categories.unit.test.ts
@@ -1,6 +1,7 @@
+import ansis from 'ansis';
 import { describe, expect, it } from 'vitest';
 import type { CategoryConfig, PluginConfig } from '@code-pushup/models';
-import { axeCategories, extractGroupSlugs } from './categories.js';
+import { axeCategories } from './categories.js';
 import { AXE_PLUGIN_SLUG } from './constants.js';
 import { axeGroupRef } from './utils.js';
 
@@ -112,33 +113,12 @@ describe('axeCategories', () => {
   });
 
   it('should throw for invalid context', () => {
-    const plugin = createMockPlugin({
-      context: { urlCount: 2, weights: { 1: 1 } },
-    });
-
-    expect(() => axeCategories(plugin)).toThrow(
-      'Invalid plugin context: weights count must match urlCount',
-    );
-  });
-});
-
-describe('extractGroupSlugs', () => {
-  it('should extract unique base slugs from groups', () => {
-    expect(
-      extractGroupSlugs([
-        { slug: 'aria-1', title: 'ARIA 1', refs: [] },
-        { slug: 'aria-2', title: 'ARIA 2', refs: [] },
-        { slug: 'color', title: 'Color & Contrast', refs: [] },
-      ]),
-    ).toEqual(['aria', 'color']);
-  });
-
-  it('should filter out invalid group slugs', () => {
-    expect(
-      extractGroupSlugs([
-        { slug: 'aria', title: 'ARIA', refs: [] },
-        { slug: 'invalid-group', title: 'Invalid', refs: [] },
-      ]),
-    ).toEqual(['aria']);
+    expect(() =>
+      axeCategories(
+        createMockPlugin({
+          context: { urlCount: 2, weights: { 1: 1 } },
+        }),
+      ),
+    ).toThrow(`Invalid ${ansis.bold('PluginUrlContext')}`);
   });
 });

--- a/packages/plugin-axe/src/lib/groups.ts
+++ b/packages/plugin-axe/src/lib/groups.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { axePresetSchema } from './config.js';
 
-/* WCAG presets for rule loading */
+/** WCAG presets for rule loading */
 const axeWcagTags = [
   'wcag2a',
   'wcag21a',
@@ -31,7 +31,7 @@ export function getWcagPresetTags(preset: AxeWcagPreset): AxeWcagTag[] {
   return WCAG_PRESET_TAGS[preset];
 }
 
-/* Category groups for all presets */
+/** Category groups for all presets */
 const axeCategoryGroupSlugs = [
   'aria',
   'color',
@@ -74,6 +74,6 @@ export function isAxeGroupSlug(slug: unknown): slug is AxeCategoryGroupSlug {
   return axeCategoryGroupSlugSchema.safeParse(slug).success;
 }
 
-/* Combined exports */
+// Combined exports
 export const axeGroupSlugSchema = axeCategoryGroupSlugSchema;
 export type AxeGroupSlug = AxeCategoryGroupSlug;

--- a/packages/plugin-axe/src/lib/utils.ts
+++ b/packages/plugin-axe/src/lib/utils.ts
@@ -1,7 +1,19 @@
-import type { CategoryRef } from '@code-pushup/models';
+import {
+  type CategoryRef,
+  type PluginConfig,
+  validate,
+} from '@code-pushup/models';
+import {
+  expandCategoryRefs,
+  extractGroupSlugs,
+  pluginUrlContextSchema,
+} from '@code-pushup/utils';
 import { AXE_PLUGIN_SLUG } from './constants.js';
-import type { AxeGroupSlug } from './groups.js';
+import { type AxeGroupSlug, isAxeGroupSlug } from './groups.js';
 
+/**
+ * @deprecated Use `axeGroupRefs` instead for multi-URL support.
+ */
 export function axeGroupRef(groupSlug: AxeGroupSlug, weight = 1): CategoryRef {
   return {
     plugin: AXE_PLUGIN_SLUG,
@@ -11,6 +23,9 @@ export function axeGroupRef(groupSlug: AxeGroupSlug, weight = 1): CategoryRef {
   };
 }
 
+/**
+ * @deprecated Use `axeAuditRefs` instead for multi-URL support.
+ */
 export function axeAuditRef(auditSlug: string, weight = 1): CategoryRef {
   return {
     plugin: AXE_PLUGIN_SLUG,
@@ -18,4 +33,77 @@ export function axeAuditRef(auditSlug: string, weight = 1): CategoryRef {
     type: 'audit',
     weight,
   };
+}
+
+/**
+ * Creates category refs for Axe groups with multi-URL support.
+ *
+ * @param plugin - Axe plugin instance
+ * @param groupSlug - Optional group slug; if omitted, includes all groups
+ * @param groupWeight - Optional weight for the ref(s)
+ * @returns Array of category refs, expanded for each URL in multi-URL configs
+ */
+export function axeGroupRefs(
+  plugin: Pick<PluginConfig, 'groups' | 'context'>,
+  groupSlug?: AxeGroupSlug,
+  groupWeight?: number,
+): CategoryRef[] {
+  const context = validate(pluginUrlContextSchema, plugin.context);
+  if (groupSlug) {
+    return expandCategoryRefs(
+      {
+        slug: groupSlug,
+        weight: groupWeight,
+        type: 'group',
+        plugin: AXE_PLUGIN_SLUG,
+      },
+      context,
+    );
+  }
+  return axeGroupSlugs(plugin).flatMap(slug =>
+    expandCategoryRefs(
+      { slug, type: 'group', plugin: AXE_PLUGIN_SLUG },
+      context,
+    ),
+  );
+}
+
+/**
+ * Creates category refs for Axe audits with multi-URL support.
+ *
+ * @param plugin - Axe plugin instance
+ * @param auditSlug - Optional audit slug; if omitted, includes all audits
+ * @param auditWeight - Optional weight for the ref(s)
+ * @returns Array of category refs, expanded for each URL in multi-URL configs
+ */
+export function axeAuditRefs(
+  plugin: Pick<PluginConfig, 'audits' | 'context'>,
+  auditSlug?: string,
+  auditWeight?: number,
+): CategoryRef[] {
+  const context = validate(pluginUrlContextSchema, plugin.context);
+  if (auditSlug) {
+    return expandCategoryRefs(
+      {
+        slug: auditSlug,
+        weight: auditWeight,
+        type: 'audit',
+        plugin: AXE_PLUGIN_SLUG,
+      },
+      context,
+    );
+  }
+  return plugin.audits.flatMap(({ slug }) =>
+    expandCategoryRefs(
+      { slug, type: 'audit', plugin: AXE_PLUGIN_SLUG },
+      context,
+    ),
+  );
+}
+
+function axeGroupSlugs(plugin: Pick<PluginConfig, 'groups'>): AxeGroupSlug[] {
+  if (!plugin.groups) {
+    return [];
+  }
+  return extractGroupSlugs(plugin.groups).filter(isAxeGroupSlug);
 }

--- a/packages/plugin-axe/src/lib/utils.unit.test.ts
+++ b/packages/plugin-axe/src/lib/utils.unit.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import { AXE_PLUGIN_SLUG } from './constants.js';
-import { axeAuditRef, axeGroupRef } from './utils.js';
+import {
+  axeAuditRef,
+  axeAuditRefs,
+  axeGroupRef,
+  axeGroupRefs,
+} from './utils.js';
 
 describe('axeGroupRef', () => {
   it('should create a group reference with default weight', () => {
@@ -39,5 +44,99 @@ describe('axeAuditRef', () => {
       type: 'audit',
       weight: 2,
     });
+  });
+});
+
+describe('axeGroupRefs', () => {
+  it('should return refs for all groups when no slug provided', () => {
+    expect(
+      axeGroupRefs({
+        groups: [
+          { slug: 'aria-1', title: 'ARIA (url1)', refs: [] },
+          { slug: 'aria-2', title: 'ARIA (url2)', refs: [] },
+        ],
+        context: { urlCount: 2, weights: { 1: 2, 2: 3 } },
+      }),
+    ).toStrictEqual([
+      { plugin: AXE_PLUGIN_SLUG, slug: 'aria-1', type: 'group', weight: 2 },
+      { plugin: AXE_PLUGIN_SLUG, slug: 'aria-2', type: 'group', weight: 3 },
+    ]);
+  });
+
+  it('should return refs for specific group when slug provided', () => {
+    expect(
+      axeGroupRefs(
+        {
+          groups: [
+            { slug: 'aria-1', title: 'ARIA (url1)', refs: [] },
+            { slug: 'aria-2', title: 'ARIA (url2)', refs: [] },
+          ],
+          context: { urlCount: 2, weights: { 1: 1, 2: 1 } },
+        },
+        'aria',
+        3,
+      ),
+    ).toStrictEqual([
+      { plugin: AXE_PLUGIN_SLUG, slug: 'aria-1', type: 'group', weight: 2 },
+      { plugin: AXE_PLUGIN_SLUG, slug: 'aria-2', type: 'group', weight: 2 },
+    ]);
+  });
+
+  it('should return empty array when plugin has no groups', () => {
+    expect(
+      axeGroupRefs({
+        groups: undefined,
+        context: { urlCount: 1, weights: { 1: 1 } },
+      }),
+    ).toBeEmpty();
+  });
+});
+
+describe('axeAuditRefs', () => {
+  it('should return refs for specific audit with multi-URL expansion', () => {
+    expect(
+      axeAuditRefs(
+        {
+          audits: [
+            { slug: 'label-1', title: 'Form elements must have labels (url1)' },
+            { slug: 'label-2', title: 'Form elements must have labels (url2)' },
+            { slug: 'aria-roles-1', title: '`[role]` values are valid (url1)' },
+            { slug: 'aria-roles-2', title: '`[role]` values are valid (url2)' },
+          ],
+          context: { urlCount: 2, weights: { 1: 1, 2: 2 } },
+        },
+        'aria-roles',
+        3,
+      ),
+    ).toStrictEqual([
+      {
+        plugin: AXE_PLUGIN_SLUG,
+        slug: 'aria-roles-1',
+        type: 'audit',
+        weight: 2,
+      },
+      {
+        plugin: AXE_PLUGIN_SLUG,
+        slug: 'aria-roles-2',
+        type: 'audit',
+        weight: 2.5,
+      },
+    ]);
+  });
+
+  it('should return refs for all audits when no slug provided', () => {
+    expect(
+      axeAuditRefs({
+        audits: [{ slug: 'duplicate-id-aria', title: 'ARIA IDs are unique' }],
+        context: { urlCount: 1, weights: { 1: 1 } },
+      }),
+    ).toStrictEqual([
+      {
+        plugin: AXE_PLUGIN_SLUG,
+        slug: 'duplicate-id-aria',
+        type: 'audit',
+        weight: 1,
+      },
+    ]);
   });
 });

--- a/packages/plugin-lighthouse/src/index.ts
+++ b/packages/plugin-lighthouse/src/index.ts
@@ -6,7 +6,12 @@ export {
   LIGHTHOUSE_PLUGIN_SLUG,
   LIGHTHOUSE_OUTPUT_PATH,
 } from './lib/constants.js';
-export { lighthouseAuditRef, lighthouseGroupRef } from './lib/utils.js';
+export {
+  lighthouseAuditRef,
+  lighthouseAuditRefs,
+  lighthouseGroupRef,
+  lighthouseGroupRefs,
+} from './lib/utils.js';
 export type { LighthouseGroupSlug, LighthouseOptions } from './lib/types.js';
 export { lighthousePlugin } from './lib/lighthouse-plugin.js';
 export default lighthousePlugin;

--- a/packages/plugin-lighthouse/src/lib/categories.unit.test.ts
+++ b/packages/plugin-lighthouse/src/lib/categories.unit.test.ts
@@ -3,7 +3,6 @@ import type { CategoryConfig } from '@code-pushup/models';
 import {
   createAggregatedCategory,
   expandAggregatedCategory,
-  extractGroupSlugs,
   lighthouseCategories,
 } from './categories.js';
 import { LIGHTHOUSE_PLUGIN_SLUG } from './constants.js';
@@ -178,13 +177,13 @@ describe('lighthouseCategories', () => {
             type: 'group',
             plugin: LIGHTHOUSE_PLUGIN_SLUG,
             slug: 'performance-1',
-            weight: 1,
+            weight: 1.5,
           },
           {
             type: 'group',
             plugin: LIGHTHOUSE_PLUGIN_SLUG,
             slug: 'performance-2',
-            weight: 1,
+            weight: 1.5,
           },
         ],
       });
@@ -247,13 +246,13 @@ describe('lighthouseCategories', () => {
           type: 'audit',
           plugin: LIGHTHOUSE_PLUGIN_SLUG,
           slug: 'first-contentful-paint-1',
-          weight: 1,
+          weight: 1.5,
         },
         {
           type: 'audit',
           plugin: LIGHTHOUSE_PLUGIN_SLUG,
           slug: 'first-contentful-paint-2',
-          weight: 1,
+          weight: 1.5,
         },
       ]);
     });
@@ -491,48 +490,6 @@ describe('lighthouseCategories', () => {
   });
 });
 
-describe('extractGroupSlugs', () => {
-  it('should extract unique base slugs from ordered groups', () => {
-    const groups = [
-      { slug: 'performance-1', title: 'Performance 1', refs: [] },
-      { slug: 'performance-2', title: 'Performance 2', refs: [] },
-      { slug: 'accessibility-1', title: 'Accessibility 1', refs: [] },
-      { slug: 'accessibility-2', title: 'Accessibility 2', refs: [] },
-    ];
-    expect(extractGroupSlugs(groups)).toEqual(['performance', 'accessibility']);
-  });
-
-  it('should handle non-ordered groups', () => {
-    const groups = [
-      { slug: 'performance', title: 'Performance', refs: [] },
-      { slug: 'accessibility', title: 'Accessibility', refs: [] },
-    ];
-    expect(extractGroupSlugs(groups)).toEqual(['performance', 'accessibility']);
-  });
-
-  it('should handle mixed ordered and non-ordered groups', () => {
-    const groups = [
-      { slug: 'performance', title: 'Performance', refs: [] },
-      { slug: 'accessibility-1', title: 'Accessibility 1', refs: [] },
-      { slug: 'accessibility-2', title: 'Accessibility 2', refs: [] },
-    ];
-    expect(extractGroupSlugs(groups)).toEqual(['performance', 'accessibility']);
-  });
-
-  it('should return unique slugs only', () => {
-    const groups = [
-      { slug: 'performance-1', title: 'Performance 1', refs: [] },
-      { slug: 'performance-2', title: 'Performance 2', refs: [] },
-      { slug: 'performance-3', title: 'Performance 3', refs: [] },
-    ];
-    expect(extractGroupSlugs(groups)).toEqual(['performance']);
-  });
-
-  it('should handle empty groups array', () => {
-    expect(extractGroupSlugs([])).toEqual([]);
-  });
-});
-
 describe('createAggregatedCategory', () => {
   it("should create category with Lighthouse groups' refs", () => {
     expect(
@@ -667,7 +624,7 @@ describe('expandAggregatedCategory', () => {
         type: 'group',
         plugin: LIGHTHOUSE_PLUGIN_SLUG,
         slug: 'performance-1',
-        weight: 3,
+        weight: 2,
       },
       {
         type: 'group',
@@ -685,7 +642,7 @@ describe('expandAggregatedCategory', () => {
         type: 'audit',
         plugin: LIGHTHOUSE_PLUGIN_SLUG,
         slug: 'first-contentful-paint-2',
-        weight: 1,
+        weight: 2,
       },
     ]);
   });
@@ -744,7 +701,7 @@ describe('expandAggregatedCategory', () => {
     ).toEqual(category);
   });
 
-  it('should prioritize URL weights over user-defined category weights', () => {
+  it('should average user-defined and URL weights', () => {
     expect(
       expandAggregatedCategory(
         {
@@ -766,18 +723,18 @@ describe('expandAggregatedCategory', () => {
         type: 'group',
         plugin: LIGHTHOUSE_PLUGIN_SLUG,
         slug: 'performance-1',
-        weight: 3,
+        weight: 2.5,
       },
       {
         type: 'group',
         plugin: LIGHTHOUSE_PLUGIN_SLUG,
         slug: 'performance-2',
-        weight: 5,
+        weight: 3.5,
       },
     ]);
   });
 
-  it('should fall back to user-defined weight when URL weight is missing', () => {
+  it('should average weights for each URL independently', () => {
     expect(
       expandAggregatedCategory(
         {
@@ -792,25 +749,25 @@ describe('expandAggregatedCategory', () => {
             },
           ],
         },
-        { urlCount: 2, weights: { 1: 3 } },
+        { urlCount: 2, weights: { 1: 3, 2: 5 } },
       ).refs,
     ).toEqual([
       {
         type: 'group',
         plugin: LIGHTHOUSE_PLUGIN_SLUG,
         slug: 'performance-1',
-        weight: 3,
+        weight: 5,
       },
       {
         type: 'group',
         plugin: LIGHTHOUSE_PLUGIN_SLUG,
         slug: 'performance-2',
-        weight: 7,
+        weight: 6,
       },
     ]);
   });
 
-  it('should not add suffixes for single URL but preserve weights', () => {
+  it('should not add suffixes for single URL but average weights', () => {
     expect(
       expandAggregatedCategory(
         {
@@ -832,7 +789,7 @@ describe('expandAggregatedCategory', () => {
         type: 'group',
         plugin: LIGHTHOUSE_PLUGIN_SLUG,
         slug: 'performance',
-        weight: 5,
+        weight: 3,
       },
     ]);
   });

--- a/packages/plugin-lighthouse/src/lib/utils.unit.test.ts
+++ b/packages/plugin-lighthouse/src/lib/utils.unit.test.ts
@@ -6,9 +6,12 @@ import {
   categoryRefSchema,
   pluginConfigSchema,
 } from '@code-pushup/models';
+import { LIGHTHOUSE_PLUGIN_SLUG } from './constants.js';
 import {
   lighthouseAuditRef,
+  lighthouseAuditRefs,
   lighthouseGroupRef,
+  lighthouseGroupRefs,
   markSkippedAuditsAndGroups,
   validateAudits,
   validateOnlyCategories,
@@ -41,6 +44,112 @@ describe('lighthouseGroupRef', () => {
       lighthouseGroupRef('performance', 0),
     );
     expect(groupRef.weight).toBe(0);
+  });
+});
+
+describe('lighthouseGroupRefs', () => {
+  it('should return refs for all groups when no slug provided', () => {
+    expect(
+      lighthouseGroupRefs({
+        groups: [
+          { slug: 'performance-1', title: 'Performance (url1)', refs: [] },
+          { slug: 'performance-2', title: 'Performance (url2)', refs: [] },
+        ],
+        context: { urlCount: 2, weights: { 1: 2, 2: 3 } },
+      }),
+    ).toStrictEqual([
+      {
+        plugin: LIGHTHOUSE_PLUGIN_SLUG,
+        slug: 'performance-1',
+        type: 'group',
+        weight: 2,
+      },
+      {
+        plugin: LIGHTHOUSE_PLUGIN_SLUG,
+        slug: 'performance-2',
+        type: 'group',
+        weight: 3,
+      },
+    ]);
+  });
+
+  it('should return refs for specific group when slug provided', () => {
+    expect(
+      lighthouseGroupRefs(
+        {
+          groups: [
+            { slug: 'performance-1', title: 'Performance (url1)', refs: [] },
+            { slug: 'performance-2', title: 'Performance (url2)', refs: [] },
+          ],
+          context: { urlCount: 2, weights: { 1: 1, 2: 1 } },
+        },
+        'performance',
+        3,
+      ),
+    ).toStrictEqual([
+      {
+        plugin: LIGHTHOUSE_PLUGIN_SLUG,
+        slug: 'performance-1',
+        type: 'group',
+        weight: 2,
+      },
+      {
+        plugin: LIGHTHOUSE_PLUGIN_SLUG,
+        slug: 'performance-2',
+        type: 'group',
+        weight: 2,
+      },
+    ]);
+  });
+
+  it('should return empty array when plugin has no groups', () => {
+    expect(
+      lighthouseGroupRefs({
+        groups: undefined,
+        context: { urlCount: 1, weights: { 1: 1 } },
+      }),
+    ).toBeEmpty();
+  });
+});
+
+describe('lighthouseAuditRefs', () => {
+  it('should return refs for specific audit with multi-URL expansion', () => {
+    expect(
+      lighthouseAuditRefs(
+        { audits: [], context: { urlCount: 2, weights: { 1: 1, 2: 2 } } },
+        'first-contentful-paint',
+        3,
+      ),
+    ).toStrictEqual([
+      {
+        plugin: LIGHTHOUSE_PLUGIN_SLUG,
+        slug: 'first-contentful-paint-1',
+        type: 'audit',
+        weight: 2,
+      },
+      {
+        plugin: LIGHTHOUSE_PLUGIN_SLUG,
+        slug: 'first-contentful-paint-2',
+        type: 'audit',
+        weight: 2.5,
+      },
+    ]);
+  });
+
+  it('should return refs for all audits when no slug provided', () => {
+    expect(
+      lighthouseAuditRefs({
+        audits: [{ slug: 'first-contentful-paint', title: '' }],
+        context: { urlCount: 1, weights: { 1: 1 } },
+      }),
+    ).toStrictEqual([
+      {
+        plugin: LIGHTHOUSE_PLUGIN_SLUG,
+        slug: 'first-contentful-paint',
+        type: 'audit',
+        weight: 1,
+      },
+    ]);
   });
 });
 

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -96,18 +96,16 @@ export { Logger, logger } from './lib/logger.js';
 export { mergeConfigs } from './lib/merge-configs.js';
 export {
   addIndex,
-  ContextValidationError,
-  createCategoryRefs,
   expandAuditsForUrls,
   expandCategoryRefs,
   expandGroupsForUrls,
-  removeIndex,
+  extractGroupSlugs,
   shouldExpandForUrls,
-  validateUrlContext,
 } from './lib/plugin-url-aggregation.js';
 export {
   getUrlIdentifier,
   normalizeUrlInput,
+  pluginUrlContextSchema,
   type PluginUrlContext,
 } from './lib/plugin-url-config.js';
 export {

--- a/packages/utils/src/lib/plugin-url-config.ts
+++ b/packages/utils/src/lib/plugin-url-config.ts
@@ -1,9 +1,21 @@
-import type { PluginUrls } from '@code-pushup/models';
+import { z } from 'zod';
+import {
+  type PluginUrls,
+  nonnegativeNumberSchema,
+  weightSchema,
+} from '@code-pushup/models';
 
-export type PluginUrlContext = {
-  urlCount: number;
-  weights: Record<string, number>;
-};
+export const pluginUrlContextSchema = z
+  .object({
+    urlCount: nonnegativeNumberSchema,
+    weights: z.record(z.string(), weightSchema),
+  })
+  .refine(({ urlCount, weights }) => Object.keys(weights).length === urlCount, {
+    message: 'weights count must match urlCount',
+  })
+  .meta({ title: 'PluginUrlContext' });
+
+export type PluginUrlContext = z.infer<typeof pluginUrlContextSchema>;
 
 export const SINGLE_URL_THRESHOLD = 1;
 


### PR DESCRIPTION
Closes #1179 

- Add multi-URL aware helpers (`lighthouseGroupRefs`, `lighthouseAuditRefs`, `axeGroupRefs`, `axeAuditRefs`) that expand category refs for multi-URL configurations
- Deprecate singular helpers (`lighthouseGroupRef`, `lighthouseAuditRef`, `axeGroupRef`, `axeAuditRef`) and category helpers (`lighthouseCategories`, `axeCategories`)
- Remove `validateUrlContext` in favor of Zod schema validation via `pluginUrlContextSchema`
- Implement weight averaging: when both URL weights and user-defined category ref weights are provided, the final weight is calculated as their average
- Add unit tests for new helpers
- Update plugin READMEs with new API examples and cross-plugin composition patterns