### PR TITLE
fix(ci): slugify project name in configPatterns

### DIFF
--- a/packages/ci/README.md
+++ b/packages/ci/README.md
@@ -244,9 +244,9 @@ if (result.mode === 'monorepo') {
 
 ### Faster CI runs with `configPatterns`
 
-By default, the `print-config` command is run sequentially for each project in order to reliably detect how `code-pushup` is configured - specifically, where to read output files from (`persist` config) and whether portal may be used as a cache (`upload` config). This allows for each project to be configured in its own way without breaking anything, but for large monorepos these extra `code-pushup print-config` executions can accumulate and significantly slow down CI pipelines.
+By default, the `print-config` command is run sequentially for each project in order to reliably detect how `code-pushup` is configured - specifically, where to read output files from (`persist` config) and whether the portal may be used as a cache (`upload` config). This allows for each project to be configured in its own way without breaking anything, but for large monorepos these extra `code-pushup print-config` executions can accumulate and significantly slow down CI pipelines.
 
-As a more scalable alternative, `configPatterns` may be provided. A user declares upfront how every project is configured, which allows `print-config` to be skipped. It's the user's responsibility to ensure this configuration holds for every project (it won't be checked). The `configPatterns` support string interpolation, substituting `{projectName}` with each project's name. Other than that, each project's `code-pushup.config` must have exactly the same `persist` and `upload` configurations.
+As a more scalable alternative, `configPatterns` may be provided. A user declares upfront how every project is configured, which allows `print-config` to be skipped. It's the user's responsibility to ensure this configuration holds for every project (it won't be checked). The `configPatterns` support string interpolation, substituting `{projectName}` with each project's (slugified) name. Other than that, each project's `code-pushup.config` must have exactly the same `persist` and `upload` configurations.
 
 ```ts
 await runInCI(refs, api, {

--- a/packages/ci/src/lib/run-utils.ts
+++ b/packages/ci/src/lib/run-utils.ts
@@ -16,6 +16,7 @@ import {
   objectFromEntries,
   readJsonFile,
   removeUndefinedAndEmptyProps,
+  slugify,
   stringifyError,
 } from '@code-pushup/utils';
 import {
@@ -510,8 +511,8 @@ export function configFromPatterns(
       upload: {
         server: upload.server,
         apiKey: upload.apiKey,
-        organization: interpolate(upload.organization, variables),
-        project: interpolate(upload.project, variables),
+        organization: slugify(interpolate(upload.organization, variables)),
+        project: slugify(interpolate(upload.project, variables)),
         ...(upload.timeout != null && { timeout: upload.timeout }),
       },
     }),


### PR DESCRIPTION
This change is necessary to support `configPatterns` in workspaces that use scoped npm package names as the project name (typically defined in `package.json`). Such names (e.g., `@my-org/my-pkg`) are not valid for `upload.project`, and need to be slugified (e.g., `my-org-my-pkg`) dynamically, since the user only configures the `{projectName}` pattern.