### PR TITLE
feat(create-cli): detect dev server URL for Axe and Lighthouse targets

### DIFF
--- a/packages/create-cli/README.md
+++ b/packages/create-cli/README.md
@@ -67,10 +67,10 @@ Each plugin exposes its own configuration keys that can be passed as CLI argumen
 
 #### Lighthouse
 
-| Option                        | Type                                                             | Default                 | Description                     |
-| ----------------------------- | ---------------------------------------------------------------- | ----------------------- | ------------------------------- |
-| **`--lighthouse.urls`**       | `string \| string[]`                                             | `http://localhost:4200` | Target URL(s) (comma-separated) |
-| **`--lighthouse.categories`** | `('performance'` \| `'a11y'` \| `'best-practices'` \| `'seo')[]` | all                     | Categories                      |
+| Option                        | Type                                                             | Default                    | Description                     |
+| ----------------------------- | ---------------------------------------------------------------- | -------------------------- | ------------------------------- |
+| **`--lighthouse.urls`**       | `string \| string[]`                                             | auto-detected from project | Target URL(s) (comma-separated) |
+| **`--lighthouse.categories`** | `('performance'` \| `'a11y'` \| `'best-practices'` \| `'seo')[]` | all                        | Categories                      |
 
 #### JSDocs
 
@@ -81,12 +81,25 @@ Each plugin exposes its own configuration keys that can be passed as CLI argumen
 
 #### Axe
 
-| Option                  | Type                                                         | Default                 | Description                                |
-| ----------------------- | ------------------------------------------------------------ | ----------------------- | ------------------------------------------ |
-| **`--axe.urls`**        | `string \| string[]`                                         | `http://localhost:4200` | Target URL(s) (comma-separated)            |
-| **`--axe.preset`**      | `'wcag21aa'` \| `'wcag22aa'` \| `'best-practice'` \| `'all'` | `wcag21aa`              | Accessibility preset                       |
-| **`--axe.setupScript`** | `boolean`                                                    | `false`                 | Create setup script for auth-protected app |
-| **`--axe.categories`**  | `boolean`                                                    | `true`                  | Add categories                             |
+| Option                  | Type                                                         | Default                    | Description                                |
+| ----------------------- | ------------------------------------------------------------ | -------------------------- | ------------------------------------------ |
+| **`--axe.urls`**        | `string \| string[]`                                         | auto-detected from project | Target URL(s) (comma-separated)            |
+| **`--axe.preset`**      | `'wcag21aa'` \| `'wcag22aa'` \| `'best-practice'` \| `'all'` | `wcag21aa`                 | Accessibility preset                       |
+| **`--axe.setupScript`** | `boolean`                                                    | `false`                    | Create setup script for auth-protected app |
+| **`--axe.categories`**  | `boolean`                                                    | `true`                     | Add categories                             |
+
+#### Dev server URL auto-detection (Axe and Lighthouse)
+
+When Axe or Lighthouse is enabled, the wizard pre-fills the target URL from project files and npm scripts. The prompt shows the detection source when available.
+
+| Signal                   | Default URL                        |
+| ------------------------ | ---------------------------------- |
+| Vite (`vite.config.*`)   | `http://localhost:5173`            |
+| Next.js (`next dev`)     | `http://localhost:3000`            |
+| Angular (`angular.json`) | `http://localhost:4200`            |
+| Unknown / empty project  | `http://localhost:4200` (fallback) |
+
+Detection is heuristic: config files are scanned with regex and are not executed.
 
 ### Examples
 

--- a/packages/create-cli/src/lib/setup/wizard.int.test.ts
+++ b/packages/create-cli/src/lib/setup/wizard.int.test.ts
@@ -1,5 +1,6 @@
 import { readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
+import { axeSetupBinding } from '@code-pushup/axe-plugin';
 import { eslintSetupBinding } from '@code-pushup/eslint-plugin';
 import { cleanTestFolder } from '@code-pushup/test-utils';
 import { getGitRoot } from '@code-pushup/utils';
@@ -289,5 +290,28 @@ describe('runSetupWizard', () => {
       } satisfies CoreConfig;
       "
     `);
+  });
+
+  it('should detect Vite dev server URL for Axe plugin setup', async () => {
+    await writeFile(
+      path.join(outputDir, 'vite.config.js'),
+      'export default { plugins: [] }',
+    );
+    await writeFile(
+      path.join(outputDir, 'package.json'),
+      JSON.stringify({ type: 'module' }),
+    );
+
+    await runSetupWizard([axeSetupBinding], {
+      yes: true,
+      plugins: ['axe'],
+      'config-format': 'js',
+      'target-dir': outputDir,
+      'axe.categories': false,
+    });
+
+    await expect(
+      readFile(path.join(outputDir, 'code-pushup.config.js'), 'utf8'),
+    ).resolves.toContain("axePlugin('http://localhost:5173')");
   });
 });

--- a/packages/create-cli/src/lib/setup/wizard.ts
+++ b/packages/create-cli/src/lib/setup/wizard.ts
@@ -7,6 +7,7 @@ import {
   formatAsciiTable,
   getGitRoot,
   logger,
+  resetDevServerUrlCache,
   toUnixPath,
 } from '@code-pushup/utils';
 import { promptCiProvider, resolveCi } from './ci.js';
@@ -47,6 +48,7 @@ export async function runSetupWizard(
   bindings: PluginSetupBinding[],
   cliArgs: CliArgs,
 ): Promise<void> {
+  resetDevServerUrlCache();
   const targetDir = cliArgs['target-dir'] ?? process.cwd();
 
   const context = await promptSetupMode(targetDir, cliArgs);

--- a/packages/plugin-axe/src/lib/binding.ts
+++ b/packages/plugin-axe/src/lib/binding.ts
@@ -5,9 +5,11 @@ import type {
   PluginSetupBinding,
 } from '@code-pushup/models';
 import {
+  FALLBACK_DEV_SERVER_URL,
   answerBoolean,
   answerNonEmptyArray,
   answerString,
+  resolveDevServerUrlPrompt,
   singleQuote,
 } from '@code-pushup/utils';
 import {
@@ -21,7 +23,6 @@ const { name: PACKAGE_NAME } = createRequire(import.meta.url)(
   '../../package.json',
 ) as typeof import('../../package.json');
 
-const DEFAULT_URL = 'http://localhost:4200';
 const PLUGIN_VAR = 'axe';
 const SETUP_SCRIPT_PATH = './axe-setup.ts';
 
@@ -56,33 +57,35 @@ export const axeSetupBinding = {
   slug: AXE_PLUGIN_SLUG,
   title: AXE_PLUGIN_TITLE,
   packageName: PACKAGE_NAME,
-  prompts: async () => [
-    {
-      key: 'axe.urls',
-      message: 'Target URL(s) (comma-separated):',
-      type: 'input',
-      default: DEFAULT_URL,
-    },
-    {
-      key: 'axe.preset',
-      message: 'Accessibility preset:',
-      type: 'select',
-      choices: [...PRESET_CHOICES],
-      default: AXE_DEFAULT_PRESET,
-    },
-    {
-      key: 'axe.setupScript',
-      message: 'Create setup script for auth-protected app?',
-      type: 'confirm',
-      default: false,
-    },
-    {
-      key: 'axe.categories',
-      message: 'Add categories?',
-      type: 'confirm',
-      default: true,
-    },
-  ],
+  prompts: async targetDir => {
+    const urlPrompt = await resolveDevServerUrlPrompt(targetDir);
+    return [
+      {
+        key: 'axe.urls',
+        type: 'input',
+        ...urlPrompt,
+      },
+      {
+        key: 'axe.preset',
+        message: 'Accessibility preset:',
+        type: 'select',
+        choices: [...PRESET_CHOICES],
+        default: AXE_DEFAULT_PRESET,
+      },
+      {
+        key: 'axe.setupScript',
+        message: 'Create setup script for auth-protected app?',
+        type: 'confirm',
+        default: false,
+      },
+      {
+        key: 'axe.categories',
+        message: 'Add categories?',
+        type: 'confirm',
+        default: true,
+      },
+    ];
+  },
   generateConfig: async ({ answers, tree }) => {
     const options = parseAnswers(answers);
     if (options.setupScript) {
@@ -118,7 +121,7 @@ export const axeSetupBinding = {
 
 function parseAnswers(answers: Record<string, PluginAnswer>): AxeOptions {
   return {
-    urls: answerNonEmptyArray(answers, 'axe.urls', DEFAULT_URL),
+    urls: answerNonEmptyArray(answers, 'axe.urls', FALLBACK_DEV_SERVER_URL),
     preset: answerString(answers, 'axe.preset') || AXE_DEFAULT_PRESET,
     setupScript: answerBoolean(answers, 'axe.setupScript'),
     categories: answerBoolean(answers, 'axe.categories'),

--- a/packages/plugin-axe/src/lib/binding.ts
+++ b/packages/plugin-axe/src/lib/binding.ts
@@ -9,6 +9,7 @@ import {
   answerBoolean,
   answerNonEmptyArray,
   answerString,
+  formatUrls,
   resolveDevServerUrlPrompt,
   singleQuote,
 } from '@code-pushup/utils';
@@ -139,11 +140,4 @@ function formatPluginCall({ urls, preset, setupScript }: AxeOptions): string {
     return `axePlugin(${formattedUrls})`;
   }
   return `axePlugin(${formattedUrls}, { ${options.join(', ')} })`;
-}
-
-function formatUrls([first, ...rest]: [string, ...string[]]): string {
-  if (rest.length === 0) {
-    return singleQuote(first);
-  }
-  return `[${[first, ...rest].map(singleQuote).join(', ')}]`;
 }

--- a/packages/plugin-axe/src/lib/binding.unit.test.ts
+++ b/packages/plugin-axe/src/lib/binding.unit.test.ts
@@ -1,8 +1,11 @@
+import { vol } from 'memfs';
 import type { PluginAnswer } from '@code-pushup/models';
 import {
+  MEMFS_VOLUME,
   createMockCodegenInput,
   createMockTree,
 } from '@code-pushup/test-utils';
+import { resetDevServerUrlCache } from '@code-pushup/utils';
 import { axeSetupBinding as binding } from './binding.js';
 
 const defaultAnswers: Record<string, PluginAnswer> = {
@@ -18,17 +21,55 @@ const noCategoryAnswers: Record<string, PluginAnswer> = {
 };
 
 describe('axeSetupBinding', () => {
+  beforeEach(() => {
+    vol.reset();
+    resetDevServerUrlCache();
+  });
+
   describe('prompts', () => {
     it('should offer preset choices with wcag21aa as default', async () => {
-      await expect(binding.prompts!()).resolves.toIncludeAllPartialMembers([
+      vol.fromJSON({ '.gitkeep': '' }, MEMFS_VOLUME);
+
+      await expect(
+        binding.prompts!(MEMFS_VOLUME),
+      ).resolves.toIncludeAllPartialMembers([
         { key: 'axe.preset', type: 'select', default: 'wcag21aa' },
       ]);
     });
 
     it('should default setupScript to false', async () => {
-      await expect(binding.prompts!()).resolves.toIncludeAllPartialMembers([
+      vol.fromJSON({ '.gitkeep': '' }, MEMFS_VOLUME);
+
+      await expect(
+        binding.prompts!(MEMFS_VOLUME),
+      ).resolves.toIncludeAllPartialMembers([
         { key: 'axe.setupScript', type: 'confirm', default: false },
       ]);
+    });
+
+    it('should fall back to localhost:4200 when no dev server config is found', async () => {
+      vol.fromJSON({ '.gitkeep': '' }, MEMFS_VOLUME);
+
+      await expect(binding.prompts!(MEMFS_VOLUME)).resolves.toContainEqual(
+        expect.objectContaining({
+          key: 'axe.urls',
+          default: 'http://localhost:4200',
+          message: 'Target URL(s) (comma-separated):',
+        }),
+      );
+    });
+
+    it('should detect Vite default URL from vite.config.js', async () => {
+      vol.fromJSON({ 'vite.config.js': 'export default {}' }, MEMFS_VOLUME);
+
+      await expect(binding.prompts!(MEMFS_VOLUME)).resolves.toContainEqual(
+        expect.objectContaining({
+          key: 'axe.urls',
+          default: 'http://localhost:5173',
+          message:
+            'Target URL(s) (detected from vite.config.js, comma-separated):',
+        }),
+      );
     });
   });
 

--- a/packages/plugin-lighthouse/src/lib/binding.ts
+++ b/packages/plugin-lighthouse/src/lib/binding.ts
@@ -5,8 +5,10 @@ import type {
   PluginSetupBinding,
 } from '@code-pushup/models';
 import {
+  FALLBACK_DEV_SERVER_URL,
   answerArray,
   answerNonEmptyArray,
+  resolveDevServerUrlPrompt,
   singleQuote,
 } from '@code-pushup/utils';
 import {
@@ -19,7 +21,6 @@ const { name: PACKAGE_NAME } = createRequire(import.meta.url)(
   '../../package.json',
 ) as typeof import('../../package.json');
 
-const DEFAULT_URL = 'http://localhost:4200';
 const PLUGIN_VAR = 'lhPlugin';
 
 const CATEGORIES = [
@@ -62,24 +63,26 @@ export const lighthouseSetupBinding = {
   slug: LIGHTHOUSE_PLUGIN_SLUG,
   title: LIGHTHOUSE_PLUGIN_TITLE,
   packageName: PACKAGE_NAME,
-  prompts: async (_targetDir: string) => [
-    {
-      key: 'lighthouse.urls',
-      message: 'Target URL(s) (comma-separated):',
-      type: 'input',
-      default: DEFAULT_URL,
-    },
-    {
-      key: 'lighthouse.categories',
-      message: 'Categories:',
-      type: 'checkbox',
-      choices: CATEGORIES.map(({ slug, title }) => ({
-        name: title,
-        value: slug,
-      })),
-      default: CATEGORIES.map(({ slug }) => slug),
-    },
-  ],
+  prompts: async targetDir => {
+    const urlPrompt = await resolveDevServerUrlPrompt(targetDir);
+    return [
+      {
+        key: 'lighthouse.urls',
+        type: 'input',
+        ...urlPrompt,
+      },
+      {
+        key: 'lighthouse.categories',
+        message: 'Categories:',
+        type: 'checkbox',
+        choices: CATEGORIES.map(({ slug, title }) => ({
+          name: title,
+          value: slug,
+        })),
+        default: CATEGORIES.map(({ slug }) => slug),
+      },
+    ];
+  },
   generateConfig: ({ answers }) => {
     const options = parseAnswers(answers);
     const hasCategories = options.categories.length > 0;
@@ -114,7 +117,11 @@ function parseAnswers(
   answers: Record<string, PluginAnswer>,
 ): LighthouseOptions {
   return {
-    urls: answerNonEmptyArray(answers, 'lighthouse.urls', DEFAULT_URL),
+    urls: answerNonEmptyArray(
+      answers,
+      'lighthouse.urls',
+      FALLBACK_DEV_SERVER_URL,
+    ),
     categories: answerArray(answers, 'lighthouse.categories'),
   };
 }

--- a/packages/plugin-lighthouse/src/lib/binding.ts
+++ b/packages/plugin-lighthouse/src/lib/binding.ts
@@ -8,6 +8,7 @@ import {
   FALLBACK_DEV_SERVER_URL,
   answerArray,
   answerNonEmptyArray,
+  formatUrls,
   resolveDevServerUrlPrompt,
   singleQuote,
 } from '@code-pushup/utils';
@@ -149,11 +150,4 @@ function createCategories({
       refsExpression: `lighthouseGroupRefs(${PLUGIN_VAR}, ${singleQuote(group)})`,
     }),
   );
-}
-
-function formatUrls([first, ...rest]: [string, ...string[]]): string {
-  if (rest.length === 0) {
-    return singleQuote(first);
-  }
-  return `[${[first, ...rest].map(singleQuote).join(', ')}]`;
 }

--- a/packages/plugin-lighthouse/src/lib/binding.unit.test.ts
+++ b/packages/plugin-lighthouse/src/lib/binding.unit.test.ts
@@ -1,5 +1,7 @@
+import { vol } from 'memfs';
 import type { PluginAnswer } from '@code-pushup/models';
-import { createMockCodegenInput } from '@code-pushup/test-utils';
+import { MEMFS_VOLUME, createMockCodegenInput } from '@code-pushup/test-utils';
+import { resetDevServerUrlCache } from '@code-pushup/utils';
 import { lighthouseSetupBinding as binding } from './binding.js';
 
 const defaultAnswers: Record<string, PluginAnswer> = {
@@ -13,15 +15,54 @@ const noCategoryAnswers: Record<string, PluginAnswer> = {
 };
 
 describe('lighthouseSetupBinding', () => {
+  beforeEach(() => {
+    vol.reset();
+    resetDevServerUrlCache();
+  });
+
   describe('prompts', () => {
     it('should select all categories by default', async () => {
-      await expect(binding.prompts!('')).resolves.toIncludeAllPartialMembers([
+      vol.fromJSON({ '.gitkeep': '' }, MEMFS_VOLUME);
+
+      await expect(
+        binding.prompts!(MEMFS_VOLUME),
+      ).resolves.toIncludeAllPartialMembers([
         {
           key: 'lighthouse.categories',
           type: 'checkbox',
           default: ['performance', 'a11y', 'best-practices', 'seo'],
         },
       ]);
+    });
+
+    it('should fall back to localhost:4200 when no dev server config is found', async () => {
+      vol.fromJSON({ '.gitkeep': '' }, MEMFS_VOLUME);
+
+      await expect(binding.prompts!(MEMFS_VOLUME)).resolves.toContainEqual(
+        expect.objectContaining({
+          key: 'lighthouse.urls',
+          default: 'http://localhost:4200',
+          message: 'Target URL(s) (comma-separated):',
+        }),
+      );
+    });
+
+    it('should detect Next.js default URL from package.json dev script', async () => {
+      vol.fromJSON(
+        {
+          'package.json': JSON.stringify({ scripts: { dev: 'next dev' } }),
+        },
+        MEMFS_VOLUME,
+      );
+
+      await expect(binding.prompts!(MEMFS_VOLUME)).resolves.toContainEqual(
+        expect.objectContaining({
+          key: 'lighthouse.urls',
+          default: 'http://localhost:3000',
+          message:
+            'Target URL(s) (detected from package.json dev script, comma-separated):',
+        }),
+      );
     });
   });
 

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -16,6 +16,13 @@ export {
 } from './lib/coverage-tree.js';
 export { createRunnerFiles } from './lib/create-runner-files.js';
 export { dateToUnixTimestamp } from './lib/dates.js';
+export { FALLBACK_DEV_SERVER_URL } from './lib/dev-server/default-ports.js';
+export {
+  detectDevServerUrl,
+  detectDevServerUrlWithSource,
+  resetDevServerUrlCache,
+  resolveDevServerUrlPrompt,
+} from './lib/dev-server/detect-dev-server-url.js';
 export { comparePairs, matchArrayItemsByKey, type Diff } from './lib/diff.js';
 export {
   coerceBooleanValue,

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -67,6 +67,7 @@ export {
   pluralizeToken,
   roundDecimals,
   serializeCommandWithArgs,
+  formatUrls,
   singleQuote,
   slugify,
   transformLines,

--- a/packages/utils/src/lib/dev-server/default-ports.ts
+++ b/packages/utils/src/lib/dev-server/default-ports.ts
@@ -1,0 +1,21 @@
+export const FALLBACK_DEV_SERVER_PORT = 4200;
+
+export const DEV_SERVER_PORTS = {
+  vite: 5173,
+  next: 3000,
+  nuxt: 3000,
+  astro: 4321,
+  angular: 4200,
+  webpack: 8080,
+  vueCli: 8080,
+  cra: 3000,
+  parcel: 1234,
+} as const;
+
+export type DevServerTool = keyof typeof DEV_SERVER_PORTS;
+
+export function toDevServerUrl(port: number): string {
+  return `http://localhost:${port}`;
+}
+
+export const FALLBACK_DEV_SERVER_URL = toDevServerUrl(FALLBACK_DEV_SERVER_PORT);

--- a/packages/utils/src/lib/dev-server/detect-dev-server-url.ts
+++ b/packages/utils/src/lib/dev-server/detect-dev-server-url.ts
@@ -59,7 +59,7 @@ export async function resolveDevServerUrlPrompt(
   return {
     default: detection.url,
     message:
-      detection.source != null && detection.source !== 'fallback'
+      detection.source !== 'fallback'
         ? `Target URL(s) (detected from ${detection.source}, comma-separated):`
         : 'Target URL(s) (comma-separated):',
   };

--- a/packages/utils/src/lib/dev-server/detect-dev-server-url.ts
+++ b/packages/utils/src/lib/dev-server/detect-dev-server-url.ts
@@ -1,0 +1,66 @@
+import path from 'node:path';
+import {
+  FALLBACK_DEV_SERVER_PORT,
+  FALLBACK_DEV_SERVER_URL,
+  toDevServerUrl,
+} from './default-ports.js';
+import { DEV_SERVER_DETECTORS } from './detectors.js';
+import type { DevServerDetectionResult, DevServerUrlPrompt } from './types.js';
+
+const cache = new Map<string, DevServerDetectionResult>();
+
+export function resetDevServerUrlCache(): void {
+  cache.clear();
+}
+
+function createFallbackResult(): DevServerDetectionResult {
+  return {
+    port: FALLBACK_DEV_SERVER_PORT,
+    url: FALLBACK_DEV_SERVER_URL,
+    source: 'fallback',
+  };
+}
+
+export async function detectDevServerUrlWithSource(
+  targetDir: string,
+): Promise<DevServerDetectionResult> {
+  const key = path.resolve(targetDir);
+  const cached = cache.get(key);
+  if (cached != null) {
+    return cached;
+  }
+
+  for (const detector of DEV_SERVER_DETECTORS) {
+    const result = await detector.detect(targetDir);
+    if (result != null) {
+      cache.set(key, result);
+      return result;
+    }
+  }
+
+  const fallback = createFallbackResult();
+  cache.set(key, fallback);
+  return fallback;
+}
+
+/**
+ * Detects the likely local dev server URL for a project directory.
+ * Used by create-cli to pre-fill Axe and Lighthouse target URL prompts.
+ */
+export async function detectDevServerUrl(targetDir: string): Promise<string> {
+  return (await detectDevServerUrlWithSource(targetDir)).url;
+}
+
+export async function resolveDevServerUrlPrompt(
+  targetDir: string,
+): Promise<DevServerUrlPrompt> {
+  const detection = await detectDevServerUrlWithSource(targetDir);
+
+  return {
+    default: detection.url,
+    message:
+      detection.source != null && detection.source !== 'fallback'
+        ? `Target URL(s) (detected from ${detection.source}, comma-separated):`
+        : 'Target URL(s) (comma-separated):',
+  };
+}

--- a/packages/utils/src/lib/dev-server/detect-dev-server-url.unit.test.ts
+++ b/packages/utils/src/lib/dev-server/detect-dev-server-url.unit.test.ts
@@ -1,0 +1,291 @@
+import { vol } from 'memfs';
+import { MEMFS_VOLUME } from '@code-pushup/test-utils';
+import * as fileSystem from '../file-system.js';
+import {
+  detectDevServerUrl,
+  detectDevServerUrlWithSource,
+  resetDevServerUrlCache,
+  resolveDevServerUrlPrompt,
+} from './detect-dev-server-url.js';
+import {
+  detectPortFromScript,
+  detectToolFromScript,
+  parsePortFromScript,
+} from './parse-port-from-script.js';
+
+describe('parsePortFromScript', () => {
+  it('should parse explicit --port flag', () => {
+    expect(parsePortFromScript('vite --port 4000')).toBe(4000);
+    expect(parsePortFromScript('next dev --port=3001')).toBe(3001);
+    expect(parsePortFromScript('vite -p 5174')).toBe(5174);
+  });
+
+  it('should return undefined when no explicit port is present', () => {
+    expect(parsePortFromScript('vite')).toBeUndefined();
+  });
+});
+
+describe('detectToolFromScript', () => {
+  it.each([
+    ['vite', 'vite'],
+    ['vite dev', 'vite'],
+    ['next dev', 'next'],
+    ['nuxt dev', 'nuxt'],
+    ['astro dev', 'astro'],
+    ['ng serve', 'angular'],
+    ['nx serve app', 'angular'],
+    ['react-scripts start', 'cra'],
+    ['vue-cli-service serve', 'vueCli'],
+    ['webpack serve', 'webpack'],
+    ['webpack-dev-server', 'webpack'],
+    ['parcel src/index.html', 'parcel'],
+  ])('should detect %s as %s', (script, tool) => {
+    expect(detectToolFromScript(script)).toBe(tool);
+  });
+});
+
+describe('detectPortFromScript', () => {
+  it('should prefer explicit port over tool default', () => {
+    expect(detectPortFromScript('vite --port 4000')).toBe(4000);
+  });
+
+  it('should return tool default when no explicit port is present', () => {
+    expect(detectPortFromScript('next dev')).toBe(3000);
+    expect(detectPortFromScript('vite')).toBe(5173);
+  });
+});
+
+describe('detectDevServerUrlWithSource', () => {
+  beforeEach(() => {
+    vol.reset();
+    resetDevServerUrlCache();
+  });
+
+  it('should fall back to localhost:4200 for an empty directory', async () => {
+    vol.fromJSON({ '.gitkeep': '' }, MEMFS_VOLUME);
+
+    await expect(
+      detectDevServerUrlWithSource(MEMFS_VOLUME),
+    ).resolves.toStrictEqual({
+      url: 'http://localhost:4200',
+      port: 4200,
+      source: 'fallback',
+    });
+  });
+
+  it('should detect Vite default port from vite.config.js', async () => {
+    vol.fromJSON(
+      {
+        'vite.config.js': 'export default { plugins: [] }',
+      },
+      MEMFS_VOLUME,
+    );
+
+    await expect(
+      detectDevServerUrlWithSource(MEMFS_VOLUME),
+    ).resolves.toStrictEqual({
+      url: 'http://localhost:5173',
+      port: 5173,
+      source: 'vite.config.js',
+    });
+  });
+
+  it('should detect Vite default port from vite.config.mts', async () => {
+    vol.fromJSON(
+      {
+        'vite.config.mts': 'export default { plugins: [] }',
+      },
+      MEMFS_VOLUME,
+    );
+
+    await expect(
+      detectDevServerUrlWithSource(MEMFS_VOLUME),
+    ).resolves.toStrictEqual({
+      url: 'http://localhost:5173',
+      port: 5173,
+      source: 'vite.config.mts',
+    });
+  });
+
+  it('should detect custom Vite port from vite.config.ts', async () => {
+    vol.fromJSON(
+      {
+        'vite.config.ts': 'export default { server: { port: 3001 } }',
+      },
+      MEMFS_VOLUME,
+    );
+
+    await expect(
+      detectDevServerUrlWithSource(MEMFS_VOLUME),
+    ).resolves.toStrictEqual({
+      url: 'http://localhost:3001',
+      port: 3001,
+      source: 'vite.config.ts',
+    });
+  });
+
+  it('should detect Angular port from angular.json', async () => {
+    vol.fromJSON(
+      {
+        'angular.json': JSON.stringify({
+          projects: {
+            app: {
+              architect: {
+                serve: {
+                  options: {
+                    port: 4300,
+                  },
+                },
+              },
+            },
+          },
+        }),
+      },
+      MEMFS_VOLUME,
+    );
+
+    await expect(
+      detectDevServerUrlWithSource(MEMFS_VOLUME),
+    ).resolves.toStrictEqual({
+      url: 'http://localhost:4300',
+      port: 4300,
+      source: 'angular.json',
+    });
+  });
+
+  it('should detect Next.js default from package.json dev script', async () => {
+    vol.fromJSON(
+      {
+        'package.json': JSON.stringify({
+          scripts: { dev: 'next dev' },
+        }),
+      },
+      MEMFS_VOLUME,
+    );
+
+    await expect(
+      detectDevServerUrlWithSource(MEMFS_VOLUME),
+    ).resolves.toStrictEqual({
+      url: 'http://localhost:3000',
+      port: 3000,
+      source: 'package.json dev script',
+    });
+  });
+
+  it('should detect webpack devServer port from webpack.config.js', async () => {
+    vol.fromJSON(
+      {
+        'webpack.config.js': 'module.exports = { devServer: { port: 9000 } }',
+      },
+      MEMFS_VOLUME,
+    );
+
+    await expect(
+      detectDevServerUrlWithSource(MEMFS_VOLUME),
+    ).resolves.toStrictEqual({
+      url: 'http://localhost:9000',
+      port: 9000,
+      source: 'webpack.config.js',
+    });
+  });
+
+  it('should detect Vite port from package.json dependency when scripts are generic', async () => {
+    vol.fromJSON(
+      {
+        'package.json': JSON.stringify({
+          scripts: { dev: 'node ./scripts/dev.mjs' },
+          devDependencies: { vite: '^8.0.0' },
+        }),
+      },
+      MEMFS_VOLUME,
+    );
+
+    await expect(
+      detectDevServerUrlWithSource(MEMFS_VOLUME),
+    ).resolves.toStrictEqual({
+      url: 'http://localhost:5173',
+      port: 5173,
+      source: 'package.json dependencies',
+    });
+  });
+
+  it('should detect Nx serve port from project.json', async () => {
+    vol.fromJSON(
+      {
+        'project.json': JSON.stringify({
+          targets: {
+            serve: {
+              options: {
+                port: 4400,
+              },
+            },
+          },
+        }),
+      },
+      MEMFS_VOLUME,
+    );
+
+    await expect(
+      detectDevServerUrlWithSource(MEMFS_VOLUME),
+    ).resolves.toStrictEqual({
+      url: 'http://localhost:4400',
+      port: 4400,
+      source: 'project.json',
+    });
+  });
+
+  it('should cache detection results per target directory', async () => {
+    vol.fromJSON({ 'vite.config.js': 'export default {}' }, MEMFS_VOLUME);
+    const readTextFileSpy = vi.spyOn(fileSystem, 'readTextFile');
+
+    await detectDevServerUrlWithSource(MEMFS_VOLUME);
+    await detectDevServerUrlWithSource(MEMFS_VOLUME);
+
+    expect(readTextFileSpy).toHaveBeenCalledTimes(1);
+    readTextFileSpy.mockRestore();
+  });
+});
+
+describe('detectDevServerUrl', () => {
+  beforeEach(() => {
+    vol.reset();
+    resetDevServerUrlCache();
+  });
+
+  it('should return only the URL string', async () => {
+    vol.fromJSON({ 'vite.config.js': 'export default {}' }, MEMFS_VOLUME);
+
+    await expect(detectDevServerUrl(MEMFS_VOLUME)).resolves.toBe(
+      'http://localhost:5173',
+    );
+  });
+});
+
+describe('resolveDevServerUrlPrompt', () => {
+  beforeEach(() => {
+    vol.reset();
+    resetDevServerUrlCache();
+  });
+
+  it('should include detection source in the prompt message', async () => {
+    vol.fromJSON({ 'vite.config.js': 'export default {}' }, MEMFS_VOLUME);
+
+    await expect(
+      resolveDevServerUrlPrompt(MEMFS_VOLUME),
+    ).resolves.toStrictEqual({
+      default: 'http://localhost:5173',
+      message: 'Target URL(s) (detected from vite.config.js, comma-separated):',
+    });
+  });
+
+  it('should use generic message for fallback detection', async () => {
+    vol.fromJSON({ '.gitkeep': '' }, MEMFS_VOLUME);
+
+    await expect(
+      resolveDevServerUrlPrompt(MEMFS_VOLUME),
+    ).resolves.toStrictEqual({
+      default: 'http://localhost:4200',
+      message: 'Target URL(s) (comma-separated):',
+    });
+  });
+});

--- a/packages/utils/src/lib/dev-server/detectors.ts
+++ b/packages/utils/src/lib/dev-server/detectors.ts
@@ -168,9 +168,6 @@ const configFileDetector: DevServerDetector = {
 
     for (const file of files) {
       const filePath = path.join(targetDir, file);
-      if (!(await fileExists(filePath))) {
-        continue;
-      }
 
       for (const detector of CONFIG_FILE_DETECTORS) {
         if (!detector.pattern.test(file)) {
@@ -179,7 +176,6 @@ const configFileDetector: DevServerDetector = {
 
         const port =
           (await parsePortFromConfigFile(filePath, {
-            defaultPort: detector.defaultPort,
             sections: [...detector.sections],
           })) ?? detector.defaultPort;
 
@@ -191,7 +187,6 @@ const configFileDetector: DevServerDetector = {
       ) {
         const port =
           (await parsePortFromConfigFile(filePath, {
-            defaultPort: DEV_SERVER_PORTS.vueCli,
             sections: ['devServer'],
           })) ?? DEV_SERVER_PORTS.vueCli;
 

--- a/packages/utils/src/lib/dev-server/detectors.ts
+++ b/packages/utils/src/lib/dev-server/detectors.ts
@@ -1,0 +1,257 @@
+import { readdir } from 'node:fs/promises';
+import path from 'node:path';
+import type { PackageJson } from 'type-fest';
+import { fileExists, readJsonFile } from '../file-system.js';
+import { hasDependency } from '../workspace-packages.js';
+import {
+  DEV_SERVER_PORTS,
+  type DevServerTool,
+  toDevServerUrl,
+} from './default-ports.js';
+import { parsePortFromConfigFile } from './parse-config-port.js';
+import { detectPortFromScript } from './parse-port-from-script.js';
+import type { DevServerDetectionResult, DevServerDetector } from './types.js';
+
+const CONFIG_EXT = '(?:[mc]?[tj]s|mts)';
+
+const CONFIG_FILE_DETECTORS = [
+  {
+    pattern: new RegExp(`^vite\\.config\\.${CONFIG_EXT}$`),
+    defaultPort: DEV_SERVER_PORTS.vite,
+    sections: ['server', 'devServer'],
+  },
+  {
+    pattern: new RegExp(`^next\\.config\\.${CONFIG_EXT}$`),
+    defaultPort: DEV_SERVER_PORTS.next,
+    sections: ['server', 'devServer'],
+  },
+  {
+    pattern: new RegExp(`^nuxt\\.config\\.${CONFIG_EXT}$`),
+    defaultPort: DEV_SERVER_PORTS.nuxt,
+    sections: ['devServer', 'server'],
+  },
+  {
+    pattern: new RegExp(`^webpack\\.config\\.${CONFIG_EXT}$`),
+    defaultPort: DEV_SERVER_PORTS.webpack,
+    sections: ['devServer'],
+  },
+  {
+    pattern: new RegExp(`^astro\\.config\\.${CONFIG_EXT}$`),
+    defaultPort: DEV_SERVER_PORTS.astro,
+    sections: ['server'],
+  },
+] as const;
+
+const VUE_CONFIG_FILES = ['vue.config.js', 'vue.config.cjs'] as const;
+
+const SCRIPT_KEYS = ['dev', 'start', 'serve'] as const;
+
+const DEPENDENCY_TOOL_MAP: { dependency: string; tool: DevServerTool }[] = [
+  { dependency: 'vite', tool: 'vite' },
+  { dependency: 'next', tool: 'next' },
+  { dependency: 'nuxt', tool: 'nuxt' },
+  { dependency: 'astro', tool: 'astro' },
+  { dependency: '@angular/cli', tool: 'angular' },
+  { dependency: '@remix-run/dev', tool: 'vite' },
+  { dependency: 'react-scripts', tool: 'cra' },
+  { dependency: '@vue/cli-service', tool: 'vueCli' },
+  { dependency: 'webpack-dev-server', tool: 'webpack' },
+  { dependency: 'webpack', tool: 'webpack' },
+  { dependency: 'parcel', tool: 'parcel' },
+];
+
+function toDetectionResult(
+  port: number,
+  source: string,
+): DevServerDetectionResult {
+  return {
+    port,
+    url: toDevServerUrl(port),
+    source,
+  };
+}
+
+type PackageJsonWithScripts = PackageJson & {
+  scripts?: Record<string, string | undefined>;
+};
+
+async function readPackageJson(
+  targetDir: string,
+): Promise<PackageJsonWithScripts | null> {
+  const packageJsonPath = path.join(targetDir, 'package.json');
+  if (!(await fileExists(packageJsonPath))) {
+    return null;
+  }
+
+  try {
+    return await readJsonFile<PackageJsonWithScripts>(packageJsonPath);
+  } catch {
+    return null;
+  }
+}
+
+const angularJsonDetector: DevServerDetector = {
+  id: 'angular-json',
+  detect: async targetDir => {
+    const angularJsonPath = path.join(targetDir, 'angular.json');
+    if (!(await fileExists(angularJsonPath))) {
+      return null;
+    }
+
+    try {
+      const angularJson = await readJsonFile<{
+        projects?: Record<
+          string,
+          {
+            architect?: {
+              serve?: {
+                options?: {
+                  port?: number;
+                };
+              };
+            };
+          }
+        >;
+      }>(angularJsonPath);
+
+      for (const project of Object.values(angularJson.projects ?? {})) {
+        const port = project.architect?.serve?.options?.port;
+        if (typeof port === 'number') {
+          return toDetectionResult(port, 'angular.json');
+        }
+      }
+    } catch {
+      return null;
+    }
+
+    return toDetectionResult(DEV_SERVER_PORTS.angular, 'angular.json');
+  },
+};
+
+const projectJsonDetector: DevServerDetector = {
+  id: 'project-json',
+  detect: async targetDir => {
+    const projectJsonPath = path.join(targetDir, 'project.json');
+    if (!(await fileExists(projectJsonPath))) {
+      return null;
+    }
+
+    try {
+      const projectJson = await readJsonFile<{
+        targets?: {
+          serve?: {
+            options?: {
+              port?: number;
+            };
+          };
+        };
+      }>(projectJsonPath);
+
+      const port = projectJson.targets?.serve?.options?.port;
+      if (typeof port === 'number') {
+        return toDetectionResult(port, 'project.json');
+      }
+    } catch {
+      return null;
+    }
+
+    return null;
+  },
+};
+
+const configFileDetector: DevServerDetector = {
+  id: 'config-file',
+  detect: async targetDir => {
+    const files = await readdir(targetDir, { encoding: 'utf8' }).catch(
+      () => [] as string[],
+    );
+
+    for (const file of files) {
+      const filePath = path.join(targetDir, file);
+      if (!(await fileExists(filePath))) {
+        continue;
+      }
+
+      for (const detector of CONFIG_FILE_DETECTORS) {
+        if (!detector.pattern.test(file)) {
+          continue;
+        }
+
+        const port =
+          (await parsePortFromConfigFile(filePath, {
+            defaultPort: detector.defaultPort,
+            sections: [...detector.sections],
+          })) ?? detector.defaultPort;
+
+        return toDetectionResult(port, file);
+      }
+
+      if (
+        VUE_CONFIG_FILES.includes(file as (typeof VUE_CONFIG_FILES)[number])
+      ) {
+        const port =
+          (await parsePortFromConfigFile(filePath, {
+            defaultPort: DEV_SERVER_PORTS.vueCli,
+            sections: ['devServer'],
+          })) ?? DEV_SERVER_PORTS.vueCli;
+
+        return toDetectionResult(port, file);
+      }
+    }
+
+    return null;
+  },
+};
+
+const packageJsonScriptsDetector: DevServerDetector = {
+  id: 'package-json-scripts',
+  detect: async targetDir => {
+    const packageJson = await readPackageJson(targetDir);
+    if (packageJson?.scripts == null) {
+      return null;
+    }
+
+    for (const key of SCRIPT_KEYS) {
+      const script = packageJson.scripts[key];
+      if (script == null) {
+        continue;
+      }
+
+      const port = detectPortFromScript(script);
+      if (port != null) {
+        return toDetectionResult(port, `package.json ${key} script`);
+      }
+    }
+
+    return null;
+  },
+};
+
+const packageJsonDependenciesDetector: DevServerDetector = {
+  id: 'package-json-dependencies',
+  detect: async targetDir => {
+    const packageJson = await readPackageJson(targetDir);
+    if (packageJson == null) {
+      return null;
+    }
+
+    for (const { dependency, tool } of DEPENDENCY_TOOL_MAP) {
+      if (hasDependency(packageJson, dependency)) {
+        return toDetectionResult(
+          DEV_SERVER_PORTS[tool],
+          'package.json dependencies',
+        );
+      }
+    }
+
+    return null;
+  },
+};
+
+export const DEV_SERVER_DETECTORS: DevServerDetector[] = [
+  angularJsonDetector,
+  projectJsonDetector,
+  configFileDetector,
+  packageJsonScriptsDetector,
+  packageJsonDependenciesDetector,
+];

--- a/packages/utils/src/lib/dev-server/parse-config-port.ts
+++ b/packages/utils/src/lib/dev-server/parse-config-port.ts
@@ -1,0 +1,41 @@
+import { readTextFile } from '../file-system.js';
+
+export function parsePortFromSection(
+  content: string,
+  section: string,
+): number | null {
+  const sectionPattern = new RegExp(
+    `${section}\\s*:\\s*\\{[\\s\\S]*?\\bport\\s*:\\s*(\\d+)`,
+  );
+  const match = content.match(sectionPattern);
+  return match?.[1] != null ? Number(match[1]) : null;
+}
+
+export function parseLoosePort(content: string): number | null {
+  const match = content.match(/\bport\s*:\s*(\d+)/);
+  return match?.[1] != null ? Number(match[1]) : null;
+}
+
+export async function parsePortFromConfigFile(
+  filePath: string,
+  {
+    defaultPort,
+    sections = ['server', 'devServer'],
+  }: {
+    defaultPort: number;
+    sections?: string[];
+  },
+): Promise<number | null> {
+  try {
+    const content = await readTextFile(filePath);
+    for (const section of sections) {
+      const sectionPort = parsePortFromSection(content, section);
+      if (sectionPort != null) {
+        return sectionPort;
+      }
+    }
+    return parseLoosePort(content) ?? defaultPort;
+  } catch {
+    return null;
+  }
+}

--- a/packages/utils/src/lib/dev-server/parse-config-port.ts
+++ b/packages/utils/src/lib/dev-server/parse-config-port.ts
@@ -18,13 +18,7 @@ export function parseLoosePort(content: string): number | null {
 
 export async function parsePortFromConfigFile(
   filePath: string,
-  {
-    defaultPort,
-    sections = ['server', 'devServer'],
-  }: {
-    defaultPort: number;
-    sections?: string[];
-  },
+  { sections = ['server', 'devServer'] }: { sections?: string[] } = {},
 ): Promise<number | null> {
   try {
     const content = await readTextFile(filePath);
@@ -34,7 +28,7 @@ export async function parsePortFromConfigFile(
         return sectionPort;
       }
     }
-    return parseLoosePort(content) ?? defaultPort;
+    return parseLoosePort(content);
   } catch {
     return null;
   }

--- a/packages/utils/src/lib/dev-server/parse-config-port.unit.test.ts
+++ b/packages/utils/src/lib/dev-server/parse-config-port.unit.test.ts
@@ -1,4 +1,8 @@
-import { parseLoosePort, parsePortFromSection } from './parse-config-port.js';
+import {
+  parseLoosePort,
+  parsePortFromConfigFile,
+  parsePortFromSection,
+} from './parse-config-port.js';
 
 describe('parsePortFromSection', () => {
   it('should parse port from a named config section', () => {
@@ -20,5 +24,32 @@ describe('parseLoosePort', () => {
     expect(
       parseLoosePort('const port = 1; export default { port: 4321 }'),
     ).toBe(4321);
+  });
+
+  it('should return first port when multiple appear', () => {
+    expect(
+      parseLoosePort('const x = { port: 1234 }; const y = { port: 5678 }'),
+    ).toBe(1234);
+  });
+
+  it('should return null when no port is present', () => {
+    expect(parseLoosePort('export default {}')).toBeNull();
+  });
+});
+
+describe('parsePortFromConfigFile', () => {
+  it('should return null when file does not exist', async () => {
+    await expect(
+      parsePortFromConfigFile('/nonexistent/vite.config.ts'),
+    ).resolves.toBeNull();
+  });
+
+  it('should return null when file has no port', async () => {
+    await expect(
+      parsePortFromConfigFile(
+        new URL('./parse-config-port.unit.test.ts', import.meta.url).pathname,
+        { sections: ['server'] },
+      ),
+    ).resolves.toBeNull();
   });
 });

--- a/packages/utils/src/lib/dev-server/parse-config-port.unit.test.ts
+++ b/packages/utils/src/lib/dev-server/parse-config-port.unit.test.ts
@@ -1,0 +1,24 @@
+import { parseLoosePort, parsePortFromSection } from './parse-config-port.js';
+
+describe('parsePortFromSection', () => {
+  it('should parse port from a named config section', () => {
+    expect(
+      parsePortFromSection(
+        'export default { server: { port: 3001 } }',
+        'server',
+      ),
+    ).toBe(3001);
+  });
+
+  it('should return null when section is missing', () => {
+    expect(parsePortFromSection('export default {}', 'server')).toBeNull();
+  });
+});
+
+describe('parseLoosePort', () => {
+  it('should parse the first loose port assignment', () => {
+    expect(
+      parseLoosePort('const port = 1; export default { port: 4321 }'),
+    ).toBe(4321);
+  });
+});

--- a/packages/utils/src/lib/dev-server/parse-port-from-script.ts
+++ b/packages/utils/src/lib/dev-server/parse-port-from-script.ts
@@ -1,0 +1,36 @@
+import { DEV_SERVER_PORTS, type DevServerTool } from './default-ports.js';
+
+const SCRIPT_TOOL_PATTERNS: { tool: DevServerTool; pattern: RegExp }[] = [
+  { tool: 'vite', pattern: /\bvite\b(?:\s|$)/ },
+  { tool: 'next', pattern: /\bnext\s+(?:dev|start)\b/ },
+  { tool: 'nuxt', pattern: /\bnuxt\s+dev\b/ },
+  { tool: 'astro', pattern: /\bastro\s+dev\b/ },
+  { tool: 'angular', pattern: /\b(?:ng\s+serve|nx\s+serve)\b/ },
+  { tool: 'cra', pattern: /\breact-scripts\s+start\b/ },
+  { tool: 'vueCli', pattern: /\bvue-cli-service\s+serve\b/ },
+  { tool: 'webpack', pattern: /\b(?:webpack\s+serve|webpack-dev-server)\b/ },
+  { tool: 'parcel', pattern: /\bparcel\b/ },
+];
+
+export function parsePortFromScript(script: string): number | undefined {
+  const explicitPort = script.match(/(?:--port(?:=|\s+)|-p\s+)(\d+)/);
+  if (explicitPort?.[1] != null) {
+    return Number(explicitPort[1]);
+  }
+  return undefined;
+}
+
+export function detectToolFromScript(
+  script: string,
+): DevServerTool | undefined {
+  return SCRIPT_TOOL_PATTERNS.find(({ pattern }) => pattern.test(script))?.tool;
+}
+
+export function detectPortFromScript(script: string): number | undefined {
+  const explicitPort = parsePortFromScript(script);
+  if (explicitPort != null) {
+    return explicitPort;
+  }
+  const tool = detectToolFromScript(script);
+  return tool != null ? DEV_SERVER_PORTS[tool] : undefined;
+}

--- a/packages/utils/src/lib/dev-server/types.ts
+++ b/packages/utils/src/lib/dev-server/types.ts
@@ -1,7 +1,7 @@
 export type DevServerDetectionResult = {
   url: string;
   port: number;
-  source: string | null;
+  source: string;
 };
 
 export type DevServerDetector = {

--- a/packages/utils/src/lib/dev-server/types.ts
+++ b/packages/utils/src/lib/dev-server/types.ts
@@ -1,0 +1,15 @@
+export type DevServerDetectionResult = {
+  url: string;
+  port: number;
+  source: string | null;
+};
+
+export type DevServerDetector = {
+  id: string;
+  detect: (targetDir: string) => Promise<DevServerDetectionResult | null>;
+};
+
+export type DevServerUrlPrompt = {
+  default: string;
+  message: string;
+};

--- a/packages/utils/src/lib/formatting.ts
+++ b/packages/utils/src/lib/formatting.ts
@@ -205,3 +205,10 @@ export function singleQuote(value: string): string {
     .replace(/'/g, String.raw`\'`);
   return `'${inner}'`;
 }
+
+export function formatUrls([first, ...rest]: [string, ...string[]]): string {
+  if (rest.length === 0) {
+    return singleQuote(first);
+  }
+  return `[${[first, ...rest].map(singleQuote).join(', ')}]`;
+}


### PR DESCRIPTION
Fixes #1286

## Summary

- Add dev server URL detection in `@code-pushup/utils` (detector registry, config/script parsers, cache)
- Pre-fill Axe and Lighthouse setup wizard prompts with detected URL and source label (e.g. `vite.config.js`)
- Reset detection cache at the start of each wizard run
- Document supported stacks and fallback behavior in create-cli README

## Behavior

| Signal | Default URL |
|--------|-------------|
| Vite (`vite.config.*`) | `http://localhost:5173` |
| Next.js | `http://localhost:3000` |
| Angular / Nx | `http://localhost:4200` |
| Unknown project | `http://localhost:4200` (fallback) |

Detection is heuristic (regex over config files; configs are not executed).

## Test plan

- [x] `nx run utils:unit-test --testPathPattern=dev-server`
- [x] `nx run plugin-axe:unit-test --testPathPattern=binding`
- [x] `nx run plugin-lighthouse:unit-test --testPathPattern=binding`
- [x] `nx run create-cli:unit-test`
- [x] `nx run create-cli:int-test` (Vite project → `5173` in generated config)
- [x] Manual: local create-cli on Vite+React app → prompt shows `detected from vite.config.js`, default `5173`

## Commits

1. `feat(utils): add dev server URL detection for setup wizards`
2. `feat(plugin-axe): pre-fill target URL from dev server detection`
3. `feat(plugin-lighthouse): pre-fill target URL from dev server detection`
4. `feat(create-cli): reset dev server cache and document URL auto-detection`
5. `refactor(utils): extract formatUrls helper for setup wizard codegen`
6. `refactor(utils): simplify config port parsing in dev server detection`

Made with [Cursor](https://cursor.com)