### PR TITLE
ci: abbreviate long coverage workflow names

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,4 +1,4 @@
-name: Code Coverage
+name: Coverage
 
 on:
   push:
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.list-packages.outputs.matrix) }}
-    name: Collect code coverage
+    name: Collect coverage
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository


### PR DESCRIPTION
Very minor tweak. The coverage workflow checks wrap onto multiple lines because of unnecessarily verbose names.

<img width="640" height="387" alt="image" src="https://github.com/user-attachments/assets/d905d4b8-e0a6-43c8-b9aa-a76b851cdab2" />

<img width="640" height="387" alt="image" src="https://github.com/user-attachments/assets/215d53d3-fc0d-4a39-856a-f6387400b86c" />
