### PR TITLE
fix(utils): prevent race condition in parallel plugin runs

### DIFF
--- a/packages/utils/src/lib/create-runner-files.ts
+++ b/packages/utils/src/lib/create-runner-files.ts
@@ -1,5 +1,6 @@
 import { writeFile } from 'node:fs/promises';
 import path from 'node:path';
+import { threadId } from 'node:worker_threads';
 import type { RunnerFilesPaths } from '@code-pushup/models';
 import { ensureDirectoryExists, pluginWorkDir } from './file-system.js';
 
@@ -13,10 +14,9 @@ export async function createRunnerFiles(
   pluginSlug: string,
   configJSON: string,
 ): Promise<RunnerFilesPaths> {
-  // Use timestamp + process ID + random suffix to ensure uniqueness
+  // Use timestamp + process ID + threadId
   // This prevents race conditions when running the same plugin for multiple projects in parallel
-  // eslint-disable-next-line @typescript-eslint/no-magic-numbers
-  const uniqueId = `${Date.now()}-${process.pid}-${Math.random().toString(36).slice(2, 8)}`;
+  const uniqueId = `${(performance.timeOrigin + performance.now()) * 10}-${process.pid}-${threadId}`;
   const runnerWorkDir = path.join(pluginWorkDir(pluginSlug), uniqueId);
   const runnerConfigPath = path.join(runnerWorkDir, 'plugin-config.json');
   const runnerOutputPath = path.join(runnerWorkDir, 'runner-output.json');


### PR DESCRIPTION
## Summary

Fixes a race condition when running the same plugin for multiple projects in parallel (e.g., via Nx targets).

## Problem

When two processes started within the same millisecond, the timestamp-based directory naming in `createRunnerFiles` would collide:

```
node_modules/.code-pushup/{pluginSlug}/{timestamp}/
```

This caused one process to delete the output directory (in `executeRunnerConfig`) while another was still using it, leading to failures.

## Solution

Added `process.pid` and a random suffix to the directory name to ensure uniqueness:

```typescript
const uniqueId = `${Date.now()}-${process.pid}-${Math.random().toString(36).slice(2, 8)}`;
```

This ensures that even when multiple processes run simultaneously, each gets its own unique working directory.